### PR TITLE
fix(build): commit picker, EL client, and 8 referenced pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,21 +98,31 @@ Current exploration: Bauhaus-inspired brand identity (see `/bauhaus` route).
 
 ## ACT Context (auto-synced from `act-global-infrastructure/wiki/decisions/act-core-facts.md`)
 
-> Last synced: 2026-04-24. **Do not edit this section directly** — edit the upstream file and run `node scripts/sync-act-context.mjs --apply`. Downstream edits get overwritten.
+> Source upstream of this file: `act-global-infrastructure/wiki/concepts/soul.md`. The two humans and the why behind everything below.
+
+> Last synced: 2026-05-09. **Do not edit this section directly.** Edit the upstream file and run `node scripts/sync-act-context.mjs --apply`. Downstream edits get overwritten.
 
 ### Entities (as of 2026-04-25)
-- **A Curious Tractor Pty Ltd** (ACN 697 347 676; ABN PENDING) — registered 2026-04-24. Primary trading entity from 1 July 2026. Shareholders: Knight Family Trust 50 + Marchesi Family Trust 50. Directors: Ben Knight + Nicholas Marchesi. Bank: NAB. Accountant: Standard Ledger.
-- **Nicholas Marchesi sole trader** (ABN 21 591 780 066) — currently trading; hard cutover to Pty 30 June 2026.
-- **A Kind Tractor Ltd** (ACN 669 029 341, ABN 73 669 029 341) — charitable CLG, ACNC-registered, **NOT DGR**, dormant.
-- **Harvest entity** + **Farm entity** — being designed pending Standard Ledger advice.
+- **A Curious Tractor Pty Ltd** (ACN 697 347 676; ABN PENDING). Registered 2026-04-24. Primary trading entity from 1 July 2026. Shareholders: Knight Family Trust 50 + Marchesi Family Trust 50. Directors: Ben Knight + Nicholas Marchesi. Bank: NAB. Accountant: Standard Ledger.
+- **Nicholas Marchesi sole trader** (ABN 21 591 780 066). Currently trading; hard cutover to Pty 30 June 2026.
+- **A Kind Tractor Ltd** (ACN 669 029 341, ABN 73 669 029 341). Charitable CLG, ACNC-registered, **NOT DGR**, dormant.
+- **Harvest entity** + **Farm entity**. Being designed pending Standard Ledger advice.
 
 **Do NOT** use "ACT Foundation" or "ACT Ventures" as legal entity names. They are conceptual labels in older docs, not real entities.
 
+### Why this structure
+
+Three trading entities, one charity, one winding-down sole trader. The point is not bureaucracy. Each project earns the right to grow on its own revenue. The Harvest's money funds The Harvest's growth. Farm money funds Farm growth. A Curious Tractor Pty Ltd is the holding muscle that carries the founder relationship and the cross-cutting work.
+
+If we ran a single Pty Ltd with three project codes, the financial story would mash. Founders would have no clean way to see whether each project pays its way. The structure costs more in compliance and saves more in legibility. Legibility is what makes the soul able to read its own body.
+
+For how money flows through these entities into the four lanes (To Us, To Down, To Grow, To Others), see `act-global-infrastructure/wiki/concepts/four-lanes.md`.
+
 ### Cutover (30 June 2026)
-- **Rule 1** — pre-cutover invoices stay with sole trader (no re-issue, no inter-entity loan); novation letters say "existing invoices pay as normal; new tranches from 1 July to Pty"
-- **Rule 2** — honest-delay fallback: if Pty not invoice-ready 1 July, sole trader continues trading until Pty is genuinely live (no retroactive invoicing, no silent mis-attribution)
-- **Rule 3** — Rotary INV-0222 ($82.5K, 380d) is a recovery problem, not a novation one
-- **Rule 4** — Shareholders Agreement is Week 1-2 (drafted by Standard Ledger's lawyer), not Week 4-5
+- **Rule 1.** Pre-cutover invoices stay with sole trader (no re-issue, no inter-entity loan). Novation letters say "existing invoices pay as normal; new tranches from 1 July to Pty".
+- **Rule 2.** Honest-delay fallback: if Pty not invoice-ready 1 July, sole trader continues trading until Pty is genuinely live (no retroactive invoicing, no silent mis-attribution).
+- **Rule 3.** Rotary INV-0222 ($82.5K, 380d) is a recovery problem, not a novation one.
+- **Rule 4.** Shareholders Agreement is Week 1-2 (drafted by Standard Ledger's lawyer), not Week 4-5.
 
 ### Active receivables on sole trader (~$507K total)
 Snow $132K · Centrecorp DRAFT $84.7K · Rotary $82.5K · PICC $113.3K · Regional Arts $33K · Just Reinvest $27.5K · BG Fit $15.4K · Aleisha Keating $11.7K · Homeland $5K · SMART Recovery $2.2K

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,6 +22,19 @@ import GatheringPostcard from "./pages/GatheringPostcard";
 import Social from "./pages/Social";
 import PhotoWall from "./pages/PhotoWall";
 import PhotoWallCheckin from "./pages/PhotoWallCheckin";
+import Witta from "./pages/Witta";
+import Works from "./pages/Works";
+import WorkDetail from "./pages/WorkDetail";
+import Blog from "./pages/Blog";
+import BlogPost from "./pages/BlogPost";
+import People from "./pages/People";
+import Person from "./pages/Person";
+import GardenLaunch from "./pages/GardenLaunch";
+import LaunchRedesign from "./pages/LaunchRedesign";
+import HarvestReviewTest from "./pages/HarvestReviewTest";
+import AdminDashboard from "./pages/AdminDashboard";
+import MediaLibraryAdmin from "./pages/admin/MediaLibraryAdmin";
+import Login from "./pages/Login";
 import NotFound from "./pages/NotFound";
 
 function Router() {
@@ -30,6 +43,25 @@ function Router() {
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [location]);
+
+  // One-click dev admin login: visit any page with ?devAdmin=1 to enable.
+  // Only works on localhost. Runs once on mount; redirects to clean URL.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (window.location.hostname !== "localhost") return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("devAdmin") === "1") {
+      localStorage.setItem("dev-admin-login", "true");
+      params.delete("devAdmin");
+      const next = window.location.pathname + (params.toString() ? `?${params}` : "");
+      window.location.replace(next);
+    } else if (params.get("devAdmin") === "0") {
+      localStorage.removeItem("dev-admin-login");
+      params.delete("devAdmin");
+      const next = window.location.pathname + (params.toString() ? `?${params}` : "");
+      window.location.replace(next);
+    }
+  }, []);
 
   // All pages are standalone (no PublicLayout)
   if (location === "/") return <BauhausHome />;
@@ -48,6 +80,28 @@ function Router() {
   if (location === "/social") return <Social />;
   if (location === "/photo-wall") return <PhotoWall />;
   if (location.startsWith("/photo-wall/checkin")) return <PhotoWallCheckin />;
+  if (location === "/witta") return <Witta />;
+  if (location === "/login") return <Login />;
+  if (location === "/admin") return <AdminDashboard />;
+  if (location === "/admin/media-library") return <MediaLibraryAdmin />;
+  if (location === "/works") return <Works />;
+  if (location.startsWith("/works/")) {
+    const slug = location.slice("/works/".length).split("/")[0];
+    return <WorkDetail slug={slug} />;
+  }
+  if (location === "/blog") return <Blog />;
+  if (location.startsWith("/blog/")) {
+    const slug = location.slice("/blog/".length).split("/")[0];
+    return <BlogPost slug={slug} />;
+  }
+  if (location === "/people") return <People />;
+  if (location.startsWith("/people/")) {
+    const slug = location.slice("/people/".length).split("/")[0];
+    return <Person slug={slug} />;
+  }
+  if (location === "/garden-launch" || location === "/june-20") return <GardenLaunch />;
+  if (location === "/launch-redesign") return <LaunchRedesign />;
+  if (location === "/new-look-test" || location === "/review-test") return <HarvestReviewTest />;
   if (location.startsWith("/feedback")) {
     const eventId = location.split("/feedback/")[1];
     return <EventFeedback eventId={eventId} />;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -29,6 +29,7 @@ import Blog from "./pages/Blog";
 import BlogPost from "./pages/BlogPost";
 import People from "./pages/People";
 import Person from "./pages/Person";
+import StoryDetail from "./pages/StoryDetail";
 import GardenLaunch from "./pages/GardenLaunch";
 import LaunchRedesign from "./pages/LaunchRedesign";
 import HarvestReviewTest from "./pages/HarvestReviewTest";
@@ -98,6 +99,10 @@ function Router() {
   if (location.startsWith("/people/")) {
     const slug = location.slice("/people/".length).split("/")[0];
     return <Person slug={slug} />;
+  }
+  if (location.startsWith("/stories/")) {
+    const storyId = location.slice("/stories/".length).split("/")[0];
+    return <StoryDetail storyId={storyId} />;
   }
   if (location === "/garden-launch" || location === "/june-20") return <GardenLaunch />;
   if (location === "/launch-redesign") return <LaunchRedesign />;

--- a/client/src/components/BauhausFooter.tsx
+++ b/client/src/components/BauhausFooter.tsx
@@ -350,6 +350,8 @@ export default function BauhausFooter({ isMobile }: BauhausFooterProps) {
         <Link href="/" style={linkStyle}>HOME</Link>
         <Link href="/gather" style={linkStyle}>THE GATHERING</Link>
         <Link href="/compendium" style={linkStyle}>THE STORY</Link>
+        <Link href="/people" style={linkStyle}>PEOPLE</Link>
+        <Link href="/blog" style={linkStyle}>JOURNAL</Link>
         <Link href="/contact" style={linkStyle}>CONTACT</Link>
         <Link href="/social" style={linkStyle}>FOLLOW</Link>
       </div>

--- a/client/src/components/HarvestImage.tsx
+++ b/client/src/components/HarvestImage.tsx
@@ -1,0 +1,161 @@
+import { useState } from "react";
+import { ImageIcon, Loader2, X } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { useAuth } from "@/_core/hooks/useAuth";
+import { toast } from "sonner";
+import { HarvestPhotoPicker, type PickedPhoto } from "./HarvestPhotoPicker";
+import { optimize, type ImageSize } from "@/lib/imageOptimize";
+
+/**
+ * Image with admin "swap" affordance.
+ *
+ * Resolves src in this priority order:
+ *   1. Override row in image_overrides for (page, slot)
+ *   2. `src` prop (page's bundled / EL-driven default)
+ *
+ * Admins see a "Swap" button on hover that opens the EL photo picker.
+ * Non-admins just see the image — same as today, no UI noise.
+ */
+export function HarvestImage({
+  page,
+  slot,
+  src: defaultSrc,
+  alt: defaultAlt,
+  className,
+  imgClassName,
+  defaultWorkSlug,
+  size = "feature",
+  priority = false,
+}: {
+  /** Logical page id, e.g. "works" */
+  page: string;
+  /** Slot id within the page, e.g. "milk-crate-pavilion-hero" */
+  slot: string;
+  /** Fallback when no override is set */
+  src: string;
+  /** Fallback alt text */
+  alt: string;
+  className?: string;
+  imgClassName?: string;
+  /** Pre-select this work in the picker filter */
+  defaultWorkSlug?: string;
+  /** Optimisation size preset (drives Supabase render width + quality) */
+  size?: ImageSize;
+  /** Above-the-fold image — sets eager loading + high fetchpriority */
+  priority?: boolean;
+}) {
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
+
+  const overrideQuery = trpc.imageOverrides.get.useQuery({ page, slot });
+  const utils = trpc.useUtils();
+  const setMutation = trpc.imageOverrides.set.useMutation({
+    onSuccess: () => {
+      utils.imageOverrides.get.invalidate({ page, slot });
+      toast.success("Image swapped.");
+    },
+    onError: (err) => toast.error("Couldn't save", { description: err.message }),
+  });
+  const clearMutation = trpc.imageOverrides.clear.useMutation({
+    onSuccess: () => {
+      utils.imageOverrides.get.invalidate({ page, slot });
+      toast.success("Reverted to default.");
+    },
+  });
+
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  const override = overrideQuery.data;
+  const rawSrc = override?.src ?? defaultSrc;
+  const src = optimize(rawSrc, size);
+  const alt = override?.altText ?? defaultAlt;
+
+  const handlePick = async (photo: PickedPhoto) => {
+    await setMutation.mutateAsync({
+      page,
+      slot,
+      mediaAssetId: photo.mediaAssetId,
+      src: photo.src,
+      altText: photo.altText ?? defaultAlt,
+      title: photo.title ?? undefined,
+    });
+  };
+
+  const handleRevert = async () => {
+    await clearMutation.mutateAsync({ page, slot });
+  };
+
+  // Hold the skeleton until the override query has settled — otherwise the
+  // browser flashes the bundled fallback first and then re-fetches the EL
+  // override. With this gate, we render the img exactly once, with the right
+  // src.
+  const isResolving = overrideQuery.isPending;
+  const showSkeleton = isResolving || !loaded;
+
+  return (
+    <div className={`relative group ${className ?? ""} ${showSkeleton ? "bg-stone-200 animate-pulse" : ""}`}>
+      {!isResolving && src && (
+        <img
+          src={src}
+          alt={alt}
+          className={`${imgClassName ?? ""} ${loaded ? "" : "opacity-0"} transition-opacity duration-300`}
+          loading={priority ? "eager" : "lazy"}
+          decoding={priority ? "sync" : "async"}
+          fetchPriority={priority ? "high" : undefined}
+          onLoad={() => setLoaded(true)}
+          onError={() => setLoaded(true)}
+        />
+      )}
+
+      {isAdmin && (
+        <>
+          {/* Hover-only admin overlay */}
+          <div className="pointer-events-none absolute inset-0 bg-black/0 group-hover:bg-black/30 transition-colors duration-200" />
+
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center gap-3 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+            <button
+              type="button"
+              onClick={() => setPickerOpen(true)}
+              disabled={setMutation.isPending}
+              className="pointer-events-auto inline-flex items-center gap-2 px-4 py-2 rounded-full bg-amber-500 text-stone-900 font-semibold text-sm hover:bg-amber-400 transition-colors shadow-lg disabled:opacity-50"
+            >
+              {setMutation.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <ImageIcon className="h-4 w-4" />
+              )}
+              Swap photo
+            </button>
+            {override && (
+              <button
+                type="button"
+                onClick={handleRevert}
+                disabled={clearMutation.isPending}
+                className="pointer-events-auto inline-flex items-center gap-1.5 px-3 py-2 rounded-full bg-stone-100 text-stone-800 font-medium text-xs hover:bg-white transition-colors shadow-md disabled:opacity-50"
+                title="Revert to the page's default image"
+              >
+                <X className="h-3.5 w-3.5" />
+                Revert
+              </button>
+            )}
+          </div>
+
+          {/* Tiny status pip — tells admin at a glance whether override is active */}
+          {override && (
+            <div className="absolute top-2 right-2 px-2 py-0.5 rounded-full bg-amber-500/90 text-stone-900 text-[10px] font-mono font-semibold uppercase tracking-wider shadow">
+              Override
+            </div>
+          )}
+
+          <HarvestPhotoPicker
+            open={pickerOpen}
+            onOpenChange={setPickerOpen}
+            onPick={handlePick}
+            defaultWorkSlug={defaultWorkSlug}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/HarvestMediaGallery.tsx
+++ b/client/src/components/HarvestMediaGallery.tsx
@@ -1,0 +1,143 @@
+import { Camera, Film } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { optimize } from "@/lib/imageOptimize";
+
+type MediaCategory = "before" | "during" | "after" | "milestone" | "general";
+
+type MediaAsset = {
+  id: string;
+  src: string;
+  title: string | null;
+  description: string | null;
+  altText: string | null;
+  category: MediaCategory;
+  date: string | null;
+  tags: string[];
+  themes: string[];
+  special?: string[];
+  works?: string[];
+};
+
+type HarvestMediaGalleryProps = {
+  title: string;
+  eyebrow: string;
+  description: string;
+  work?: string;
+  theme?: string;
+  category?: MediaCategory;
+  limit?: number;
+  tagHint: string;
+  className?: string;
+};
+
+function isVideoAsset(src: string): boolean {
+  return /\.(mp4|mov|m4v|webm)(\?.*)?$/i.test(src);
+}
+
+export function HarvestMediaGallery({
+  title,
+  eyebrow,
+  description,
+  work,
+  theme,
+  category,
+  limit = 8,
+  tagHint,
+  className = "",
+}: HarvestMediaGalleryProps) {
+  const query = trpc.gallery.fromEL.useQuery(
+    {
+      work,
+      theme,
+      category,
+      limit,
+    },
+    {
+      staleTime: 5 * 60 * 1000,
+    },
+  );
+
+  const media = (query.data?.media ?? []) as MediaAsset[];
+  const total = query.data?.pagination?.total ?? media.length;
+
+  return (
+    <article className={`border border-stone-300/80 bg-[#FFFDF7] ${className}`}>
+      <div className="border-b border-stone-200 p-5">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#8B4A2A]">
+              {eyebrow}
+            </p>
+            <h3 className="mt-2 text-2xl font-black leading-tight">{title}</h3>
+          </div>
+          <span className="border border-stone-300 px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.16em] text-stone-600">
+            {query.isLoading ? "loading" : `${total} in EL`}
+          </span>
+        </div>
+        <p className="mt-4 text-sm leading-relaxed text-stone-700">{description}</p>
+        <p className="mt-4 border-l-2 border-[#C4922A] pl-3 font-mono text-[10px] uppercase tracking-[0.14em] text-stone-500">
+          tag as: {tagHint}
+        </p>
+      </div>
+
+      {query.isLoading ? (
+        <div className="grid gap-3 p-5 sm:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className="aspect-[4/3] animate-pulse bg-stone-200" />
+          ))}
+        </div>
+      ) : media.length === 0 ? (
+        <div className="p-5">
+          <div className="flex min-h-[220px] flex-col justify-center border border-dashed border-stone-300 bg-stone-50 p-6 text-center">
+            <Camera className="mx-auto h-8 w-8 text-stone-400" />
+            <p className="mt-3 text-sm font-semibold text-stone-700">No matching media yet.</p>
+            <p className="mx-auto mt-2 max-w-sm text-sm leading-relaxed text-stone-500">
+              Upload or retag assets in Empathy Ledger with {tagHint}. They will appear
+              here through the Harvest gallery API.
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div className="grid gap-3 p-5 sm:grid-cols-2">
+          {media.map((item) => {
+            const video = isVideoAsset(item.src);
+            return (
+              <figure key={item.id} className="group">
+                <div className="relative aspect-[4/3] overflow-hidden bg-stone-200">
+                  {video ? (
+                    <video
+                      src={item.src}
+                      controls
+                      preload="metadata"
+                      playsInline
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <img
+                      src={optimize(item.src, "card")}
+                      alt={item.altText ?? item.title ?? title}
+                      loading="lazy"
+                      decoding="async"
+                      className="h-full w-full object-cover transition duration-500 group-hover:scale-[1.03]"
+                    />
+                  )}
+                  <span className="absolute left-2 top-2 inline-flex items-center gap-1 bg-[#1C1917]/80 px-2 py-1 font-mono text-[9px] uppercase tracking-[0.14em] text-[#F5F0E8]">
+                    {video ? <Film className="h-3 w-3" /> : <Camera className="h-3 w-3" />}
+                    {video ? "video" : "image"}
+                  </span>
+                </div>
+                {(item.title || item.description) && (
+                  <figcaption className="mt-2 text-xs leading-relaxed text-stone-500">
+                    {item.title && <span className="font-semibold text-stone-700">{item.title}</span>}
+                    {item.title && item.description && " - "}
+                    {item.description}
+                  </figcaption>
+                )}
+              </figure>
+            );
+          })}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/client/src/components/HarvestPhotoPicker.tsx
+++ b/client/src/components/HarvestPhotoPicker.tsx
@@ -1,0 +1,213 @@
+import { useState } from "react";
+import { Loader2, Search, Check } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { trpc } from "@/lib/trpc";
+
+const WORKS = [
+  { slug: "milk-crate-pavilion", label: "Milk Create Pavilion" },
+  { slug: "the-cedar", label: "The Cedar" },
+  { slug: "the-garden", label: "The Garden" },
+  { slug: "the-sauna", label: "The Sauna" },
+  { slug: "the-shop", label: "The Shop" },
+] as const;
+
+const THEMES = [
+  { slug: "eat", label: "Eat" },
+  { slug: "grow", label: "Grow" },
+  { slug: "make", label: "Make" },
+  { slug: "gather", label: "Gather" },
+] as const;
+
+export type PickedPhoto = {
+  mediaAssetId: string;
+  src: string;
+  altText: string | null;
+  title: string | null;
+};
+
+export function HarvestPhotoPicker({
+  open,
+  onOpenChange,
+  onPick,
+  defaultWorkSlug,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onPick: (photo: PickedPhoto) => void;
+  /** Pre-select a work filter (e.g. the page's work slug). */
+  defaultWorkSlug?: string;
+}) {
+  const [work, setWork] = useState<string | undefined>(defaultWorkSlug);
+  const [theme, setTheme] = useState<string | undefined>(undefined);
+  const [search, setSearch] = useState("");
+
+  const query = trpc.gallery.fromEL.useQuery(
+    { work, theme, limit: 100 },
+    { enabled: open },
+  );
+  const photos = query.data?.media ?? [];
+
+  const filtered = search.trim()
+    ? photos.filter((p) =>
+        [p.title, p.description, p.altText]
+          .filter(Boolean)
+          .some((s) => s!.toLowerCase().includes(search.toLowerCase())),
+      )
+    : photos;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-5xl w-full max-h-[90vh] flex flex-col p-0">
+        <DialogHeader className="p-6 pb-4 border-b">
+          <DialogTitle className="font-serif text-2xl text-stone-800">
+            Pick a photo from the Harvest gallery
+          </DialogTitle>
+          <DialogDescription>
+            Filter by work or theme. Click a photo to use it here.
+            Photos come from Empathy Ledger and are cached for 5 minutes.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Filters */}
+        <div className="px-6 py-4 border-b bg-stone-50 space-y-3">
+          <div className="flex flex-wrap gap-2">
+            <FilterChip label="Any work" active={!work} onClick={() => setWork(undefined)} />
+            {WORKS.map((w) => (
+              <FilterChip
+                key={w.slug}
+                label={w.label}
+                active={work === w.slug}
+                onClick={() => setWork(w.slug)}
+              />
+            ))}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <FilterChip label="Any theme" active={!theme} onClick={() => setTheme(undefined)} />
+            {THEMES.map((t) => (
+              <FilterChip
+                key={t.slug}
+                label={t.label}
+                active={theme === t.slug}
+                onClick={() => setTheme(t.slug)}
+              />
+            ))}
+          </div>
+          <div className="relative max-w-md">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-stone-400" />
+            <Input
+              placeholder="Search title, alt text, or description"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+        </div>
+
+        {/* Grid */}
+        <div className="flex-1 overflow-y-auto p-6">
+          {query.isLoading ? (
+            <div className="flex items-center justify-center py-20 text-stone-500">
+              <Loader2 className="h-6 w-6 animate-spin mr-3" />
+              Loading photos…
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className="text-center py-20 text-stone-500">
+              <p className="mb-2">
+                No photos match these filters{work ? ` for "${work}"` : ""}.
+              </p>
+              <p className="text-sm">
+                Upload to The Harvest Gallery in EL admin (
+                <code className="bg-stone-100 px-1.5 py-0.5 rounded">
+                  /admin/galleries
+                </code>
+                ) and they'll appear here.
+              </p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+              {filtered.map((photo) => (
+                <button
+                  key={photo.id}
+                  onClick={() => {
+                    onPick({
+                      mediaAssetId: photo.id,
+                      src: photo.src,
+                      altText: photo.altText,
+                      title: photo.title,
+                    });
+                    onOpenChange(false);
+                  }}
+                  className="group relative aspect-square overflow-hidden rounded-md bg-stone-100 ring-2 ring-transparent hover:ring-amber-500 transition-all"
+                  type="button"
+                >
+                  <img
+                    src={photo.src}
+                    alt={photo.altText ?? photo.title ?? ""}
+                    loading="lazy"
+                    className="w-full h-full object-cover"
+                  />
+                  <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                    <div className="bg-amber-500 text-stone-900 rounded-full p-2">
+                      <Check className="h-5 w-5" />
+                    </div>
+                  </div>
+                  {(photo.title || photo.projectId) && (
+                    <div className="absolute bottom-0 inset-x-0 bg-gradient-to-t from-black/70 to-transparent p-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <p className="text-white text-[10px] leading-tight truncate">
+                        {photo.title}
+                      </p>
+                    </div>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-4 border-t bg-stone-50 flex items-center justify-between text-sm text-stone-600">
+          <span>
+            {filtered.length} photo{filtered.length === 1 ? "" : "s"}
+            {work ? ` · work: ${work}` : ""}
+            {theme ? ` · theme: ${theme}` : ""}
+          </span>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function FilterChip({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`px-3 py-1 rounded-full text-xs font-medium transition-colors border ${
+        active
+          ? "bg-stone-800 text-amber-300 border-stone-800"
+          : "bg-white text-stone-700 border-stone-300 hover:bg-stone-100"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/client/src/data/works.ts
+++ b/client/src/data/works.ts
@@ -1,0 +1,355 @@
+/**
+ * The Harvest — Works
+ *
+ * Each "work" is a piece in The Harvest's living collection. Some are built,
+ * some are growing, some are forthcoming. They are presented like a museum
+ * exhibition: every piece carries a thread back to Witta's history.
+ *
+ * Edit this file to add, reorder, or update works. The /works index and
+ * /works/:slug detail pages render directly from this data.
+ */
+
+/* ─────────────────────────────────────────────────────────
+   Lifecycle vocabulary — the tense/state taxonomy.
+   Each work carries one or more of these tags. Tags also
+   double as the comms taxonomy (build campaign / grow
+   campaign / etc.). Works move through tags over time.
+   ───────────────────────────────────────────────────────── */
+
+export type LifecycleFamily = "build" | "grow" | "make" | "concept" | "open";
+export type LifecycleTense = "past" | "present" | "future" | "ongoing";
+
+export type LifecycleVocabEntry = {
+  label: string;
+  family: LifecycleFamily;
+  tense: LifecycleTense;
+  /** Tailwind class string for the badge background + text */
+  badgeClass: string;
+};
+
+export const LIFECYCLE_VOCAB = {
+  // Build family — physical structures, infrastructure
+  planned:    { label: "Planned",    family: "build" as const, tense: "future"  as const, badgeClass: "bg-stone-100 text-stone-700 border border-stone-300" },
+  funded:     { label: "Funded",     family: "build" as const, tense: "future"  as const, badgeClass: "bg-amber-100 text-amber-900 border border-amber-300" },
+  building:   { label: "Building",   family: "build" as const, tense: "present" as const, badgeClass: "bg-amber-500 text-stone-900" },
+  built:      { label: "Built",      family: "build" as const, tense: "past"    as const, badgeClass: "bg-stone-800 text-amber-300" },
+  extending:  { label: "Extending",  family: "build" as const, tense: "present" as const, badgeClass: "bg-orange-500 text-stone-900" },
+  maintained: { label: "Maintained", family: "build" as const, tense: "ongoing" as const, badgeClass: "bg-stone-300 text-stone-800" },
+
+  // Grow family — gardens, food, slow living things
+  planted:    { label: "Planted",   family: "grow" as const, tense: "past"    as const, badgeClass: "bg-emerald-100 text-emerald-900 border border-emerald-300" },
+  growing:    { label: "Growing",   family: "grow" as const, tense: "present" as const, badgeClass: "bg-emerald-700 text-emerald-50" },
+  harvested:  { label: "Harvested", family: "grow" as const, tense: "past"    as const, badgeClass: "bg-emerald-900 text-emerald-100" },
+
+  // Make family — art, craft, fabrication
+  drafted:    { label: "Drafted", family: "make" as const, tense: "past"    as const, badgeClass: "bg-rose-100 text-rose-900 border border-rose-300" },
+  making:     { label: "Making",  family: "make" as const, tense: "present" as const, badgeClass: "bg-rose-600 text-rose-50" },
+  made:       { label: "Made",    family: "make" as const, tense: "past"    as const, badgeClass: "bg-rose-900 text-rose-100" },
+
+  // Concept family — early stages, listening
+  concept:    { label: "Concept",    family: "concept" as const, tense: "future"  as const, badgeClass: "bg-stone-100 text-stone-600 border border-dashed border-stone-400" },
+  consulting: { label: "Consulting", family: "concept" as const, tense: "present" as const, badgeClass: "bg-amber-100 text-stone-800 border border-amber-300" },
+
+  // Open family — public-facing states
+  open:       { label: "Open",       family: "open" as const, tense: "present" as const, badgeClass: "bg-emerald-500 text-stone-900" },
+  forthcoming:{ label: "Forthcoming",family: "open" as const, tense: "future"  as const, badgeClass: "bg-amber-100 text-stone-800 border border-amber-300" },
+} as const satisfies Record<string, LifecycleVocabEntry>;
+
+export type LifecycleTag = keyof typeof LIFECYCLE_VOCAB;
+
+/** Sort key — past first, then ongoing, present, future. Within each, by label. */
+const TENSE_ORDER: Record<LifecycleTense, number> = { past: 0, ongoing: 1, present: 2, future: 3 };
+export function sortLifecycleTags(tags: LifecycleTag[]): LifecycleTag[] {
+  return [...tags].sort((a, b) => {
+    const ta = TENSE_ORDER[LIFECYCLE_VOCAB[a].tense];
+    const tb = TENSE_ORDER[LIFECYCLE_VOCAB[b].tense];
+    if (ta !== tb) return ta - tb;
+    return LIFECYCLE_VOCAB[a].label.localeCompare(LIFECYCLE_VOCAB[b].label);
+  });
+}
+
+/** @deprecated Use lifecycleTags array instead. Kept only for legacy callers. */
+export type WorkStatus = "built" | "growing" | "forthcoming";
+
+export type WittaThread = {
+  /** Year or era anchor — should match an entry in /witta timeline where possible */
+  year: string;
+  /** What that moment in Witta history was */
+  moment: string;
+  /** The thread — how this work pulls on that history */
+  thread: string;
+};
+
+export type WorkHand = {
+  name: string;
+  role: string;
+};
+
+export type Work = {
+  slug: string;
+  title: string;
+  /** One-line subtitle shown under the title */
+  subtitle: string;
+  /**
+   * Lifecycle tags — one or more from LIFECYCLE_VOCAB. A work can be in
+   * multiple states at once (e.g. ["built", "extending"] for a structure
+   * that's up but actively being added to). These tags also drive comms
+   * categorisation and shift over time as the work progresses.
+   */
+  lifecycleTags: LifecycleTag[];
+  /** "Reclaimed milk crates, scaffold, timber" — kept short, museum-label style */
+  materials: string;
+  /** Year built / planted / opening — flexible string */
+  year: string;
+  /** Hero image, served from /images/... */
+  heroImage: string;
+  heroAlt: string;
+  /** Optional credit line for the hero image */
+  heroCredit?: string;
+  /** Short description for the index card (1-2 sentences) */
+  blurb: string;
+  /** Long-form sections on the detail page */
+  whatItIs: string;
+  why: string;
+  how: string;
+  /** Threads back to Witta history — usually 2-4 */
+  wittaThreads: WittaThread[];
+  /** People (and partner orgs) behind it */
+  hands: WorkHand[];
+  /** Optional external link (e.g. fellowship page) */
+  link?: { label: string; href: string };
+  /** Optional related works for cross-linking */
+  related?: string[];
+};
+
+export const works: Work[] = [
+  {
+    slug: "milk-crate-pavilion",
+    title: "Milk Create Pavilion",
+    subtitle: "Milk crate, milk create — the same syllables, both true",
+    lifecycleTags: ["building"],
+    materials: "Reclaimed milk crates, scaffold, salvaged timber, community hands",
+    year: "Built March 2026",
+    heroImage: "/images/social/04-radical-scoops.png",
+    heroAlt: "The Milk Create Pavilion under construction at The Harvest, March 2026",
+    heroCredit: "Radical Scoops fellowship · Regional Arts Australia",
+    blurb:
+      "Eighty people built it together in a single weekend. Milk crates from the dairy industry, scaffold poles, found timber. The first piece of architecture on the site is also the most communal.",
+    whatItIs:
+      "A modular open-air pavilion at the heart of The Harvest. Roughly 14m × 9m, sized to fit comfortably under the pecan trees. Plays the role of gallery, theatre, market hall, dining room and weather shelter — sometimes in the same afternoon. Designed to come apart, rearrange, and grow.",
+    why:
+      "We needed a shared roof before we needed walls. A pavilion lets the community show up before the buildings finish — markets, exhibitions, films, dinners, conversations. It says clearly: this place is for gathering, and gathering is the first work.",
+    how:
+      "Built across one weekend in March 2026 with more than eighty community members under the Radical Scoops fellowship. Milk crates were sourced from the dairy industry that once powered Witta. Scaffold was hired and rebuilt as structure. Timber was offcuts, salvage, and gifts. No single builder — everyone took a corner.",
+    wittaThreads: [
+      {
+        year: "1904",
+        moment: "Maleny's first butter factory opens — the co-operative model takes root.",
+        thread:
+          "The crate is the icon of that century. Stacked, shared, returned, restacked. We took the form and made it a roof.",
+      },
+      {
+        year: "1960s",
+        moment: "Dairy industry peak — around 300 butter and cheese factories across the hinterland.",
+        thread:
+          "These crates carried the milk that built every house on this ridge. Reusing them keeps the lineage in the room.",
+      },
+      {
+        year: "2000",
+        moment: "Dairy deregulation. Farms that sustained families for generations become unviable.",
+        thread:
+          "What was discarded after deregulation becomes the architecture of the next chapter. Not nostalgia — repurpose.",
+      },
+    ],
+    hands: [
+      { name: "Eighty community members", role: "Builders, weekend of 7 March 2026" },
+      { name: "Regional Arts Australia", role: "Radical Scoops fellowship funder" },
+      { name: "Ben Knight & Nicholas Marchesi", role: "Co-founders, project leads" },
+    ],
+    link: {
+      label: "Radical Scoops fellowship",
+      href: "https://regionalarts.com.au/resources/radical-scoops",
+    },
+    related: ["the-cedar", "the-garden"],
+  },
+  {
+    slug: "the-cedar",
+    title: "The Cedar",
+    subtitle: "Working with the wood the range almost lost",
+    lifecycleTags: ["building", "making"],
+    materials: "Red cedar and hoop pine from local properties · second- and third-growth",
+    year: "Sourced 2026",
+    heroImage: "/images/witta/history/bullock-team-eudlo-1905.jpg",
+    heroAlt: "Bullock teams hauling cedar logs, Eudlo district, c. 1905",
+    heroCredit: "State Library of Queensland",
+    blurb:
+      "Cedar came back. Not the giants — those went to London and never came home. But what's grown back belongs to the people who stayed. We're working with timber from a Witta resident's land.",
+    whatItIs:
+      "An ongoing collection of timber pieces being built into The Harvest — bench seats, a bar, gallery rails, the kitchen pass. Mostly red cedar and hoop pine, sourced locally rather than imported. Each piece is documented: where it came from, who milled it, where it sits.",
+    why:
+      "The range was stripped of cedar inside two generations. By 1906 it was commercially extinct. The wood we now use carries that history — it is what came back after the rush. Choosing local timber over plantation hardwood is a small act of repair, and an act of recognition.",
+    how:
+      "Sourced from Barry Rodgerig's property and other Witta residents who have nursed second-growth stands for decades. Milled by local sawyers. Used unfinished where possible. The grain stays visible. Where a knot or split tells a story, we keep it.",
+    wittaThreads: [
+      {
+        year: "1860",
+        moment: "Bunya pine reserve rescinded. Timber-getters flood in. The 'red gold' rush begins.",
+        thread:
+          "What was extracted is what we are now restoring — slowly, plank by plank.",
+      },
+      {
+        year: "1886",
+        moment: "Two giant cedar logs shipped to the Indian and Colonial Exhibition in London. No buyer — too large for any mill in the world.",
+        thread:
+          "Half of one of those logs is reportedly still in a London museum. The wood we use today is from the descendants the loggers missed.",
+      },
+      {
+        year: "1906",
+        moment: "Red cedar faces commercial extinction. One-third of Queensland's hoop and bunya pine already gone.",
+        thread:
+          "Every cedar plank in The Harvest is a quiet refusal of that ending.",
+      },
+    ],
+    hands: [
+      { name: "Barry Rodgerig", role: "27-year nurseryman, primary timber source" },
+      { name: "Local sawyers", role: "Milling and dressing" },
+      { name: "Nicholas Marchesi", role: "Material lead, gallery rail design" },
+    ],
+    related: ["milk-crate-pavilion", "the-garden"],
+  },
+  {
+    slug: "the-garden",
+    title: "The Garden",
+    subtitle: "The volcano made the soil. The community works the rows.",
+    lifecycleTags: ["planted", "growing"],
+    materials: "Krasnozem basalt soil · seasonal beds · community-managed",
+    year: "Established 2025, planted ongoing",
+    heroImage: "/images/compendium/sophie-garden.jpg",
+    heroAlt: "Sophie working in the garden at The Harvest",
+    blurb:
+      "The reason anything grows here is Jurassic. Volcanic red soil, two metres of rain a year, mist from the coast that gets pushed up the range. The garden is half landscape, half practice.",
+    whatItIs:
+      "The productive garden at The Harvest — beds for kitchen herbs, salad, fruiting vegetables, perennials, and a slowly building food forest. Tended by the Wednesday Maintenance Crew and a rotating roster of volunteers. Not a display garden. A working one.",
+    why:
+      "If we don't grow some of what we eat, we are not what we say we are. The garden is the daily proof. It also gives us a reason for people to come back every week — caring for something living is the strongest invitation we have.",
+    how:
+      "Beds were laid out in late 2025 around the existing canopy. Wednesday Maintenance Crew runs weekly through the seasons — weeding, mulching, planting, harvesting. Cuttings go to the kitchen, surplus to neighbours, scraps back to compost. Decisions are made in the bed, not on paper.",
+    wittaThreads: [
+      {
+        year: "Time immemorial",
+        moment: "Jinibara custodianship of the Blackall Range. Land managed through fire, seasonal movement, and deep ecological knowledge.",
+        thread:
+          "The first gardeners of this place worked it for tens of thousands of years. We grow on Country, with respect, and we are still learning.",
+      },
+      {
+        year: "Jurassic era",
+        moment: "Volcanic basalt soils form the deep, nutrient-rich krasnozem of the Blackall Range.",
+        thread:
+          "The soil is older than every story. It is the reason the rainforest, the dairies, and now the garden exist.",
+      },
+      {
+        year: "1893",
+        moment: "Meat and Dairy Encouragement Act. Dairy begins replacing timber across the range.",
+        thread:
+          "The pasture economy that followed was monoculture. The garden is the opposite: plural, seasonal, and small enough to know.",
+      },
+    ],
+    hands: [
+      { name: "Wednesday Maintenance Crew", role: "Weekly stewards" },
+      { name: "Sophie", role: "Garden volunteer" },
+      { name: "Susie & Joey", role: "Community Stewards (from July 2026)" },
+    ],
+    related: ["milk-crate-pavilion", "the-shop"],
+  },
+  {
+    slug: "the-sauna",
+    title: "The Sauna",
+    subtitle: "A communal warmth ritual for a cold-mist hinterland",
+    lifecycleTags: ["concept", "consulting"],
+    materials: "Cedar lining · timber-fire heater · spring-fed cold plunge (proposed)",
+    year: "Proposed 2026–27",
+    heroImage: "/images/sketch-share.png",
+    heroAlt: "A sketch placeholder for the proposed Witta sauna",
+    blurb:
+      "Five hundred and sixty metres up. Five to ten degrees cooler than the coast. Mist on the ridge most mornings. A sauna is not a luxury here — it is a way the community already wants to gather.",
+    whatItIs:
+      "A small communal sauna planned for The Harvest site, sized for six to eight people. Wood-fired. Designed to sit close to the garden, with a cold-water plunge or shower nearby. Bookable by members and open at scheduled community sessions.",
+    why:
+      "Witta's first European settlers were German, and the cooperative culture they brought — shared equipment, shared facilities — is part of why this place exists. A sauna is a tiny, useful version of that: a warm room nobody owns alone. It also answers a real question of the climate. The range is wet, cool, and often misty. Heat is a gift here, and shared heat doubles as conversation.",
+    how:
+      "Concept stage. Likely cedar-lined (see The Cedar) and stove-heated, with an off-grid or low-draw electrical setup. Build sequence depends on sub-operator and member feedback. May be the first piece The Harvest builds with its own revenue rather than grant funding.",
+    wittaThreads: [
+      {
+        year: "561m elevation",
+        moment: "Witta sits high. Cooler, mistier, and 5–10°C below the coast.",
+        thread:
+          "A sauna does for the body what the kitchen does for the table. It makes the climate hospitable on the climate's terms.",
+      },
+      {
+        year: "1887",
+        moment: "German families from Brisbane's Logan district select land and name the settlement Teutoburg.",
+        thread:
+          "Communal warmth has European roots in this village. We're not importing the practice — we're returning to one.",
+      },
+      {
+        year: "Cooperative roots",
+        moment: "Maleny co-op region: shared butter factories, pooled equipment, mutual infrastructure.",
+        thread:
+          "A sauna is co-op infrastructure for the body. Same logic, smaller scale.",
+      },
+    ],
+    hands: [
+      { name: "Community members", role: "Co-design (open from late 2026)" },
+      { name: "Local builders", role: "TBC" },
+    ],
+    related: ["milk-crate-pavilion", "the-shop"],
+  },
+  {
+    slug: "the-shop",
+    title: "The Shop",
+    subtitle: "Reclaiming the village shop that Witta hasn't had in a generation",
+    lifecycleTags: ["concept", "planned"],
+    materials: "Local makers · co-op model · low overhead · honesty more than ornament",
+    year: "Proposed 2027",
+    heroImage: "/images/sketch-food.png",
+    heroAlt: "A sketch placeholder for the proposed community shop at The Harvest",
+    blurb:
+      "Witta has roughly 1,300 residents and no shops, no pub. The Shop is a small, slow attempt to put one back — on co-operative terms, with the makers who already live here.",
+    whatItIs:
+      "A small retail space at The Harvest stocking what Witta and the surrounding hinterland produces — preserves, ferments, ceramics, prints, oils, herbs, baked goods, gifts from the residencies. Run on a consignment-and-co-op model rather than a buy-low-sell-high one. Sublicenced under the lease, at arm's length from Harvest Pty's programming.",
+    why:
+      "The strategic plan calls for sub-licenced retail. The deeper reason is that Witta's last shop closed inside living memory and the gap is felt every week. A village without a shop has to drive for everything. A shop with the right shape — not Coles, not boutique — gives makers a shelf and gives neighbours a reason to walk past.",
+    how:
+      "Sub-licenced under the lease, capital-light by design. Co-design with local makers and the Wednesday Maintenance Crew. Honest signage: who made it, where it came from, what they got paid. Open progressively as products and operators are ready, not all at once.",
+    wittaThreads: [
+      {
+        year: "Today",
+        moment: "Witta: ~1,300 residents. No shops. No pub. A school that closed in 1974.",
+        thread:
+          "The Shop answers an absence that's been there for fifty years. Modestly, on the village's own terms.",
+      },
+      {
+        year: "1904",
+        moment: "Maleny's first butter factory opens. The co-operative model takes root.",
+        thread:
+          "The first commerce here was co-operative. The Shop returns to that operating system, scaled to a village.",
+      },
+      {
+        year: "1980s",
+        moment: "Maleny attracts artists, craftspeople, and alternative lifestylers. Co-ops, organic produce, and intentional communities replace dairy infrastructure.",
+        thread:
+          "Forty years of makers around Witta still need a shelf. We're building the shelf.",
+      },
+    ],
+    hands: [
+      { name: "Local makers (Witta + hinterland)", role: "Stockists, co-designers" },
+      { name: "Sub-operator (TBC)", role: "Day-to-day retail" },
+      { name: "Harvest Pty Ltd", role: "Sub-licence holder" },
+    ],
+    related: ["the-garden", "milk-crate-pavilion"],
+  },
+];
+
+export const worksBySlug: Record<string, Work> = Object.fromEntries(
+  works.map((w) => [w.slug, w]),
+);

--- a/client/src/lib/empathyLedger.ts
+++ b/client/src/lib/empathyLedger.ts
@@ -1,0 +1,27 @@
+/**
+ * Client-side helpers for talking to the Empathy Ledger admin UI.
+ *
+ * The base URL is configurable via VITE_EMPATHY_LEDGER_URL — defaults to the
+ * local dev server (http://localhost:3030). Set to https://www.empathyledger.com
+ * (or the prod URL) in .env when deploying.
+ */
+
+const DEFAULT_BASE = "http://localhost:3030";
+
+/** A Curious Tractor — the org all Harvest photos sit under in EL. */
+export const EL_HARVEST_ORG_ID = "db0de7bd-eb10-446b-99e9-0f3b7c199b8a";
+
+export function getElBase(): string {
+  const v = import.meta.env.VITE_EMPATHY_LEDGER_URL as string | undefined;
+  return (v || DEFAULT_BASE).replace(/\/$/, "");
+}
+
+/** Direct links into the EL admin surfaces we send Harvest admins to. */
+export const elLinks = {
+  photoManager: () => `${getElBase()}/organisations/${EL_HARVEST_ORG_ID}/photo-manager`,
+  galleries:    () => `${getElBase()}/admin/galleries`,
+  bulkEdit:     () => `${getElBase()}/admin/bulk-edit`,
+  articles:     () => `${getElBase()}/admin/stories?contentType=articles`,
+  /** A specific article — pass the EL article id (uuid). */
+  articleById: (id: string) => `${getElBase()}/admin/stories/${id}`,
+};

--- a/client/src/lib/imageOptimize.ts
+++ b/client/src/lib/imageOptimize.ts
@@ -1,0 +1,55 @@
+/**
+ * Image optimisation helper.
+ *
+ * Supabase Storage exposes a render endpoint that resizes/optimises images on
+ * the fly:  /storage/v1/render/image/public/<bucket>/<path>?width=...&quality=...
+ *
+ * We swap `/object/public/` for `/render/image/public/` on EL-hosted assets
+ * and append the size you actually need. Local images and external URLs are
+ * returned untouched.
+ *
+ * Real-world saving on Harvest gallery photos: ~430KB → ~70KB at 400px.
+ */
+
+export type ImageSize = "thumb" | "card" | "hero" | "feature";
+
+const PRESETS: Record<ImageSize, { width: number; quality: number }> = {
+  thumb:   { width: 400,  quality: 70 },  // grid tiles
+  card:    { width: 800,  quality: 75 },  // /works index cards
+  hero:    { width: 1600, quality: 82 },  // detail-page hero
+  feature: { width: 1200, quality: 78 },  // inline feature images
+};
+
+/**
+ * Given a Supabase Storage URL and a size preset, return an optimised version.
+ * Untouched if the URL isn't a Supabase /object/public/ URL or is empty.
+ */
+export function optimize(url: string | null | undefined, size: ImageSize): string {
+  if (!url) return "";
+  const preset = PRESETS[size];
+
+  // Detect Supabase storage public URL
+  const m = url.match(/^(https:\/\/[^/]+)\/storage\/v1\/object\/public\/(.+)$/);
+  if (!m) return url;
+
+  const [, origin, path] = m;
+  // Strip any existing query string from the path before re-appending ours
+  const [cleanPath, existingQuery] = path.split("?");
+  const params = new URLSearchParams(existingQuery || "");
+  params.set("width", String(preset.width));
+  params.set("quality", String(preset.quality));
+  params.set("resize", "contain");
+  return `${origin}/storage/v1/render/image/public/${cleanPath}?${params.toString()}`;
+}
+
+/**
+ * Build a srcSet for responsive images. Useful when the same photo appears
+ * at varying viewport widths.
+ */
+export function buildSrcSet(url: string | null | undefined): string | undefined {
+  if (!url) return undefined;
+  const sizes: ImageSize[] = ["thumb", "card", "feature", "hero"];
+  return sizes
+    .map((s) => `${optimize(url, s)} ${PRESETS[s].width}w`)
+    .join(", ");
+}

--- a/client/src/pages/BauhausHome.tsx
+++ b/client/src/pages/BauhausHome.tsx
@@ -5,6 +5,7 @@ import BauhausFooter from "@/components/BauhausFooter";
 import FadeIn from "@/components/FadeIn";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { rootStyle, colors, fonts } from "@/styles/brand";
+import { trpc } from "@/lib/trpc";
 
 const zones = [
   {
@@ -37,6 +38,7 @@ const events = [
 export default function BauhausHome() {
   const isMobile = useMediaQuery("(max-width: 768px)");
   const [scrollVisible, setScrollVisible] = useState(false);
+  const { data: storytellers } = trpc.harvest.publicStorytellers.useQuery(undefined, { staleTime: 5 * 60_000 });
 
   useEffect(() => {
     document.title = "The Harvest - Witta, Sunshine Coast Hinterland";
@@ -371,6 +373,191 @@ export default function BauhausHome() {
               </FadeIn>
             ))}
           </div>
+        </div>
+      </section>
+
+      {/* --- 3.5 PEOPLE OF THE HARVEST --- */}
+      <section style={{
+        backgroundColor: colors.shed,
+        color: colors.milk,
+        padding: isMobile ? "100px 28px" : "160px 40px",
+      }}>
+        <div style={{ maxWidth: 1200, margin: "0 auto" }}>
+          <FadeIn>
+            <div style={{ marginBottom: 64, textAlign: "center" }}>
+              <span style={{
+                fontFamily: fonts.display,
+                fontWeight: 700,
+                fontSize: 12,
+                letterSpacing: "0.4em",
+                color: colors.goldenHour,
+                marginBottom: 24,
+                display: "block",
+              }}>
+                PEOPLE OF THE HARVEST
+              </span>
+              <h2 style={{
+                fontFamily: fonts.display,
+                fontSize: isMobile ? "clamp(32px, 7vw, 48px)" : "clamp(40px, 5vw, 64px)",
+                fontWeight: 900,
+                lineHeight: 1.05,
+                letterSpacing: "-0.01em",
+                margin: 0,
+              }}>
+                The hands behind the work.
+              </h2>
+            </div>
+          </FadeIn>
+
+          <div style={{
+            display: "grid",
+            gridTemplateColumns: isMobile ? "1fr" : "repeat(3, 1fr)",
+            gap: isMobile ? 24 : 40,
+            marginBottom: 56,
+          }}>
+            {(storytellers ?? []).slice(0, 3).map((s, i) => (
+              <FadeIn key={s.id} delay={0.1 + i * 0.1}>
+                <Link href={`/people/${s.slug}`}>
+                  <div style={{
+                    backgroundColor: "rgba(245,240,232,0.05)",
+                    border: `1px solid rgba(245,240,232,0.15)`,
+                    padding: isMobile ? 28 : 36,
+                    cursor: "pointer",
+                    height: "100%",
+                    display: "flex",
+                    flexDirection: "column",
+                    transition: "border-color 0.3s, background-color 0.3s",
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.borderColor = colors.goldenHour;
+                    e.currentTarget.style.backgroundColor = "rgba(245,240,232,0.08)";
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.borderColor = "rgba(245,240,232,0.15)";
+                    e.currentTarget.style.backgroundColor = "rgba(245,240,232,0.05)";
+                  }}
+                  >
+                    <div style={{ display: "flex", alignItems: "center", gap: 16, marginBottom: 24 }}>
+                      {s.avatarUrl ? (
+                        <img
+                          src={s.avatarUrl}
+                          alt={s.displayName}
+                          style={{
+                            width: 64, height: 64, borderRadius: "50%",
+                            objectFit: "cover",
+                            border: `1px solid rgba(245,240,232,0.3)`,
+                          }}
+                        />
+                      ) : (
+                        <div style={{
+                          width: 64, height: 64, borderRadius: "50%",
+                          backgroundColor: colors.goldenHour,
+                          color: colors.shed,
+                          display: "flex", alignItems: "center", justifyContent: "center",
+                          fontFamily: fonts.display,
+                          fontWeight: 900,
+                          fontSize: 28,
+                        }}>
+                          {s.displayName.charAt(0).toUpperCase()}
+                        </div>
+                      )}
+                      <div>
+                        <h3 style={{
+                          fontFamily: fonts.display,
+                          fontWeight: 900,
+                          fontSize: 22,
+                          margin: 0,
+                          lineHeight: 1.1,
+                        }}>
+                          {s.displayName}
+                        </h3>
+                        {s.location && (
+                          <p style={{
+                            fontFamily: fonts.body,
+                            fontSize: 12,
+                            opacity: 0.6,
+                            margin: "4px 0 0",
+                          }}>
+                            {s.location}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+
+                    {s.bio && (
+                      <p style={{
+                        fontFamily: fonts.body,
+                        fontSize: 15,
+                        lineHeight: 1.6,
+                        opacity: 0.85,
+                        margin: 0,
+                        flex: 1,
+                        display: "-webkit-box",
+                        WebkitLineClamp: 4,
+                        WebkitBoxOrient: "vertical",
+                        overflow: "hidden",
+                      }}>
+                        {s.bio}
+                      </p>
+                    )}
+
+                    <div style={{ marginTop: 24, display: "flex", flexWrap: "wrap", gap: 8 }}>
+                      {s.publishedArticleCount > 0 && (
+                        <span style={{ fontFamily: fonts.display, fontSize: 10, letterSpacing: "0.1em", opacity: 0.65 }}>
+                          {s.publishedArticleCount} ARTICLE{s.publishedArticleCount === 1 ? "" : "S"}
+                        </span>
+                      )}
+                      {s.transcriptCount > 0 && (
+                        <span style={{ fontFamily: fonts.display, fontSize: 10, letterSpacing: "0.1em", opacity: 0.65 }}>
+                          · {s.transcriptCount} RECORDING{s.transcriptCount === 1 ? "" : "S"}
+                        </span>
+                      )}
+                    </div>
+
+                    <span style={{
+                      fontFamily: fonts.display,
+                      fontWeight: 700,
+                      fontSize: 11,
+                      letterSpacing: "0.15em",
+                      marginTop: 24,
+                      color: colors.goldenHour,
+                    }}>
+                      READ MORE →
+                    </span>
+                  </div>
+                </Link>
+              </FadeIn>
+            ))}
+          </div>
+
+          <FadeIn delay={0.5}>
+            <div style={{ textAlign: "center" }}>
+              <Link href="/people">
+                <span style={{
+                  display: "inline-block",
+                  border: `2px solid ${colors.milk}`,
+                  fontFamily: fonts.display,
+                  fontWeight: 700,
+                  fontSize: 13,
+                  letterSpacing: "0.2em",
+                  padding: "20px 48px",
+                  color: colors.milk,
+                  cursor: "pointer",
+                  transition: "all 0.3s",
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.backgroundColor = colors.milk;
+                  e.currentTarget.style.color = colors.shed;
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.backgroundColor = "transparent";
+                  e.currentTarget.style.color = colors.milk;
+                }}>
+                  MEET ALL THE PEOPLE →
+                </span>
+              </Link>
+            </div>
+          </FadeIn>
         </div>
       </section>
 

--- a/client/src/pages/BauhausHome.tsx
+++ b/client/src/pages/BauhausHome.tsx
@@ -155,6 +155,22 @@ export default function BauhausHome() {
                 PHOTO WALL
               </span>
             </Link>
+            <Link href="/people">
+              <span style={{
+                fontFamily: fonts.display,
+                fontWeight: 700,
+                fontSize: 12,
+                letterSpacing: "0.1em",
+                color: colors.milk,
+                backgroundColor: "rgba(255,255,255,0.15)",
+                border: `1px solid rgba(255,255,255,0.3)`,
+                padding: "12px 24px",
+                display: "inline-block",
+                cursor: "pointer",
+              }}>
+                MEET THE PEOPLE
+              </span>
+            </Link>
           </div>
         </div>
         {/* Scroll indicator */}
@@ -427,6 +443,27 @@ export default function BauhausHome() {
             >
               LEARN MORE AT REGIONAL ARTS AUSTRALIA
             </a>
+          </FadeIn>
+          <FadeIn delay={0.3}>
+            <div style={{ marginTop: 32 }}>
+              <Link
+                href="/works"
+                style={{
+                  display: "inline-block",
+                  fontFamily: fonts.display,
+                  fontWeight: 700,
+                  fontSize: 13,
+                  letterSpacing: "0.2em",
+                  color: colors.shed,
+                  textDecoration: "underline",
+                  textDecorationColor: colors.goldenHour,
+                  textDecorationThickness: 2,
+                  textUnderlineOffset: 6,
+                }}
+              >
+                SEE THE COLLECTION →
+              </Link>
+            </div>
           </FadeIn>
         </div>
       </section>

--- a/client/src/pages/Blog.tsx
+++ b/client/src/pages/Blog.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { motion } from "framer-motion";
 import { trpc } from "@/lib/trpc";
 import BlogCard, { type ELArticle } from "@/components/BlogCard";
@@ -26,13 +25,16 @@ const staggerContainer = {
 
 export default function Blog() {
   const [theme, setTheme] = useState<BlogTheme>(null);
+  const [workFilter, setWorkFilter] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
 
-  // Fetch articles from Empathy Ledger
-  const { data, isLoading } = useQuery({
-    queryKey: ["blog", "list", theme],
-    queryFn: () => trpc.blog.list.query(theme ? { theme } : undefined),
-  });
+  // Fetch articles from Empathy Ledger — filter server-side by work (project) too
+  const { data, isLoading } = trpc.blog.list.useQuery(
+    {
+      theme: theme ?? undefined,
+      project: workFilter ?? undefined,
+    },
+  );
 
   const articles = data?.articles || [];
 
@@ -75,13 +77,20 @@ export default function Blog() {
               Community stories, transformation journeys, and moments of connection.
               A window into life at The Harvest.
             </p>
+            <div className="mt-6">
+              <Link href="/people">
+                <a className="inline-flex items-center gap-2 text-sm font-semibold text-amber-700 hover:text-amber-800">
+                  Or meet the storytellers <span aria-hidden>→</span>
+                </a>
+              </Link>
+            </div>
           </motion.div>
         </div>
       </section>
 
       {/* Search and Filters */}
       <section className="py-8 border-b border-stone-200 bg-white sticky top-16 z-30">
-        <div className="container">
+        <div className="container space-y-4">
           <div className="flex flex-col lg:flex-row gap-6 items-start lg:items-center justify-between">
             <BlogCategories selected={theme} onChange={setTheme} />
 
@@ -95,6 +104,28 @@ export default function Blog() {
                 className="pl-10 bg-stone-50 border-stone-200"
               />
             </div>
+          </div>
+
+          {/* Work filter — chip row */}
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xs font-mono uppercase tracking-wider text-stone-400 mr-1">
+              Work:
+            </span>
+            <BlogWorkChip label="All" active={!workFilter} onClick={() => setWorkFilter(null)} />
+            {[
+              { slug: "milk-crate-pavilion", label: "Milk Create Pavilion" },
+              { slug: "the-cedar", label: "The Cedar" },
+              { slug: "the-garden", label: "The Garden" },
+              { slug: "the-sauna", label: "The Sauna" },
+              { slug: "the-shop", label: "The Shop" },
+            ].map((w) => (
+              <BlogWorkChip
+                key={w.slug}
+                label={w.label}
+                active={workFilter === w.slug}
+                onClick={() => setWorkFilter(w.slug)}
+              />
+            ))}
           </div>
         </div>
       </section>
@@ -113,7 +144,7 @@ export default function Blog() {
             <h2 className="text-2xl font-serif font-bold text-stone-800 mb-6">
               Stories from the Land
             </h2>
-            <Link href="/stories">
+            <Link href="/people/barry-rodgerig">
               <Card className="overflow-hidden border-0 bg-stone-800 group cursor-pointer hover:ring-2 hover:ring-amber-500/50 transition-all">
                 <div className="grid md:grid-cols-2">
                   <div className="relative h-64 md:h-auto overflow-hidden">
@@ -225,5 +256,29 @@ export default function Blog() {
       </section>
 
     </div>
+  );
+}
+
+function BlogWorkChip({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
+        active
+          ? "bg-stone-800 text-amber-300 border-stone-800"
+          : "bg-white text-stone-700 border-stone-300 hover:bg-stone-100"
+      }`}
+    >
+      {label}
+    </button>
   );
 }

--- a/client/src/pages/BlogPost.tsx
+++ b/client/src/pages/BlogPost.tsx
@@ -1,7 +1,10 @@
-import { useQuery } from "@tanstack/react-query";
-import { useParams, Link } from "wouter";
+import { Link } from "wouter";
 import { motion } from "framer-motion";
 import { trpc } from "@/lib/trpc";
+import { EditableText } from "@/components/EditableText";
+import { useAuth } from "@/_core/hooks/useAuth";
+import { elLinks } from "@/lib/empathyLedger";
+import { ExternalLink, Pencil } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import ShareButtons from "@/components/ShareButtons";
@@ -43,28 +46,41 @@ function estimateReadingTime(content: string | null | undefined): number {
   return Math.max(1, Math.ceil(words / 200));
 }
 
-export default function BlogPost() {
-  const params = useParams<{ slug: string }>();
-  const slug = params.slug;
+export default function BlogPost({ slug }: { slug: string }) {
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
 
-  const { data: article, isLoading, error } = useQuery({
-    queryKey: ["blog", "post", slug],
-    queryFn: () => trpc.blog.bySlug.query({ slug: slug! }),
-    enabled: !!slug,
-  });
+  const { data: article, isLoading, error } = trpc.blog.bySlug.useQuery(
+    { slug },
+    { enabled: !!slug },
+  );
 
   // Get related articles (recent articles from same theme)
   const primaryTheme = article?.themes?.[0];
-  const { data: relatedData } = useQuery({
-    queryKey: ["blog", "related", primaryTheme],
-    queryFn: () => trpc.blog.list.query({ theme: primaryTheme }),
-    enabled: !!primaryTheme,
-  });
+  const { data: relatedData } = trpc.blog.list.useQuery(
+    primaryTheme ? { theme: primaryTheme } : undefined,
+    { enabled: !!primaryTheme },
+  );
 
   // Filter out current article and limit to 3
   const relatedArticles = (relatedData?.articles || [])
     .filter((a: ELArticle) => a.id !== article?.id)
     .slice(0, 3);
+
+  // Resolve "is this article by a Harvest storyteller?" so we can link author -> /people/:slug.
+  // Match either by author_name == display_name OR by article slug containing storyteller first name.
+  const { data: harvestStorytellers } = trpc.harvest.publicStorytellers.useQuery(undefined, { staleTime: 5 * 60_000 });
+  const matchedStoryteller = (() => {
+    if (!article || !harvestStorytellers) return null;
+    const authorLower = (article.authorName || "").toLowerCase();
+    const slugLower = (slug || "").toLowerCase();
+    const byName = harvestStorytellers.find((s) => s.displayName.toLowerCase() === authorLower);
+    if (byName) return byName;
+    return harvestStorytellers.find((s) => {
+      const first = s.displayName.toLowerCase().split(/\s+/)[0];
+      return first.length >= 3 && (slugLower.includes(first) || authorLower.includes(first));
+    }) ?? null;
+  })();
 
   const currentUrl = typeof window !== "undefined" ? window.location.href : "";
 
@@ -118,6 +134,28 @@ export default function BlogPost() {
       {/* Hero Section */}
       <section className="pt-32 pb-8">
         <div className="container max-w-4xl">
+          {/* Admin bar — only visible when logged in as admin */}
+          {isAdmin && (
+            <div className="mb-6 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm flex flex-wrap items-center gap-3">
+              <span className="font-mono text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full bg-amber-500 text-stone-900 font-semibold whitespace-nowrap">
+                Admin
+              </span>
+              <span className="text-stone-700">
+                Title and subtitle are website overrides (hover the
+                <Pencil className="inline h-3 w-3 mx-1" /> pencil). The body lives in EL.
+              </span>
+              <a
+                href={elLinks.articleById(article.id)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="ml-auto inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-white border border-amber-300 text-amber-800 hover:bg-amber-100 transition-colors text-xs"
+              >
+                <ExternalLink className="h-3 w-3" />
+                Edit body in EL
+              </a>
+            </div>
+          )}
+
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -142,23 +180,38 @@ export default function BlogPost() {
               {theme}
             </Badge>
 
-            {/* Title */}
-            <h1 className="text-4xl md:text-5xl font-serif font-bold text-stone-800 leading-tight mb-4">
-              {article.title}
-            </h1>
+            {/* Title — admin-editable on the website (overrides EL display) */}
+            <EditableText
+              page="blog"
+              slot={`${slug}-title`}
+              defaultContent={article.title}
+              as="h1"
+              className="text-4xl md:text-5xl font-serif font-bold text-stone-800 leading-tight mb-4"
+            />
 
-            {/* Subtitle */}
-            {article.subtitle && (
-              <p className="text-xl text-stone-600 mb-6">
-                {article.subtitle}
-              </p>
+            {/* Subtitle — admin-editable */}
+            {(article.subtitle || isAdmin) && (
+              <EditableText
+                page="blog"
+                slot={`${slug}-subtitle`}
+                defaultContent={article.subtitle || ""}
+                as="p"
+                className="text-xl text-stone-600 mb-6"
+                multiline
+              />
             )}
 
             {/* Meta */}
             <div className="flex flex-wrap items-center gap-6 text-stone-500 mb-8">
               <span className="flex items-center gap-2">
                 <User className="h-4 w-4" />
-                {article.authorName}
+                {matchedStoryteller ? (
+                  <Link href={`/people/${matchedStoryteller.slug}`}>
+                    <a className="text-amber-700 underline-offset-2 hover:underline">{article.authorName}</a>
+                  </Link>
+                ) : (
+                  article.authorName
+                )}
               </span>
               <span className="flex items-center gap-2">
                 <Calendar className="h-4 w-4" />
@@ -276,17 +329,49 @@ export default function BlogPost() {
       {/* Author Section */}
       <section className="py-12 bg-stone-50">
         <div className="container max-w-3xl">
-          <div className="flex items-center gap-4">
-            <div className="w-16 h-16 rounded-full bg-amber-100 flex items-center justify-center">
-              <span className="text-2xl font-serif font-bold text-amber-700">
-                {article.authorName.charAt(0)}
-              </span>
+          {matchedStoryteller ? (
+            <Link href={`/people/${matchedStoryteller.slug}`}>
+              <a className="group flex items-start gap-4 rounded-lg border border-stone-200 bg-white p-5 transition hover:border-amber-300 hover:shadow-md">
+                {matchedStoryteller.avatarUrl ? (
+                  <img
+                    src={matchedStoryteller.avatarUrl}
+                    alt={matchedStoryteller.displayName}
+                    className="h-16 w-16 flex-shrink-0 rounded-full border border-stone-200 object-cover"
+                  />
+                ) : (
+                  <div className="flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-full bg-amber-100">
+                    <span className="text-2xl font-serif font-bold text-amber-700">
+                      {matchedStoryteller.displayName.charAt(0)}
+                    </span>
+                  </div>
+                )}
+                <div className="min-w-0">
+                  <p className="font-semibold text-stone-800 group-hover:text-amber-700">{matchedStoryteller.displayName}</p>
+                  {matchedStoryteller.location && (
+                    <p className="text-stone-500 text-sm">{matchedStoryteller.location}</p>
+                  )}
+                  {matchedStoryteller.bio && (
+                    <p className="mt-2 line-clamp-3 text-sm leading-relaxed text-stone-600">{matchedStoryteller.bio}</p>
+                  )}
+                  <p className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-amber-700">
+                    More by {matchedStoryteller.displayName.split(" ")[0]} <ChevronRight className="h-3 w-3" />
+                  </p>
+                </div>
+              </a>
+            </Link>
+          ) : (
+            <div className="flex items-center gap-4">
+              <div className="w-16 h-16 rounded-full bg-amber-100 flex items-center justify-center">
+                <span className="text-2xl font-serif font-bold text-amber-700">
+                  {article.authorName.charAt(0)}
+                </span>
+              </div>
+              <div>
+                <p className="font-semibold text-stone-800">{article.authorName}</p>
+                <p className="text-stone-500 text-sm">The Harvest Community</p>
+              </div>
             </div>
-            <div>
-              <p className="font-semibold text-stone-800">{article.authorName}</p>
-              <p className="text-stone-500 text-sm">The Harvest Community</p>
-            </div>
-          </div>
+          )}
         </div>
       </section>
 

--- a/client/src/pages/GardenLaunch.tsx
+++ b/client/src/pages/GardenLaunch.tsx
@@ -1,0 +1,453 @@
+import { useEffect, useState } from "react";
+import { Link } from "wouter";
+import { motion } from "framer-motion";
+import {
+  ArrowRight,
+  Calendar,
+  Clock,
+  MapPin,
+  Mail,
+  Phone,
+  Users,
+  CheckCircle2,
+  Sparkles,
+  Mic,
+  Music,
+  Sprout,
+  Hammer,
+} from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { trpc } from "@/lib/trpc";
+import { toast } from "sonner";
+
+const EVENT = {
+  date: "Saturday 20 June 2026",
+  time: "10am – 3pm",
+  address: "9 Gumland Drive, Witta QLD 4552",
+  shortAddress: "Witta · Sunshine Coast Hinterland",
+  acknowledgement: "Jinibara Country",
+};
+
+const fadeInUp = {
+  initial: { opacity: 0, y: 30 },
+  whileInView: { opacity: 1, y: 0 },
+  viewport: { once: true, margin: "-50px" },
+  transition: { duration: 0.6 },
+};
+
+const programItems = [
+  {
+    icon: Sprout,
+    title: "The Garden Walk",
+    body: "We'll walk the new beds together — what's in, what's coming, who's tending which row.",
+  },
+  {
+    icon: Hammer,
+    title: "Milk Create Pavilion open",
+    body: "First public day under the pavilion, built by 80 of you in March. Same crates, new shade.",
+  },
+  {
+    icon: Music,
+    title: "Long table lunch",
+    body: "Wood-fired, hinterland-grown, chef-led. Free. BYO seat or bring an empty one for a neighbour.",
+  },
+  {
+    icon: Mic,
+    title: "Kids' co-design",
+    body: "The children plan their own corner of The Harvest. Markers, chalk, whatever floats up.",
+  },
+  {
+    icon: Users,
+    title: "Open mic — what's missing in Witta?",
+    body: "A few minutes each, anyone who wants to speak. We listen and we write it down.",
+  },
+];
+
+export default function GardenLaunch() {
+  useEffect(() => {
+    document.title = "Garden Launch + Community Day · 20 June 2026 · The Harvest";
+    let meta = document.querySelector('meta[name="description"]') as HTMLMetaElement | null;
+    if (!meta) {
+      meta = document.createElement("meta");
+      meta.name = "description";
+      document.head.appendChild(meta);
+    }
+    meta.content = "Saturday 20 June 2026, 10am–3pm. Garden Launch and Community Day at The Harvest, Witta. Free. RSVP for a seat at the long table.";
+  }, []);
+
+  const countQuery = trpc.eoi.count.useQuery(undefined, {
+    refetchOnWindowFocus: false,
+  });
+  const count = countQuery.data?.count ?? 0;
+
+  return (
+    <div className="min-h-screen bg-stone-50">
+      {/* Hero */}
+      <section className="relative py-24 md:py-32 bg-stone-900 text-white overflow-hidden">
+        <div className="absolute inset-0 opacity-30">
+          <video
+            src="/images/compendium/hero-aerial.mp4"
+            autoPlay
+            muted
+            loop
+            playsInline
+            className="w-full h-full object-cover"
+          />
+        </div>
+        <div className="container relative">
+          <motion.div
+            initial={{ opacity: 0, y: 40 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8 }}
+            className="max-w-3xl mx-auto text-center"
+          >
+            <p className="font-mono text-amber-300 text-sm mb-4 uppercase tracking-[0.25em]">
+              Coming up · {EVENT.date}
+            </p>
+            <h1 className="text-5xl md:text-7xl font-serif font-bold leading-[0.95] mb-6">
+              Garden Launch<br />
+              <span className="text-amber-400">+ Community Day</span>
+            </h1>
+            <p className="text-xl md:text-2xl text-stone-200 italic font-serif leading-snug max-w-2xl mx-auto mb-10">
+              The first full day under the pavilion. The garden, finally open.
+              The neighbours, finally in the same room.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-8">
+              <a
+                href="#rsvp"
+                className="inline-flex items-center justify-center gap-2 px-8 py-3.5 rounded-full bg-amber-500 text-stone-900 font-semibold hover:bg-amber-400 transition-colors"
+              >
+                Save your spot
+                <ArrowRight className="h-4 w-4" />
+              </a>
+              <a
+                href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(EVENT.address)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 px-8 py-3.5 rounded-full border border-stone-500 text-stone-100 hover:bg-stone-800 transition-colors"
+              >
+                <MapPin className="h-4 w-4" />
+                Get directions
+              </a>
+            </div>
+            {count > 0 && (
+              <p className="text-stone-300 text-sm">
+                <span className="text-amber-400 font-semibold">{count}</span>{" "}
+                {count === 1 ? "neighbour has" : "neighbours have"} RSVP'd so far.
+              </p>
+            )}
+          </motion.div>
+        </div>
+      </section>
+
+      {/* Quick facts */}
+      <section className="py-12 md:py-16 bg-stone-100 border-b border-stone-200">
+        <div className="container">
+          <div className="max-w-4xl mx-auto grid sm:grid-cols-2 lg:grid-cols-4 gap-6 text-center">
+            <Fact icon={Calendar} label="Date" value={EVENT.date} />
+            <Fact icon={Clock} label="Time" value={EVENT.time} />
+            <Fact icon={MapPin} label="Place" value={EVENT.shortAddress} />
+            <Fact icon={Sparkles} label="Cost" value="Free" />
+          </div>
+          <p className="text-center text-stone-500 italic text-sm mt-8">
+            We acknowledge the Jinibara people as the Traditional Custodians of
+            this Country. The day begins with a Welcome.
+          </p>
+        </div>
+      </section>
+
+      {/* What it is */}
+      <section className="py-20 md:py-24">
+        <div className="container">
+          <div className="max-w-3xl mx-auto">
+            <motion.div {...fadeInUp}>
+              <p className="font-mono text-amber-700 text-sm mb-4 uppercase tracking-[0.2em]">
+                What it is
+              </p>
+              <h2 className="text-3xl md:text-5xl font-serif font-bold text-stone-800 mb-6 leading-tight">
+                A small village, on its own ground, for a day.
+              </h2>
+              <div className="space-y-5 text-lg text-stone-700 leading-relaxed">
+                <p>
+                  This is the first proper open day at The Harvest. The garden's
+                  beds are in. The Milk Create Pavilion is up. The kitchen will
+                  be feeding, the kids will be drawing, and the long table will
+                  stretch as far as it needs to.
+                </p>
+                <p>
+                  It's a launch, but really it's an invitation. We've spent two
+                  years listening. This day is the first answer — and the first
+                  question for the next year of the work.
+                </p>
+                <p className="font-serif italic text-stone-600">
+                  Come for an hour or stay all afternoon. Bring kids, bring a friend,
+                  bring an empty seat for someone you'd like to meet.
+                </p>
+              </div>
+            </motion.div>
+          </div>
+        </div>
+      </section>
+
+      {/* What to expect */}
+      <section className="py-20 md:py-24 bg-stone-100">
+        <div className="container">
+          <div className="max-w-5xl mx-auto">
+            <motion.div {...fadeInUp} className="mb-12 max-w-2xl">
+              <p className="font-mono text-amber-700 text-sm mb-3 uppercase tracking-[0.2em]">
+                What to expect
+              </p>
+              <h2 className="text-3xl md:text-4xl font-serif font-bold text-stone-800">
+                Soft schedule. Real food. No hurry.
+              </h2>
+            </motion.div>
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+              {programItems.map((item, i) => {
+                const Icon = item.icon;
+                return (
+                  <motion.div
+                    key={item.title}
+                    initial={{ opacity: 0, y: 16 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    viewport={{ once: true }}
+                    transition={{ duration: 0.4, delay: i * 0.06 }}
+                  >
+                    <Card className="h-full border-0 shadow-sm bg-white">
+                      <CardContent className="p-6">
+                        <div className="w-12 h-12 rounded-full bg-amber-100 flex items-center justify-center mb-4">
+                          <Icon className="h-6 w-6 text-amber-700" />
+                        </div>
+                        <h3 className="font-serif text-xl font-bold text-stone-800 mb-2">
+                          {item.title}
+                        </h3>
+                        <p className="text-stone-600 leading-relaxed">{item.body}</p>
+                      </CardContent>
+                    </Card>
+                  </motion.div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* RSVP */}
+      <RsvpSection eventLabel={EVENT.date} />
+
+      {/* Connect */}
+      <section className="py-16 md:py-20 bg-stone-50 border-t border-stone-200">
+        <div className="container">
+          <div className="max-w-3xl mx-auto text-center">
+            <p className="font-mono text-amber-700 text-sm mb-4 uppercase tracking-[0.2em]">
+              Stay close
+            </p>
+            <h2 className="text-2xl md:text-3xl font-serif font-bold text-stone-800 mb-4">
+              Hear about the day, and the next one.
+            </h2>
+            <p className="text-stone-600 mb-8 leading-relaxed">
+              The Harvest's quietest channel is the newsletter — one note before each
+              gathering, never more. Or follow along where the photos go.
+            </p>
+            <div className="flex flex-wrap gap-3 justify-center">
+              <a
+                href="https://www.instagram.com/the.harvest.witta/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full border border-stone-300 text-stone-700 hover:bg-stone-100 transition-colors"
+              >
+                Instagram
+              </a>
+              <a
+                href="https://www.facebook.com/theharvestwitta"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full border border-stone-300 text-stone-700 hover:bg-stone-100 transition-colors"
+              >
+                Facebook
+              </a>
+              <Link
+                href="/works"
+                className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full border border-stone-300 text-stone-700 hover:bg-stone-100 transition-colors"
+              >
+                See the collection
+              </Link>
+              <Link
+                href="/witta"
+                className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full border border-stone-300 text-stone-700 hover:bg-stone-100 transition-colors"
+              >
+                Witta history
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+/* ---------- helpers ---------- */
+
+function Fact({ icon: Icon, label, value }: { icon: typeof Calendar; label: string; value: string }) {
+  return (
+    <div>
+      <Icon className="h-5 w-5 text-amber-700 mx-auto mb-2" />
+      <p className="font-mono text-stone-400 text-[10px] uppercase tracking-[0.2em] mb-1">
+        {label}
+      </p>
+      <p className="text-stone-800 font-medium">{value}</p>
+    </div>
+  );
+}
+
+function RsvpSection({ eventLabel }: { eventLabel: string }) {
+  const submit = trpc.eoi.submit.useMutation();
+  const utils = trpc.useUtils();
+
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [excitement, setExcitement] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+
+  const canSubmit =
+    name.trim().length > 0 &&
+    (email.trim().length > 0 || phone.trim().length > 0) &&
+    !submit.isPending;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    try {
+      await submit.mutateAsync({
+        name: name.trim(),
+        email: email.trim() || null,
+        phone: phone.trim() || null,
+        excitement: excitement.trim() || undefined,
+        source: "Garden Launch page",
+      });
+      setSubmitted(true);
+      utils.eoi.count.invalidate();
+      toast.success("Saved your spot. See you on the 20th.");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Something went wrong";
+      toast.error("Couldn't save just now", { description: msg });
+    }
+  };
+
+  return (
+    <section id="rsvp" className="py-20 md:py-28 bg-stone-800 text-white scroll-mt-16">
+      <div className="container">
+        <div className="max-w-2xl mx-auto">
+          <motion.div {...fadeInUp} className="text-center mb-10">
+            <p className="font-mono text-amber-400 text-sm mb-3 uppercase tracking-[0.2em]">
+              RSVP — {eventLabel}
+            </p>
+            <h2 className="text-3xl md:text-5xl font-serif font-bold mb-4 leading-tight">
+              Save your spot at the long table.
+            </h2>
+            <p className="text-stone-300 leading-relaxed">
+              Free. Just so we know how much food to bring. Your name (and an
+              email or phone) is enough.
+            </p>
+          </motion.div>
+
+          <Card className="border-0 shadow-xl bg-stone-50 text-stone-800">
+            <CardContent className="p-6 md:p-8">
+              {submitted ? (
+                <motion.div
+                  initial={{ opacity: 0, scale: 0.95 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  className="text-center py-8"
+                >
+                  <CheckCircle2 className="h-12 w-12 text-amber-500 mx-auto mb-4" />
+                  <h3 className="text-2xl font-serif font-bold mb-2">
+                    You're in.
+                  </h3>
+                  <p className="text-stone-600 max-w-md mx-auto">
+                    We'll send a quick note in the week before with parking + the
+                    short program. See you on the 20th.
+                  </p>
+                </motion.div>
+              ) : (
+                <form onSubmit={handleSubmit} className="space-y-5">
+                  <div className="space-y-2">
+                    <Label htmlFor="rsvp-name">Your name *</Label>
+                    <Input
+                      id="rsvp-name"
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
+                      placeholder="First and last is great"
+                      required
+                      maxLength={255}
+                    />
+                  </div>
+                  <div className="grid sm:grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="rsvp-email">Email</Label>
+                      <div className="relative">
+                        <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-stone-400" />
+                        <Input
+                          id="rsvp-email"
+                          type="email"
+                          value={email}
+                          onChange={(e) => setEmail(e.target.value)}
+                          placeholder="you@example.com"
+                          className="pl-9"
+                        />
+                      </div>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="rsvp-phone">Phone</Label>
+                      <div className="relative">
+                        <Phone className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-stone-400" />
+                        <Input
+                          id="rsvp-phone"
+                          type="tel"
+                          value={phone}
+                          onChange={(e) => setPhone(e.target.value)}
+                          placeholder="04…"
+                          className="pl-9"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <p className="text-stone-500 text-xs -mt-3">
+                    Email or phone — we just need one way to send the reminder.
+                  </p>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="rsvp-excitement">
+                      What are you most curious about? (optional)
+                    </Label>
+                    <Textarea
+                      id="rsvp-excitement"
+                      value={excitement}
+                      onChange={(e) => setExcitement(e.target.value)}
+                      rows={3}
+                      placeholder="The garden, the pavilion, the food, the kids' bit, just being here…"
+                      maxLength={1000}
+                    />
+                  </div>
+
+                  <Button
+                    type="submit"
+                    disabled={!canSubmit}
+                    className="w-full bg-amber-500 hover:bg-amber-400 text-stone-900 font-semibold"
+                    size="lg"
+                  >
+                    {submit.isPending ? "Saving…" : "Save my spot"}
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </Button>
+                </form>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/pages/HarvestReviewTest.tsx
+++ b/client/src/pages/HarvestReviewTest.tsx
@@ -1,0 +1,1089 @@
+import { useEffect, useState, type FormEvent, type ReactNode } from "react";
+import { Link } from "wouter";
+import { motion } from "framer-motion";
+import {
+  ArrowRight,
+  BookOpen,
+  Calendar,
+  Check,
+  ClipboardList,
+  Hammer,
+  Mail,
+  Map,
+  MapPin,
+  Menu,
+  Milk,
+  Music,
+  Store,
+  Table2,
+  TreePine,
+  Users,
+  X,
+} from "lucide-react";
+import { toast } from "sonner";
+import { HarvestImage } from "@/components/HarvestImage";
+import { trpc } from "@/lib/trpc";
+
+type ReviewColumn = {
+  label: string;
+  title: string;
+  points: string[];
+};
+
+type Thread = {
+  title: string;
+  room: string;
+  image: string;
+  alt: string;
+  note: string;
+  body: string;
+  ideas: string[];
+  icon: typeof Hammer;
+  color: string;
+};
+
+type WorkUpdate = {
+  slot: string;
+  workSlug?: string;
+  status: string;
+  title: string;
+  room: string;
+  image: string;
+  alt: string;
+  body: string;
+  ask: string;
+};
+
+type IdeaGroup = {
+  title: string;
+  icon: typeof ClipboardList;
+  ideas: string[];
+};
+
+type EventDetail = {
+  label: string;
+  value: string;
+  detail: string;
+  icon: typeof Calendar;
+};
+
+type NewsletterInterest =
+  | "events"
+  | "workshops"
+  | "markets"
+  | "venue-hire"
+  | "garden-centre"
+  | "food-kitchen";
+
+const eventDetails: EventDetail[] = [
+  {
+    label: "date",
+    value: "Saturday 20 June 2026",
+    detail: "Community celebration day.",
+    icon: Calendar,
+  },
+  {
+    label: "time",
+    value: "10am to 3pm",
+    detail: "Soft program, music, food, walks and work notes.",
+    icon: Music,
+  },
+  {
+    label: "place",
+    value: "9 Gumland Drive, Witta",
+    detail: "The Harvest, on Jinibara Country.",
+    icon: MapPin,
+  },
+  {
+    label: "focus",
+    value: "Register below",
+    detail: "Put your name down for the day and the build notes.",
+    icon: Users,
+  },
+];
+
+const reviewColumns: ReviewColumn[] = [
+  {
+    label: "full idea",
+    title: "a garden, kitchen and art space, staged honestly",
+    points: [
+      "The full Harvest idea is still simple: Garden grows, Kitchen feeds, Art Space makes.",
+      "This round is the Garden: seedlings, beds, soil, shade and paths until July.",
+      "The first build pieces are the timber walkways and giant milk crate pavilion for events, music and gathering.",
+      "The longer build is kitchen, art, events and community space, but we should not make it sound ready yet.",
+    ],
+  },
+  {
+    label: "register for 20 June",
+    title: "put your name down for the community day",
+    points: [
+      "Saturday 20 June 2026, 10am to 3pm, at 9 Gumland Drive, Witta.",
+      "The day is a community celebration and working open day, not a polished venue reveal.",
+      "The garden is the focus until July. Kitchen, art, events and community space are part of the longer build.",
+      "Register below so we can send the useful details before the gate opens.",
+    ],
+  },
+  {
+    label: "longer term",
+    title: "a living collection place for Witta",
+    points: [
+      "Dairy shows up now through the milk crate pavilion, milk bar thinking and the district's food history.",
+      "Timber shows up now through the walkways, old material, Barry's shed, tools and Witta sawmill memory.",
+      "Co-op interest shows up now through a local produce shelf, shared tools and a shop people can help shape.",
+      "The newsletter will carry progress photos, works updates, event notes and short Witta stories as they are ready.",
+    ],
+  },
+];
+
+const threads: Thread[] = [
+  {
+    title: "timber",
+    room: "paths and art space",
+    image: "/images/compendium/barry/IMG_5745.jpg",
+    alt: "Barry beside old machinery at The Harvest",
+    note: "Story in progress: we are tracing the full St Mary's and Witta timber source trail.",
+    body: "The garden walkways are being built with timber taken from St Mary's Cathedral in Sydney. We are tracing the story that some of that timber began in the Witta region before it travelled south and came back as part of the new paths.",
+    ideas: [
+      "Walk the first path sections on 20 June.",
+      "See the timber as material, memory and a practical way through the garden.",
+      "Bring sawmill leads, timber hands, story leads, tools, or a memory from the ridge.",
+      "Follow the timber register as we name where each piece came from and where it lands.",
+    ],
+    icon: Hammer,
+    color: "#8B4A2A",
+  },
+  {
+    title: "dairy",
+    room: "pavilion and food",
+    image: "/images/witta/history/teutoburg-cheese-making-1899.png",
+    alt: "Historical cheese making at Teutoburg, Blackall Range, circa 1899",
+    note: "Historical image: Teutoburg cheese making, Blackall Range, circa 1899.",
+    body: "The milk crates are becoming more than storage. The first pavilion uses the crate as a working object: stacked, carried, borrowed, returned, and turned into shade for events, music, play, meals and gathering.",
+    ideas: [
+      "Stand under the first pavilion structure as it is being built.",
+      "Bring milk crates, dairy family photos, local memories, or a hand with the build.",
+      "Follow the milk bar and kitchen tests as the food side comes into view.",
+      "See how a dairy object becomes seating, shade, storage, wayfinding and story.",
+    ],
+    icon: Milk,
+    color: "#C4922A",
+  },
+  {
+    title: "co-operatives",
+    room: "shop and table",
+    image: "/images/compendium/team-garden-selfie.jpg",
+    alt: "People gathered in the garden at The Harvest",
+    note: "Co-op is a working interest here, not a legal claim yet.",
+    body: "The co-op interest starts with useful things: a local produce shelf, shared tools, open books, working bees, and a table people can actually sit at.",
+    ideas: [
+      "Tell us what you would put on the first shelf.",
+      "Bring growers, makers, cooks, gardeners, repairers and people who know how to run the plain systems.",
+      "Follow the path from garden produce to shop table to future kitchen.",
+      "Help shape the practical model before anyone gives it a formal name.",
+    ],
+    icon: Table2,
+    color: "#3B5563",
+  },
+];
+
+const workUpdates: WorkUpdate[] = [
+  {
+    slot: "garden-area",
+    workSlug: "the-garden",
+    status: "in progress",
+    title: "garden area until July",
+    room: "garden",
+    image: "/images/compendium/sophie-garden.jpg",
+    alt: "Sophie working in the garden at The Harvest",
+    body: "The whole site is moving, but the public work until July is the garden: beds, paths, play, pavilion, shade, produce, and weekly hands in the soil.",
+    ask: "Bring gloves, seedlings, mulch, tools, or two spare hours.",
+  },
+  {
+    slot: "milk-crate-pavilion",
+    workSlug: "milk-crate-pavilion",
+    status: "building",
+    title: "giant milk crate pavilion",
+    room: "garden pavilion",
+    image: "/images/sketches/milk-crate-pavilion-01.jpg",
+    alt: "Concept sketch for the milk crate pavilion",
+    body: "A large pavilion made from milk crates. A roof and frame for events, music, play, talks, shared meals, shade and the dairy story.",
+    ask: "Bring milk crates, scaffold leads, shade ideas, music, or a practical fix.",
+  },
+  {
+    slot: "timber-walkways",
+    workSlug: "the-cedar",
+    status: "story",
+    title: "St Mary's timber walkways",
+    room: "garden paths",
+    image: "/images/compendium/barry/IMG_5699.jpg",
+    alt: "Barry working in the shed",
+    body: "Walkways made from timber taken from St Mary's Cathedral in Sydney. We are tracing the Witta-origin story as part of the timber register.",
+    ask: "Bring source leads, timber hands, labels, tools, or a local sawmill memory.",
+  },
+  {
+    slot: "kids-playground",
+    workSlug: "the-garden",
+    status: "co-design",
+    title: "kids playground",
+    room: "garden",
+    image: "/images/site-plan/inspiration/log-climbing-frame.jpeg",
+    alt: "Log climbing frame reference for the kids playground",
+    body: "A play area shaped with local kids, not designed over their heads. The kids should help decide what belongs there and what it should feel like.",
+    ask: "Bring kids' ideas, logs, safe materials, shade, seating, or someone who can build with care.",
+  },
+  {
+    slot: "co-op-shop",
+    workSlug: "the-shop",
+    status: "shop test",
+    title: "co-op type shop",
+    room: "whole site",
+    image: "/images/local-produce.jpg",
+    alt: "Local produce gathered for a Harvest food story",
+    body: "A local produce shop idea: a place for nearby growers, makers, cooks, gardeners and neighbours to put real things on the first shelf.",
+    ask: "Bring produce ideas, shelf ideas, growers, makers, prices, and the plain systems that make it work.",
+  },
+  {
+    slot: "future-kitchen-food-loop",
+    workSlug: "the-shop",
+    status: "future loop",
+    title: "future kitchen food loop",
+    room: "future kitchen",
+    image: "/images/harvest-eat.jpg",
+    alt: "Harvest table and food setting",
+    body: "The hope is simple: the garden slowly grows into the food story for the future cafe and restaurant space inside.",
+    ask: "Bring kitchen growers, chefs, compost thinking, preserving ideas, and honest seasonal limits.",
+  },
+];
+
+const ideaGroups: IdeaGroup[] = [
+  {
+    title: "progress notes",
+    icon: Map,
+    ideas: [
+      "What changed in the garden this week.",
+      "What is ready to see on 20 June.",
+      "Which jobs need hands, materials or local knowledge.",
+      "Photos from the beds, paths, pavilion and shop table.",
+    ],
+  },
+  {
+    title: "timber coming home",
+    icon: Hammer,
+    ideas: [
+      "The St Mary's timber story as it is verified.",
+      "Where each walkway section lands in the garden.",
+      "Barry's shed, tools and local making memory.",
+      "Calls for timber hands, labels and source leads.",
+    ],
+  },
+  {
+    title: "dairy and crates",
+    icon: BookOpen,
+    ideas: [
+      "How the milk crate pavilion is being made.",
+      "Dairy family memories, photos and local food history.",
+      "Milk bar and kitchen tests as they begin.",
+      "Ways to lend crates, hands, shade ideas or music.",
+    ],
+  },
+  {
+    title: "20 June stories",
+    icon: Music,
+    ideas: [
+      "Who came through the gate.",
+      "What people noticed first.",
+      "What locals brought to the shelf or the build.",
+      "What the next working bee needs.",
+    ],
+  },
+  {
+    title: "co-op shop test",
+    icon: Store,
+    ideas: [
+      "What locals already grow, cook, make or repair.",
+      "What could go on the first shelf.",
+      "How prices, payments, stock and trust might work.",
+      "How the garden can support the shop over time.",
+    ],
+  },
+  {
+    title: "garden to table",
+    icon: TreePine,
+    ideas: [
+      "What is growing now.",
+      "What can realistically feed the future kitchen.",
+      "Compost, preserving, herbs, seedlings and seasonal limits.",
+      "The long path from garden bed to plate.",
+    ],
+  },
+  {
+    title: "kids and play",
+    icon: Users,
+    ideas: [
+      "Kids marking what they want to climb, hide in, build or change.",
+      "Safe materials, shade, seating and logs.",
+      "Parents and builders helping without taking over.",
+      "Updates on what the kids choose next.",
+    ],
+  },
+];
+
+const updateOptions: { id: NewsletterInterest; label: string; body: string }[] = [
+  {
+    id: "events",
+    label: "20 June event",
+    body: "registration notes, gate times and open day details",
+  },
+  {
+    id: "workshops",
+    label: "timber and making",
+    body: "walkways, tools, repair, art and events space work",
+  },
+  {
+    id: "food-kitchen",
+    label: "future kitchen",
+    body: "long table, milk bar tests, cafe and simple food",
+  },
+  {
+    id: "garden-centre",
+    label: "garden build",
+    body: "beds, planting, paths, seedlings and weekly work",
+  },
+  {
+    id: "markets",
+    label: "co-op shop",
+    body: "local produce, shared tools and shelf tests",
+  },
+];
+
+const pageNavLinks = [
+  { label: "20 June", href: "#review" },
+  { label: "This Stage", href: "#rooms" },
+  { label: "Stories", href: "#threads" },
+  { label: "Works", href: "#work" },
+  { label: "Updates", href: "#stories" },
+];
+
+const fadeInUp = {
+  initial: { opacity: 1, y: 0 },
+  whileInView: { opacity: 1, y: 0 },
+  viewport: { once: true, margin: "-70px" },
+  transition: { duration: 0.52 },
+};
+
+export default function HarvestReviewTest() {
+  useEffect(() => {
+    document.title = "The Harvest Witta - 20 June Community Day";
+    let meta = document.querySelector('meta[name="description"]') as HTMLMetaElement | null;
+    if (!meta) {
+      meta = document.createElement("meta");
+      meta.name = "description";
+      document.head.appendChild(meta);
+    }
+    meta.content =
+      "Register for The Harvest Witta community day on 20 June 2026 and follow the Garden, kitchen, art, events and community space as they grow, feed, make and gather local stories.";
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-[#F5F0E8] text-[#1C1917]">
+      <SiteNav />
+      <Hero />
+      <Review />
+      <Threads />
+      <WorkNotes />
+      <IdeaWall />
+      <UpdateForm />
+      <Closing />
+    </main>
+  );
+}
+
+function SiteNav() {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const closeMenu = () => setMenuOpen(false);
+
+  return (
+    <header className="fixed inset-x-0 top-0 z-50 border-b border-stone-900/10 bg-[#F5F0E8]/96 text-[#1C1917] shadow-[0_10px_30px_rgba(28,25,23,0.08)] backdrop-blur-md">
+      <div className="mx-auto flex min-h-[76px] max-w-7xl items-center justify-between gap-5 px-5 md:px-8">
+        <Link
+          href="/"
+          className="flex min-w-0 items-center gap-4"
+          onClick={closeMenu}
+          aria-label="The Harvest home"
+        >
+          <span className="flex h-12 w-12 shrink-0 overflow-hidden border border-stone-900/10 bg-[#F5F0E8]">
+            <img
+              src="/images/logo-mono-v1.png"
+              alt=""
+              className="h-full w-full object-cover object-[50%_33%]"
+            />
+          </span>
+          <span className="grid min-w-0">
+            <span className="truncate text-[22px] font-black leading-none tracking-normal text-[#1C1917]">
+              The Harvest Witta
+            </span>
+            <span className="mt-1 truncate text-xs font-semibold tracking-normal text-stone-600">
+              Garden first · Kitchen, art, events + community next
+            </span>
+          </span>
+        </Link>
+
+        <nav
+          className="hidden items-center gap-1 rounded-full border border-stone-900/10 bg-white/46 p-1 lg:flex"
+          aria-label="Page sections"
+        >
+          {pageNavLinks.map((link) => (
+            <a
+              key={link.href}
+              href={link.href}
+              className="rounded-full px-4 py-2 text-sm font-semibold text-stone-700 transition hover:bg-[#1C1917] hover:text-[#F5F0E8]"
+            >
+              {link.label}
+            </a>
+          ))}
+        </nav>
+
+        <div className="hidden items-center gap-3 lg:flex">
+          <Link
+            href="/works"
+            className="inline-flex min-h-11 items-center justify-center border border-stone-900/14 px-5 py-2 text-sm font-semibold text-[#1C1917] transition hover:border-[#1C1917] hover:bg-white/54"
+          >
+            All Works
+          </Link>
+          <a
+            href="#updates"
+            className="inline-flex min-h-11 items-center justify-center gap-2 bg-[#C4922A] px-5 py-2 text-sm font-bold text-[#1C1917] transition hover:bg-[#DEAD4A]"
+          >
+            Register
+            <Calendar className="h-4 w-4" />
+          </a>
+        </div>
+
+        <button
+          type="button"
+          className="inline-flex h-11 w-11 items-center justify-center border border-stone-900/16 text-[#1C1917] transition hover:bg-white/60 lg:hidden"
+          aria-label={menuOpen ? "Close menu" : "Open menu"}
+          aria-expanded={menuOpen}
+          onClick={() => setMenuOpen((open) => !open)}
+        >
+          {menuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+        </button>
+      </div>
+
+      {menuOpen && (
+        <div className="border-t border-stone-900/10 bg-[#F5F0E8] px-5 py-4 lg:hidden">
+          <nav className="mx-auto grid max-w-7xl gap-2" aria-label="Mobile page sections">
+            {pageNavLinks.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                onClick={closeMenu}
+                className="flex min-h-12 items-center border border-stone-900/10 bg-white/46 px-4 text-base font-semibold text-[#1C1917]"
+              >
+                {link.label}
+              </a>
+            ))}
+            <div className="grid gap-2 pt-2 sm:grid-cols-2">
+              <Link
+                href="/works"
+                onClick={closeMenu}
+                className="inline-flex min-h-12 items-center justify-center border border-stone-900/14 px-4 font-semibold text-[#1C1917]"
+              >
+                Open Works
+              </Link>
+              <a
+                href="#updates"
+                onClick={closeMenu}
+                className="inline-flex min-h-12 items-center justify-center gap-2 bg-[#C4922A] px-4 font-semibold text-[#1C1917]"
+              >
+                Register for 20 June
+                <Calendar className="h-4 w-4" />
+              </a>
+            </div>
+          </nav>
+        </div>
+      )}
+    </header>
+  );
+}
+
+function Hero() {
+  return (
+    <section id="top" className="relative min-h-[94vh] overflow-hidden bg-[#1C1917] text-[#F5F0E8]">
+      <img
+        src="/images/compendium/seed-house-front.jpg"
+        alt="The Harvest building in Witta"
+        className="absolute inset-0 h-full w-full object-cover opacity-[0.62]"
+      />
+      <div className="absolute inset-0 bg-[#1C1917]/68" />
+
+      <div className="relative z-10 mx-auto grid min-h-[94vh] max-w-7xl items-end gap-10 px-5 pb-12 pt-28 md:grid-cols-[1fr_0.72fr] md:px-8 md:pb-16">
+        <motion.div
+          initial={{ opacity: 0, y: 28 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.72 }}
+          className="max-w-4xl"
+        >
+          <p className="font-mono text-xs uppercase tracking-[0.24em] text-[#C4922A]">
+            Saturday 20 June 2026 / Witta / Jinibara Country
+          </p>
+          <h1 className="mt-5 max-w-4xl text-5xl font-black leading-[0.92] tracking-normal md:text-7xl lg:text-8xl">
+            The Garden is taking shape.
+          </h1>
+          <p className="mt-7 max-w-2xl text-xl leading-relaxed text-white/82">
+            The Harvest is a garden, kitchen and art space taking shape in Witta:
+            a place to grow, feed and make. This round is Garden-first: beds,
+            timber paths, the milk crate pavilion, kids playground and a co-op shop
+            test. The longer build is kitchen, art, events and community space.
+          </p>
+          <div className="mt-9 flex flex-col gap-3 sm:flex-row">
+            <a
+              href="#updates"
+              className="inline-flex min-h-12 items-center justify-center gap-2 bg-[#C4922A] px-6 py-3 font-semibold text-[#1C1917] transition hover:bg-[#DEAD4A]"
+            >
+              Register for 20 June
+              <Calendar className="h-4 w-4" />
+            </a>
+            <a
+              href="#work"
+              className="inline-flex min-h-12 items-center justify-center gap-2 border border-white/34 px-6 py-3 font-semibold text-white transition hover:border-white hover:bg-white/10"
+            >
+              See the works
+              <ArrowRight className="h-4 w-4" />
+            </a>
+          </div>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.72, delay: 0.12 }}
+          id="rooms"
+          className="scroll-mt-28 grid gap-3"
+        >
+          {[
+            ["Now", "Garden area", "seedlings, beds, soil and shade"],
+            ["Building", "Paths + pavilion", "timber walkways and the giant milk crate roof"],
+            ["Next", "Play + shop", "kids playground and co-op produce shelf"],
+          ].map(([tag, title, body]) => (
+            <div key={title} className="border border-white/18 bg-white/8 p-5 backdrop-blur">
+              <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-[#C4922A]">
+                {tag}
+              </p>
+              <h2 className="mt-2 text-2xl font-black">{title}</h2>
+              <p className="mt-2 text-sm leading-relaxed text-white/72">{body}</p>
+            </div>
+          ))}
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+
+function Review() {
+  return (
+    <section id="review" className="scroll-mt-24 bg-[#F5F0E8] py-16 md:py-24">
+      <div className="mx-auto max-w-7xl px-5 md:px-8">
+        <motion.div {...fadeInUp} className="mb-10 grid gap-6 md:grid-cols-[0.82fr_1fr] md:items-end">
+          <div>
+            <p className="font-mono text-xs uppercase tracking-[0.2em] text-[#8B4A2A]">
+              20 June community day
+            </p>
+            <h2 className="mt-3 max-w-2xl text-4xl font-black leading-[0.96] md:text-6xl">
+              Come through the gate and see what is being made.
+            </h2>
+          </div>
+          <p className="max-w-2xl text-lg leading-relaxed text-stone-700 md:justify-self-end">
+            The Harvest is opening the first version to the community on Saturday
+            20 June. You will be able to walk the Garden, see the works in progress,
+            and understand how the longer kitchen, art, events and community space is beginning to form.
+          </p>
+        </motion.div>
+
+        <div className="mb-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {eventDetails.map((detail) => {
+            const Icon = detail.icon;
+            return (
+              <motion.article
+                key={detail.label}
+                {...fadeInUp}
+                className="border border-stone-300/80 bg-[#FFFDF7] p-5"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#8B4A2A]">
+                    {detail.label}
+                  </p>
+                  <Icon className="h-5 w-5 text-[#4A6741]" />
+                </div>
+                <h3 className="mt-3 text-2xl font-black leading-tight">{detail.value}</h3>
+                <p className="mt-3 text-sm leading-relaxed text-stone-600">{detail.detail}</p>
+              </motion.article>
+            );
+          })}
+        </div>
+
+        <div className="grid gap-5 lg:grid-cols-3">
+          {reviewColumns.map((column) => (
+            <motion.article
+              key={column.title}
+              {...fadeInUp}
+              className="border border-stone-300/80 bg-[#FFFDF7] p-6"
+            >
+              <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-[#8B4A2A]">
+                {column.label}
+              </p>
+              <h3 className="mt-3 text-2xl font-black leading-tight">{column.title}</h3>
+              <ul className="mt-5 space-y-4 text-sm leading-relaxed text-stone-700">
+                {column.points.map((point) => (
+                  <li key={point} className="grid grid-cols-[auto_1fr] gap-3">
+                    <Check className="mt-0.5 h-4 w-4 text-[#4A6741]" />
+                    <span>{point}</span>
+                  </li>
+                ))}
+              </ul>
+            </motion.article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Threads() {
+  return (
+    <section id="threads" className="scroll-mt-24 bg-[#1C1917] py-16 text-[#F5F0E8] md:py-24">
+      <div className="mx-auto max-w-7xl px-5 md:px-8">
+        <motion.div {...fadeInUp} className="mb-10 max-w-3xl">
+          <p className="font-mono text-xs uppercase tracking-[0.2em] text-[#C4922A]">
+            local industry threads
+          </p>
+          <h2 className="mt-3 text-4xl font-black leading-[0.96] md:text-6xl">
+            Dairy, timber and co-op history are part of the experience.
+          </h2>
+          <p className="mt-5 max-w-2xl text-lg leading-relaxed text-white/70">
+            These are not themes sitting on a wall. They show up as crates, timber,
+            tools, produce, shop shelves, paths, meals and stories people can add to.
+          </p>
+        </motion.div>
+
+        <div className="grid gap-5 lg:grid-cols-3">
+          {threads.map((thread) => {
+            const Icon = thread.icon;
+            return (
+              <motion.article
+                key={thread.title}
+                {...fadeInUp}
+                className="overflow-hidden border border-white/14 bg-white/6"
+              >
+                <div className="aspect-[4/3] overflow-hidden bg-stone-800">
+                  <img
+                    src={thread.image}
+                    alt={thread.alt}
+                    className="h-full w-full object-cover"
+                  />
+                </div>
+                <div className="p-6">
+                  <div className="flex items-center justify-between gap-4">
+                    <span
+                      className="inline-flex h-10 w-10 items-center justify-center text-white"
+                      style={{ backgroundColor: thread.color }}
+                    >
+                      <Icon className="h-5 w-5" />
+                    </span>
+                    <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-white/48">
+                      {thread.room}
+                    </p>
+                  </div>
+                  <h3 className="mt-5 text-3xl font-black">{thread.title}</h3>
+                  <p className="mt-3 leading-relaxed text-white/74">{thread.body}</p>
+                  <ul className="mt-5 space-y-3 text-sm leading-relaxed text-white/68">
+                    {thread.ideas.map((idea) => (
+                      <li key={idea} className="border-t border-white/12 pt-3">
+                        {idea}
+                      </li>
+                    ))}
+                  </ul>
+                  <SourceNote>{thread.note}</SourceNote>
+                </div>
+              </motion.article>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function WorkNotes() {
+  return (
+    <section id="work" className="scroll-mt-24 bg-[#F5F0E8] py-16 md:py-24">
+      <div className="mx-auto max-w-7xl px-5 md:px-8">
+        <motion.div {...fadeInUp} className="mb-10 grid gap-6 md:grid-cols-[0.88fr_1fr] md:items-end">
+          <div>
+            <p className="font-mono text-xs uppercase tracking-[0.2em] text-[#8B4A2A]">
+              works in progress
+            </p>
+            <h2 className="mt-3 max-w-2xl text-4xl font-black leading-[0.96] md:text-6xl">
+              See the works, photos and updates as they move.
+            </h2>
+          </div>
+          <p className="max-w-2xl text-lg leading-relaxed text-stone-700 md:justify-self-end">
+            Until July, the garden area carries the public work. These are the first
+            works to follow: what is being made, what changed, and what help is useful now.
+          </p>
+        </motion.div>
+
+        <div className="grid gap-5 md:grid-cols-2">
+          {workUpdates.map((item) => (
+            <motion.article
+              key={item.title}
+              {...fadeInUp}
+              className="grid overflow-hidden border border-stone-300/80 bg-[#FFFDF7] md:grid-cols-[0.78fr_1fr]"
+            >
+              <HarvestImage
+                page="new-look-test"
+                slot={`${item.slot}-card`}
+                defaultWorkSlug={item.workSlug}
+                src={item.image}
+                alt={item.alt}
+                size="card"
+                className="min-h-[260px] bg-stone-200"
+                imgClassName="h-full w-full object-cover"
+              />
+              <div className="flex flex-col justify-between p-6">
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="bg-[#C4922A] px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.18em] text-[#1C1917]">
+                      {item.status}
+                    </span>
+                    <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-stone-500">
+                      {item.room}
+                    </span>
+                  </div>
+                  <h3 className="mt-4 text-3xl font-black leading-tight">{item.title}</h3>
+                  <p className="mt-4 leading-relaxed text-stone-700">{item.body}</p>
+                </div>
+                <p className="mt-6 border-t border-stone-200 pt-4 text-sm font-semibold leading-relaxed text-[#4A6741]">
+                  Ask: {item.ask}
+                </p>
+              </div>
+            </motion.article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function IdeaWall() {
+  return (
+    <section id="stories" className="scroll-mt-24 bg-[#B58B70] py-16 md:py-24">
+      <div className="mx-auto max-w-7xl px-5 md:px-8">
+        <motion.div {...fadeInUp} className="mb-10 max-w-3xl">
+          <p className="font-mono text-xs uppercase tracking-[0.2em] text-stone-950/64">
+            stories as we go
+          </p>
+          <h2 className="mt-3 text-4xl font-black leading-[0.96] text-stone-950 md:text-6xl">
+            The stories become a living collection for Witta.
+          </h2>
+          <p className="mt-5 max-w-2xl text-lg leading-relaxed text-stone-950/72">
+            The newsletter should not be noise. It should carry progress photos,
+            short notes, useful asks, and the local stories, objects and memories that
+            belong with the Garden, kitchen, art, events and community space.
+          </p>
+        </motion.div>
+
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {ideaGroups.map((group) => {
+            const Icon = group.icon;
+            return (
+              <motion.article
+                key={group.title}
+                {...fadeInUp}
+                className="border border-stone-950/20 bg-[#F5F0E8] p-6"
+              >
+                <div className="flex items-center justify-between">
+                  <h3 className="text-2xl font-black">{group.title}</h3>
+                  <Icon className="h-5 w-5 text-[#8B4A2A]" />
+                </div>
+                <ul className="mt-5 space-y-3 text-sm leading-relaxed text-stone-700">
+                  {group.ideas.map((idea) => (
+                    <li key={idea} className="border-t border-stone-300 pt-3">
+                      {idea}
+                    </li>
+                  ))}
+                </ul>
+              </motion.article>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function UpdateForm() {
+  const subscribe = trpc.newsletter.subscribe.useMutation();
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [selectedInterests, setSelectedInterests] = useState<NewsletterInterest[]>([
+    "events",
+    "food-kitchen",
+    "garden-centre",
+  ]);
+  const [submitted, setSubmitted] = useState(false);
+  const [submittedForEvent, setSubmittedForEvent] = useState(false);
+
+  const toggleInterest = (id: NewsletterInterest) => {
+    setSelectedInterests((current) =>
+      current.includes(id) ? current.filter((item) => item !== id) : [...current, id]
+    );
+  };
+
+  const eventSelected = selectedInterests.includes("events");
+  const followOptions = updateOptions.filter((option) => option.id !== "events");
+  const canSubmit = name.trim().length > 0 && email.trim().length > 0 && !subscribe.isPending;
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canSubmit) return;
+
+    const [firstName, ...rest] = name.trim().split(/\s+/);
+    const wantsEvent = selectedInterests.includes("events");
+
+    try {
+      await subscribe.mutateAsync({
+        email: email.trim(),
+        phone: phone.trim() || null,
+        firstName,
+        lastName: rest.join(" ") || undefined,
+        source: wantsEvent
+          ? "Harvest June 20 event registration"
+          : "Harvest public newsletter signup",
+        interests: selectedInterests,
+      });
+      setSubmittedForEvent(wantsEvent);
+      setSubmitted(true);
+      toast.success(wantsEvent ? "Registered for 20 June updates." : "Saved for Harvest updates.");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Please try again later.";
+      toast.error("Could not save this yet", { description: message });
+    }
+  };
+
+  return (
+    <section id="updates" className="scroll-mt-24 bg-[#3B5563] py-16 text-white md:py-24">
+      <div className="mx-auto grid max-w-7xl gap-10 px-5 md:grid-cols-[0.86fr_1.14fr] md:px-8">
+        <motion.div {...fadeInUp}>
+          <p className="font-mono text-xs uppercase tracking-[0.2em] text-[#C4922A]">
+            register and follow
+          </p>
+          <h2 className="mt-3 max-w-xl text-4xl font-black leading-[0.96] md:text-6xl">
+            Register for 20 June and get the build notes.
+          </h2>
+          <p className="mt-6 max-w-xl text-lg leading-relaxed text-white/76">
+            Put your name down for the community day. We will also send the useful
+            notes as this Garden round takes shape: pavilion, timber paths, kids
+            playground, co-op shop and the first hints of the long-table food loop.
+          </p>
+          <div className="mt-8 grid gap-3 text-sm leading-relaxed text-white/70">
+            <p className="border-l-2 border-[#C4922A] pl-4">
+              Event: Saturday 20 June 2026, 10am to 3pm.
+            </p>
+            <p className="border-l-2 border-[#C4922A] pl-4">
+              Place: 9 Gumland Drive, Witta, on Jinibara Country.
+            </p>
+            <p className="border-l-2 border-[#C4922A] pl-4">
+              Bring: hands, stories, produce, crates, timber, tools, or time.
+            </p>
+          </div>
+        </motion.div>
+
+        <motion.div {...fadeInUp} className="border border-white/16 bg-[#F5F0E8] p-5 text-[#1C1917] md:p-7">
+          {submitted ? (
+            <div className="flex min-h-[420px] flex-col justify-center text-center">
+              <Check className="mx-auto h-12 w-12 text-[#4A6741]" />
+              <h3 className="mt-5 text-3xl font-black">
+                {submittedForEvent ? "You are on the 20 June list." : "You are on the newsletter list."}
+              </h3>
+              <p className="mx-auto mt-3 max-w-md leading-relaxed text-stone-700">
+                We will send the useful notes: event details, beds, crates, timber,
+                playground, produce, stories and the next practical ask.
+              </p>
+              <button
+                type="button"
+                onClick={() => setSubmitted(false)}
+                className="mx-auto mt-8 inline-flex min-h-11 items-center justify-center gap-2 border border-stone-900/30 px-5 py-2.5 font-semibold text-stone-900 transition hover:bg-stone-900/[0.08]"
+              >
+                Add another person
+              </button>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-5">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <label className="grid gap-2 text-sm font-semibold">
+                  Name
+                  <input
+                    value={name}
+                    onChange={(event) => setName(event.target.value)}
+                    className="min-h-12 border border-stone-300 bg-white px-4 text-base outline-none focus:border-[#8B4A2A]"
+                    placeholder="First and last"
+                    required
+                    maxLength={120}
+                  />
+                </label>
+                <label className="grid gap-2 text-sm font-semibold">
+                  Email
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={(event) => setEmail(event.target.value)}
+                    className="min-h-12 border border-stone-300 bg-white px-4 text-base outline-none focus:border-[#8B4A2A]"
+                    placeholder="you@example.com"
+                    required
+                    maxLength={180}
+                  />
+                </label>
+              </div>
+
+              <label className="grid gap-2 text-sm font-semibold">
+                Phone, optional
+                <input
+                  type="tel"
+                  value={phone}
+                  onChange={(event) => setPhone(event.target.value)}
+                  className="min-h-12 border border-stone-300 bg-white px-4 text-base outline-none focus:border-[#8B4A2A]"
+                  placeholder="04..."
+                  maxLength={60}
+                />
+              </label>
+
+              <fieldset className="space-y-3">
+                <legend className="text-sm font-semibold">Register</legend>
+                <label
+                  className={`grid gap-2 border p-4 transition ${
+                    eventSelected
+                      ? "border-[#4A6741] bg-[#4A6741]/10"
+                      : "border-stone-300 bg-white"
+                  }`}
+                >
+                  <span className="flex items-center gap-3">
+                    <input
+                      type="checkbox"
+                      checked={eventSelected}
+                      onChange={() => toggleInterest("events")}
+                      className="h-4 w-4 accent-[#4A6741]"
+                    />
+                    <span className="font-semibold">Register my interest for 20 June</span>
+                  </span>
+                  <span className="text-sm leading-relaxed text-stone-600">
+                    Community celebration and working open day, Saturday 20 June, 10am to 3pm.
+                  </span>
+                </label>
+              </fieldset>
+
+              <fieldset className="space-y-3">
+                <legend className="text-sm font-semibold">Also send me updates about</legend>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {followOptions.map((option) => {
+                    const checked = selectedInterests.includes(option.id);
+                    return (
+                      <label
+                        key={option.id}
+                        className={`grid min-h-[112px] gap-2 border p-4 transition ${
+                          checked
+                            ? "border-[#4A6741] bg-[#4A6741]/10"
+                            : "border-stone-300 bg-white"
+                        }`}
+                      >
+                        <span className="flex items-center gap-3">
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={() => toggleInterest(option.id)}
+                            className="h-4 w-4 accent-[#4A6741]"
+                          />
+                          <span className="font-semibold">{option.label}</span>
+                        </span>
+                        <span className="text-sm leading-relaxed text-stone-600">
+                          {option.body}
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              </fieldset>
+
+              <button
+                type="submit"
+                disabled={!canSubmit}
+                className="inline-flex min-h-12 w-full items-center justify-center gap-2 bg-[#1C1917] px-6 py-3 font-semibold text-[#F5F0E8] transition hover:bg-[#3D3832] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {subscribe.isPending
+                  ? "Saving..."
+                  : eventSelected
+                    ? "Register and join the list"
+                    : "Join the newsletter"}
+                <Mail className="h-4 w-4" />
+              </button>
+            </form>
+          )}
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+
+function Closing() {
+  return (
+    <section className="relative overflow-hidden bg-[#1C1917] py-16 text-[#F5F0E8] md:py-24">
+      <img
+        src="/images/compendium/hero-aerial.jpg"
+        alt="Aerial view of The Harvest site in Witta"
+        className="absolute inset-0 h-full w-full object-cover opacity-[0.24]"
+      />
+      <div className="absolute inset-0 bg-[#1C1917]/72" />
+      <div className="relative mx-auto max-w-7xl px-5 md:px-8">
+        <motion.div {...fadeInUp} className="max-w-3xl">
+          <p className="font-mono text-xs uppercase tracking-[0.2em] text-[#C4922A]">
+            keep going
+          </p>
+          <h2 className="mt-3 text-4xl font-black leading-[0.96] md:text-6xl">
+            Follow the works as they become real.
+          </h2>
+          <p className="mt-6 max-w-2xl text-lg leading-relaxed text-white/78">
+            Start with the garden area, milk crate pavilion, timber walkways,
+            kids playground, co-op shop and garden-to-cafe food loop. Each work
+            will gather photos, updates, stories and one practical way to help.
+            Over time, that becomes part of a living Witta collection.
+          </p>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <Link
+              href="/works"
+              className="inline-flex min-h-12 items-center justify-center gap-2 bg-[#C4922A] px-6 py-3 font-semibold text-[#1C1917] transition hover:bg-[#DEAD4A]"
+            >
+              See the works
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+            <Link
+              href="#updates"
+              className="inline-flex min-h-12 items-center justify-center gap-2 border border-white/28 px-6 py-3 font-semibold text-white transition hover:border-white hover:bg-white/10"
+            >
+              Register for 20 June
+            </Link>
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+
+function SourceNote({ children }: { children: ReactNode }) {
+  return (
+    <p className="mt-4 font-mono text-[10px] uppercase tracking-[0.14em] text-white/42">
+      {children}
+    </p>
+  );
+}

--- a/client/src/pages/LaunchRedesign.tsx
+++ b/client/src/pages/LaunchRedesign.tsx
@@ -1,0 +1,493 @@
+import { useEffect } from "react";
+import { Link } from "wouter";
+import { motion } from "framer-motion";
+import {
+  ArrowRight,
+  Calendar,
+  Camera,
+  Hammer,
+  MapPin,
+  Sprout,
+  Users,
+} from "lucide-react";
+
+type Room = {
+  name: string;
+  verb: string;
+  body: string;
+  image: string;
+  alt: string;
+  icon: typeof Sprout;
+  accent: string;
+};
+
+type Proof = {
+  eyebrow: string;
+  title: string;
+  body: string;
+  image: string;
+  alt: string;
+  credit?: string;
+};
+
+type Ask = {
+  title: string;
+  body: string;
+};
+
+const rooms: Room[] = [
+  {
+    name: "Garden",
+    verb: "Grow",
+    body: "Beds, nursery life, working bees, kids, soil, and food in the ground.",
+    image: "/images/compendium/sophie-garden.jpg",
+    alt: "Sophie working in the garden at The Harvest",
+    icon: Sprout,
+    accent: "#4A6741",
+  },
+  {
+    name: "Kitchen",
+    verb: "Feed",
+    body: "A long table, simple food, milk bar thinking, pop-ups, and local producers.",
+    image: "/images/witta/history/teutoburg-cheese-making-1899.png",
+    alt: "Historical cheese making at Teutoburg, Blackall Range, circa 1899",
+    icon: Users,
+    accent: "#C4922A",
+  },
+  {
+    name: "Art Space",
+    verb: "Make",
+    body: "Tools, workshops, residencies, repair, timber, and walls that can change.",
+    image: "/images/compendium/barry/IMG_5745.jpg",
+    alt: "Barry at the workbench in the shed",
+    icon: Hammer,
+    accent: "#8B4A2A",
+  },
+];
+
+const proofItems: Proof[] = [
+  {
+    eyebrow: "Timber",
+    title: "The shed remembers work.",
+    body: "Barry's machinery, local timber, pit-sawn stories, and new hands in the room. The art space starts with tools, not decoration.",
+    image: "/images/compendium/barry/IMG_5699.jpg",
+    alt: "Inside Barry's shed at The Harvest",
+  },
+  {
+    eyebrow: "Dairy",
+    title: "The crates carry the dairy thread.",
+    body: "The milk crate pavilion takes a plain object from the dairy economy and turns it into the first shared roof.",
+    image: "/images/witta/history/teutoburg-cheese-making-1899.png",
+    alt: "Historical cheese making at Teutoburg, Blackall Range, circa 1899",
+    credit: "Queensland State Archives source image, citation to confirm before public use.",
+  },
+  {
+    eyebrow: "Co-operatives",
+    title: "The table comes before the structure.",
+    body: "Shared tools, open books, local help, and a practical question: what can this place hold if people build the first version together?",
+    image: "/images/compendium/team-garden-selfie.jpg",
+    alt: "A group at The Harvest garden",
+  },
+];
+
+const asks: Ask[] = [
+  {
+    title: "Hands",
+    body: "People who can help plant, carry, clean, build, cook, sort, paint, repair, or welcome.",
+  },
+  {
+    title: "Materials",
+    body: "Old timber, milk crates, tools, garden gear, tables, chairs, and useful things with a story.",
+  },
+  {
+    title: "Stories",
+    body: "Witta photos, dairy memories, timber stories, co-op records, and names we should know.",
+  },
+];
+
+const fadeInUp = {
+  initial: { opacity: 1, y: 0 },
+  whileInView: { opacity: 1, y: 0 },
+  viewport: { once: true, margin: "-80px" },
+  transition: { duration: 0.55 },
+};
+
+function SourceNote({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mt-3 max-w-xl font-mono text-[10px] uppercase tracking-[0.14em] text-stone-500">
+      {children}
+    </p>
+  );
+}
+
+export default function LaunchRedesign() {
+  useEffect(() => {
+    document.title = "The Harvest Witta · Launch Redesign Prototype";
+    let meta = document.querySelector('meta[name="description"]') as HTMLMetaElement | null;
+    if (!meta) {
+      meta = document.createElement("meta");
+      meta.name = "description";
+      document.head.appendChild(meta);
+    }
+    meta.content =
+      "A photo-led redesign prototype for The Harvest Witta, built around the real place, real people, and Witta history.";
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-[#F5F0E8] text-[#1C1917]">
+      <Hero />
+      <Rooms />
+      <WittaThread />
+      <WorksProof />
+      <LaunchAsk />
+      <Closing />
+    </main>
+  );
+}
+
+function Hero() {
+  return (
+    <section className="relative min-h-[92vh] overflow-hidden bg-stone-950 text-[#F5F0E8]">
+      <img
+        src="/images/compendium/hero-aerial.jpg"
+        alt="Aerial view of The Harvest site in Witta"
+        className="absolute inset-0 h-full w-full object-cover opacity-[0.58]"
+      />
+      <div className="absolute inset-0 bg-gradient-to-r from-stone-950/78 via-stone-950/44 to-stone-950/8" />
+      <div className="absolute inset-x-0 top-0 z-10 border-b border-white/12 bg-stone-950/28 backdrop-blur-sm">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-5 py-4 md:px-8">
+          <Link href="/" className="font-mono text-xs uppercase tracking-[0.22em] text-white/74">
+            The Harvest Witta
+          </Link>
+          <nav className="hidden items-center gap-6 font-mono text-[11px] uppercase tracking-[0.16em] text-white/66 md:flex">
+            <a href="#rooms" className="hover:text-white">
+              Rooms
+            </a>
+            <a href="#witta" className="hover:text-white">
+              Witta
+            </a>
+            <a href="#works" className="hover:text-white">
+              Works
+            </a>
+            <a href="#support" className="hover:text-white">
+              Support
+            </a>
+          </nav>
+        </div>
+      </div>
+
+      <div className="relative z-10 mx-auto flex min-h-[92vh] max-w-7xl items-end px-5 pb-14 pt-28 md:px-8 md:pb-16">
+        <motion.div
+          initial={{ opacity: 0, y: 28 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.75 }}
+          className="max-w-4xl"
+        >
+          <p className="mb-5 font-mono text-xs uppercase tracking-[0.24em] text-[#C4922A]">
+            Witta · Jinibara Country · Launch readiness 20 June 2026
+          </p>
+          <h1 className="max-w-4xl text-[clamp(3.4rem,8vw,7.6rem)] font-black leading-[0.9] tracking-normal">
+            Garden.
+            <br />
+            Kitchen.
+            <br />
+            Art Space.
+          </h1>
+          <p className="mt-7 max-w-2xl text-xl leading-relaxed text-white/84 md:text-2xl">
+            A working place for growing, feeding, making, and gathering in Witta.
+          </p>
+          <div className="mt-9 flex flex-col gap-3 sm:flex-row">
+            <a
+              href="#support"
+              className="inline-flex min-h-12 items-center justify-center gap-2 bg-[#C4922A] px-6 py-3 font-semibold text-stone-950 transition hover:bg-[#E0AD43]"
+            >
+              Help build the first version
+              <ArrowRight className="h-4 w-4" />
+            </a>
+            <a
+              href="#witta"
+              className="inline-flex min-h-12 items-center justify-center gap-2 border border-white/34 px-6 py-3 font-semibold text-white transition hover:border-white hover:bg-white/10"
+            >
+              Follow the Witta thread
+            </a>
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+
+function Rooms() {
+  return (
+    <section id="rooms" className="bg-[#F5F0E8] py-16 md:py-24">
+      <div className="mx-auto max-w-7xl px-5 md:px-8">
+        <motion.div {...fadeInUp} className="mb-10 grid gap-6 md:grid-cols-[0.82fr_1fr] md:items-end">
+          <div>
+            <p className="font-mono text-xs uppercase tracking-[0.2em] text-[#8B4A2A]">
+              The simple spine
+            </p>
+            <h2 className="mt-3 text-4xl font-black leading-[0.96] md:text-6xl">
+              Three rooms. One place.
+            </h2>
+          </div>
+          <p className="max-w-2xl text-lg leading-relaxed text-stone-700 md:justify-self-end">
+            The Harvest becomes legible when it stops trying to explain everything. Grow,
+            feed, make. The rest can gather around that.
+          </p>
+        </motion.div>
+
+        <div className="grid gap-5 md:grid-cols-3">
+          {rooms.map((room) => {
+            const Icon = room.icon;
+            return (
+              <motion.article
+                key={room.name}
+                {...fadeInUp}
+                className="group overflow-hidden border border-stone-300/70 bg-[#FFFDF7]"
+              >
+                <div className="aspect-[4/3] overflow-hidden bg-stone-200">
+                  <img
+                    src={room.image}
+                    alt={room.alt}
+                    className="h-full w-full object-cover transition duration-700 group-hover:scale-105"
+                  />
+                </div>
+                <div className="p-6">
+                  <div className="mb-5 flex items-center justify-between">
+                    <span
+                      className="inline-flex h-10 w-10 items-center justify-center rounded-full text-white"
+                      style={{ backgroundColor: room.accent }}
+                    >
+                      <Icon className="h-5 w-5" />
+                    </span>
+                    <span className="font-mono text-xs uppercase tracking-[0.18em] text-stone-500">
+                      {room.verb}
+                    </span>
+                  </div>
+                  <h3 className="text-3xl font-black">{room.name}</h3>
+                  <p className="mt-3 leading-relaxed text-stone-700">{room.body}</p>
+                </div>
+              </motion.article>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function WittaThread() {
+  return (
+    <section id="witta" className="bg-[#1C1917] py-16 text-[#F5F0E8] md:py-24">
+      <div className="mx-auto grid max-w-7xl gap-10 px-5 md:grid-cols-[1.05fr_0.95fr] md:px-8">
+        <motion.div {...fadeInUp}>
+          <p className="font-mono text-xs uppercase tracking-[0.2em] text-[#C4922A]">
+            Witta thread
+          </p>
+          <h2 className="mt-3 max-w-2xl text-4xl font-black leading-[0.96] md:text-6xl">
+            The launch story is timber, dairy, and co-operatives.
+          </h2>
+          <div className="mt-8 space-y-5 text-lg leading-relaxed text-stone-200">
+            <p>
+              The Harvest should not borrow history as wallpaper. It should put the
+              history to work.
+            </p>
+            <p>
+              Old timber becomes seats, rails, tables, and workbenches. Dairy crates
+              become a pavilion. Co-operative memory becomes a table people can sit at
+              before anyone pretends the structure is finished.
+            </p>
+          </div>
+          <div className="mt-9 grid gap-3 sm:grid-cols-3">
+            {["Timber", "Dairy", "Co-operatives"].map((word) => (
+              <div key={word} className="border border-white/18 p-4">
+                <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-white/54">
+                  Thread
+                </p>
+                <p className="mt-1 text-xl font-black">{word}</p>
+              </div>
+            ))}
+          </div>
+        </motion.div>
+
+        <motion.figure {...fadeInUp} className="self-start">
+          <div className="overflow-hidden border border-white/16 bg-white/5">
+            <img
+              src="/images/witta/history/teutoburg-farm-couple-corn-1899.png"
+              alt="Couple with tall corn at Manitzky's Farm, Teutoburg, circa 1899"
+              className="h-full max-h-[720px] w-full object-cover"
+            />
+          </div>
+          <SourceNote>
+            Historical source: Queensland State Archives image 2383, citation to confirm
+            before public release.
+          </SourceNote>
+        </motion.figure>
+      </div>
+    </section>
+  );
+}
+
+function WorksProof() {
+  return (
+    <section id="works" className="bg-[#F5F0E8] py-16 md:py-24">
+      <div className="mx-auto max-w-7xl px-5 md:px-8">
+        <motion.div {...fadeInUp} className="mb-10 max-w-3xl">
+          <p className="font-mono text-xs uppercase tracking-[0.2em] text-[#8B4A2A]">
+            Proof before polish
+          </p>
+          <h2 className="mt-3 text-4xl font-black leading-[0.96] md:text-6xl">
+            The website should show work already happening.
+          </h2>
+        </motion.div>
+
+        <div className="grid gap-5 lg:grid-cols-3">
+          {proofItems.map((item) => (
+            <motion.article
+              key={item.title}
+              {...fadeInUp}
+              className="overflow-hidden border border-stone-300/70 bg-[#FFFDF7]"
+            >
+              <div className="aspect-[5/4] overflow-hidden bg-stone-200">
+                <img
+                  src={item.image}
+                  alt={item.alt}
+                  className="h-full w-full object-cover"
+                />
+              </div>
+              <div className="p-6">
+                <p className="font-mono text-xs uppercase tracking-[0.18em] text-[#8B4A2A]">
+                  {item.eyebrow}
+                </p>
+                <h3 className="mt-3 text-2xl font-black leading-tight">{item.title}</h3>
+                <p className="mt-4 leading-relaxed text-stone-700">{item.body}</p>
+                {item.credit && <SourceNote>{item.credit}</SourceNote>}
+              </div>
+            </motion.article>
+          ))}
+        </div>
+
+        <motion.div {...fadeInUp} className="mt-8 grid gap-5 lg:grid-cols-[0.9fr_1.1fr]">
+          <figure className="border border-stone-300/70 bg-white p-4">
+            <img
+              src="/images/compendium/MASTER FLOOR PLAN.png"
+              alt="Master floor plan for The Harvest"
+              className="max-h-[520px] w-full object-contain"
+            />
+            <SourceNote>Floor plan source: Harvest design material, credit to confirm.</SourceNote>
+          </figure>
+          <div className="flex flex-col justify-between border border-stone-300/70 bg-[#3B5563] p-7 text-white md:p-10">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.2em] text-[#F5F0E8]/68">
+                First screen
+              </p>
+              <h3 className="mt-4 max-w-xl text-3xl font-black leading-tight md:text-5xl">
+                Show the place before asking people to believe in it.
+              </h3>
+            </div>
+            <ul className="mt-8 grid gap-3 text-lg text-white/84">
+              <li>Garden, Kitchen, Art Space visible in the first scroll.</li>
+              <li>Real photos before abstract claims.</li>
+              <li>One practical ask in every major section.</li>
+            </ul>
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+
+function LaunchAsk() {
+  return (
+    <section id="support" className="bg-[#B58B70] py-16 md:py-24">
+      <div className="mx-auto max-w-7xl px-5 md:px-8">
+        <div className="grid gap-10 lg:grid-cols-[0.85fr_1.15fr] lg:items-start">
+          <motion.div {...fadeInUp}>
+            <p className="font-mono text-xs uppercase tracking-[0.2em] text-stone-950/64">
+              The ask
+            </p>
+            <h2 className="mt-3 text-4xl font-black leading-[0.96] text-stone-950 md:text-6xl">
+              Help build what opens first.
+            </h2>
+            <p className="mt-6 text-lg leading-relaxed text-stone-950/78">
+              By 20 June, the site, deck, and social story need to say the same thing:
+              come see what is taking shape, and bring something useful if you can.
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <a
+                href="mailto:hello@theharvestwitta.com.au?subject=I can help The Harvest"
+                className="inline-flex min-h-12 items-center justify-center gap-2 bg-stone-950 px-6 py-3 font-semibold text-[#F5F0E8] transition hover:bg-stone-800"
+              >
+                Say what you can bring
+                <ArrowRight className="h-4 w-4" />
+              </a>
+              <Link
+                href="/garden-launch"
+                className="inline-flex min-h-12 items-center justify-center gap-2 border border-stone-950/36 px-6 py-3 font-semibold text-stone-950 transition hover:bg-stone-950/8"
+              >
+                See the launch page
+              </Link>
+            </div>
+          </motion.div>
+
+          <div className="grid gap-4 md:grid-cols-3">
+            {asks.map((ask) => (
+              <motion.article
+                key={ask.title}
+                {...fadeInUp}
+                className="min-h-[260px] border border-stone-950/20 bg-[#F5F0E8] p-6"
+              >
+                <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-stone-500">
+                  Useful
+                </p>
+                <h3 className="mt-3 text-3xl font-black text-stone-950">{ask.title}</h3>
+                <p className="mt-4 leading-relaxed text-stone-700">{ask.body}</p>
+              </motion.article>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Closing() {
+  return (
+    <section className="relative overflow-hidden bg-stone-950 py-16 text-white md:py-24">
+      <img
+        src="/images/compendium/team-garden-selfie.jpg"
+        alt="People gathered in the garden at The Harvest"
+        className="absolute inset-0 h-full w-full object-cover opacity-28"
+      />
+      <div className="absolute inset-0 bg-stone-950/62" />
+      <div className="relative mx-auto max-w-7xl px-5 md:px-8">
+        <motion.div {...fadeInUp} className="max-w-3xl">
+          <p className="font-mono text-xs uppercase tracking-[0.2em] text-[#C4922A]">
+            Next screen
+          </p>
+          <h2 className="mt-3 text-4xl font-black leading-[0.96] md:text-6xl">
+            Come see what is taking shape.
+          </h2>
+          <p className="mt-6 max-w-2xl text-lg leading-relaxed text-white/78">
+            The first version opens with what is already here: garden beds, old timber,
+            milk crates, a shed, a table, and neighbours who want to help shape it.
+          </p>
+          <div className="mt-8 grid gap-3 font-mono text-xs uppercase tracking-[0.16em] text-white/64 sm:grid-cols-3">
+            <p className="inline-flex items-center gap-2">
+              <Calendar className="h-4 w-4 text-[#C4922A]" />
+              20 June 2026
+            </p>
+            <p className="inline-flex items-center gap-2">
+              <MapPin className="h-4 w-4 text-[#C4922A]" />
+              9 Gumland Drive
+            </p>
+            <p className="inline-flex items-center gap-2">
+              <Camera className="h-4 w-4 text-[#C4922A]" />
+              Real photos only
+            </p>
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/pages/People.tsx
+++ b/client/src/pages/People.tsx
@@ -14,6 +14,14 @@ export default function People() {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-stone-50 to-white">
+      <nav className="absolute top-0 left-0 right-0 z-10 px-6 py-4">
+        <Link href="/">
+          <a className="inline-flex items-center gap-2 text-sm font-mono uppercase tracking-wider text-stone-700 hover:text-amber-700">
+            ← The Harvest
+          </a>
+        </Link>
+      </nav>
+
       <section className="pt-32 pb-12 bg-gradient-to-b from-amber-50 to-stone-50">
         <div className="container">
           <motion.div

--- a/client/src/pages/People.tsx
+++ b/client/src/pages/People.tsx
@@ -105,7 +105,10 @@ export default function People() {
                           {s.publishedStoryCount > 0 && (
                             <span>· {s.publishedStoryCount} {s.publishedStoryCount === 1 ? "story" : "stories"}</span>
                           )}
-                          {s.publishedArticleCount === 0 && s.publishedStoryCount === 0 && (
+                          {s.transcriptCount > 0 && (
+                            <span>· {s.transcriptCount} {s.transcriptCount === 1 ? "recording" : "recordings"}</span>
+                          )}
+                          {s.publishedArticleCount === 0 && s.publishedStoryCount === 0 && s.transcriptCount === 0 && (
                             <span className="text-stone-400">Profile only — content coming</span>
                           )}
                         </div>

--- a/client/src/pages/People.tsx
+++ b/client/src/pages/People.tsx
@@ -1,0 +1,116 @@
+import { motion } from "framer-motion";
+import { Link } from "wouter";
+import { trpc } from "@/lib/trpc";
+import { ArrowRight, Users } from "lucide-react";
+
+const fadeInUp = {
+  initial: { opacity: 0, y: 20 },
+  animate: { opacity: 1, y: 0 },
+  transition: { duration: 0.5 },
+};
+
+export default function People() {
+  const { data: storytellers, isLoading } = trpc.harvest.publicStorytellers.useQuery();
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-stone-50 to-white">
+      <section className="pt-32 pb-12 bg-gradient-to-b from-amber-50 to-stone-50">
+        <div className="container">
+          <motion.div
+            {...fadeInUp}
+            className="max-w-3xl mx-auto text-center"
+          >
+            <span className="inline-flex items-center gap-2 px-4 py-2 bg-amber-100 text-amber-800 rounded-full text-sm font-medium mb-6">
+              <Users className="h-4 w-4" />
+              The people of The Harvest
+            </span>
+            <h1 className="text-4xl md:text-5xl font-serif font-bold text-stone-800 mb-6">
+              Who is on the land
+            </h1>
+            <p className="text-lg text-stone-600 leading-relaxed">
+              Storytellers, growers, makers — the people whose hands and voices shape The Harvest.
+            </p>
+          </motion.div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-stone-50">
+        <div className="container">
+          {isLoading ? (
+            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 max-w-5xl mx-auto">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="h-64 animate-pulse rounded-lg border border-stone-200 bg-white" />
+              ))}
+            </div>
+          ) : !storytellers || storytellers.length === 0 ? (
+            <p className="text-center text-stone-600">No storytellers yet — check back soon.</p>
+          ) : (
+            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 max-w-5xl mx-auto">
+              {storytellers.map((s, i) => (
+                <motion.article
+                  key={s.id}
+                  initial={{ opacity: 0, y: 20 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true }}
+                  transition={{ duration: 0.4, delay: i * 0.08 }}
+                >
+                  <Link href={`/people/${s.slug}`}>
+                    <a className="group block h-full overflow-hidden rounded-lg border border-stone-200 bg-white p-6 transition hover:border-amber-300 hover:shadow-md">
+                      <div className="flex items-start gap-4">
+                        {s.avatarUrl ? (
+                          <img
+                            src={s.avatarUrl}
+                            alt={s.displayName}
+                            className="h-16 w-16 flex-shrink-0 rounded-full border border-stone-200 object-cover"
+                          />
+                        ) : (
+                          <div className="flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-full border border-stone-200 bg-amber-50 text-2xl font-serif font-bold text-amber-700">
+                            {s.displayName.slice(0, 1).toUpperCase()}
+                          </div>
+                        )}
+                        <div className="min-w-0">
+                          <h2 className="text-xl font-serif font-bold text-stone-800 group-hover:text-amber-700">
+                            {s.displayName}
+                          </h2>
+                          <p className="mt-1 text-xs text-stone-500">
+                            {s.location ?? "The Harvest"}
+                            {s.projectRole && (
+                              <span className="ml-2 inline-flex items-center rounded-full bg-stone-100 px-2 py-0.5 text-[10px] font-semibold text-stone-700">
+                                {s.projectRole}
+                              </span>
+                            )}
+                          </p>
+                        </div>
+                      </div>
+
+                      {s.bio && (
+                        <p className="mt-4 line-clamp-4 text-sm leading-relaxed text-stone-600">
+                          {s.bio}
+                        </p>
+                      )}
+
+                      <div className="mt-5 flex items-center justify-between border-t border-stone-100 pt-4">
+                        <div className="flex flex-wrap gap-2 text-xs text-stone-500">
+                          {s.publishedArticleCount > 0 && (
+                            <span>{s.publishedArticleCount} {s.publishedArticleCount === 1 ? "article" : "articles"}</span>
+                          )}
+                          {s.publishedStoryCount > 0 && (
+                            <span>· {s.publishedStoryCount} {s.publishedStoryCount === 1 ? "story" : "stories"}</span>
+                          )}
+                          {s.publishedArticleCount === 0 && s.publishedStoryCount === 0 && (
+                            <span className="text-stone-400">Profile only — content coming</span>
+                          )}
+                        </div>
+                        <ArrowRight className="h-4 w-4 text-stone-400 transition group-hover:translate-x-1 group-hover:text-amber-600" />
+                      </div>
+                    </a>
+                  </Link>
+                </motion.article>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/client/src/pages/Person.tsx
+++ b/client/src/pages/Person.tsx
@@ -112,6 +112,28 @@ export default function Person({ slug }: { slug: string }) {
         </section>
       )}
 
+      {s.localPhotos.length > 0 && (
+        <section className="py-12 bg-stone-100">
+          <div className="container mx-auto max-w-5xl">
+            <h2 className="mb-6 inline-flex items-center gap-2 text-2xl font-serif font-bold text-stone-800">
+              <ImageIcon className="h-5 w-5 text-amber-700" /> Moments with {s.displayName.split(" ")[0]}
+            </h2>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+              {s.localPhotos.map((p) => (
+                <figure key={p.src} className="overflow-hidden rounded-lg bg-stone-200 aspect-square">
+                  <img
+                    src={p.src}
+                    alt={p.alt}
+                    loading="lazy"
+                    className="h-full w-full object-cover transition hover:scale-105"
+                  />
+                </figure>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
       {s.articles.length > 0 && (
         <section className="py-12 bg-stone-50">
           <div className="container mx-auto max-w-3xl">
@@ -210,7 +232,7 @@ export default function Person({ slug }: { slug: string }) {
         </section>
       )}
 
-      {s.articles.length === 0 && s.stories.length === 0 && s.transcripts.length === 0 && (
+      {s.articles.length === 0 && s.stories.length === 0 && s.transcripts.length === 0 && s.localPhotos.length === 0 && (
         <section className="py-12 bg-stone-50">
           <div className="container mx-auto max-w-3xl text-center text-stone-600">
             <ImageIcon className="mx-auto h-8 w-8 text-stone-400" />

--- a/client/src/pages/Person.tsx
+++ b/client/src/pages/Person.tsx
@@ -1,0 +1,197 @@
+import { motion } from "framer-motion";
+import { Link } from "wouter";
+import { trpc } from "@/lib/trpc";
+import { ArrowLeft, ArrowRight, MapPin, Newspaper, BookOpen, Image as ImageIcon } from "lucide-react";
+
+const fadeInUp = {
+  initial: { opacity: 0, y: 20 },
+  animate: { opacity: 1, y: 0 },
+  transition: { duration: 0.5 },
+};
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-AU", { day: "numeric", month: "long", year: "numeric" });
+}
+
+export default function Person({ slug }: { slug: string }) {
+  const { data, isLoading, error } = trpc.harvest.publicStorytellerBySlug.useQuery(
+    { slug },
+    { enabled: !!slug },
+  );
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-stone-50 pt-32">
+        <div className="container mx-auto max-w-3xl">
+          <div className="h-64 animate-pulse rounded-lg border border-stone-200 bg-white" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="min-h-screen bg-stone-50 pt-32 pb-16">
+        <div className="container mx-auto max-w-3xl text-center">
+          <h1 className="text-3xl font-serif font-bold text-stone-800">No one here by that name.</h1>
+          <p className="mt-4 text-stone-600">This storyteller might not be on The Harvest project (yet).</p>
+          <Link href="/people">
+            <a className="mt-6 inline-flex items-center gap-2 text-amber-700 hover:text-amber-800">
+              <ArrowLeft className="h-4 w-4" /> Back to all people
+            </a>
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const s = data;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-stone-50 to-white">
+      <section className="pt-32 pb-12 bg-gradient-to-b from-amber-50 to-stone-50">
+        <div className="container">
+          <Link href="/people">
+            <a className="mb-6 inline-flex items-center gap-2 text-sm text-stone-600 hover:text-amber-700">
+              <ArrowLeft className="h-4 w-4" /> All people
+            </a>
+          </Link>
+
+          <motion.div {...fadeInUp} className="max-w-3xl">
+            <div className="flex flex-col gap-6 sm:flex-row sm:items-start">
+              {s.avatarUrl ? (
+                <img
+                  src={s.avatarUrl}
+                  alt={s.displayName}
+                  className="h-32 w-32 flex-shrink-0 rounded-full border-2 border-stone-200 object-cover shadow-md"
+                />
+              ) : (
+                <div className="flex h-32 w-32 flex-shrink-0 items-center justify-center rounded-full border-2 border-stone-200 bg-amber-100 text-5xl font-serif font-bold text-amber-700 shadow-md">
+                  {s.displayName.slice(0, 1).toUpperCase()}
+                </div>
+              )}
+              <div className="min-w-0">
+                <h1 className="text-4xl md:text-5xl font-serif font-bold text-stone-800">
+                  {s.displayName}
+                </h1>
+                <div className="mt-3 flex flex-wrap items-center gap-3 text-sm text-stone-600">
+                  {s.location && (
+                    <span className="inline-flex items-center gap-1.5">
+                      <MapPin className="h-4 w-4" /> {s.location}
+                    </span>
+                  )}
+                  {s.projectRole && (
+                    <span className="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-800">
+                      {s.projectRole} on The Harvest
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          </motion.div>
+        </div>
+      </section>
+
+      {s.bio && (
+        <section className="py-12 bg-white">
+          <div className="container mx-auto max-w-3xl">
+            <p className="whitespace-pre-line text-lg leading-relaxed text-stone-700">
+              {s.bio}
+            </p>
+          </div>
+        </section>
+      )}
+
+      {s.articles.length > 0 && (
+        <section className="py-12 bg-stone-50">
+          <div className="container mx-auto max-w-3xl">
+            <h2 className="mb-6 inline-flex items-center gap-2 text-2xl font-serif font-bold text-stone-800">
+              <Newspaper className="h-5 w-5 text-amber-700" /> Articles by {s.displayName.split(" ")[0]}
+            </h2>
+            <div className="grid gap-4">
+              {s.articles.map((a) => (
+                <Link key={a.id} href={a.slug ? `/blog/${a.slug}` : "#"}>
+                  <a className="group block rounded-lg border border-stone-200 bg-white p-5 transition hover:border-amber-300 hover:shadow-md">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <h3 className="text-lg font-serif font-bold text-stone-800 group-hover:text-amber-700">
+                          {a.title}
+                        </h3>
+                        {a.publishedAt && (
+                          <p className="mt-1 text-xs text-stone-500">{formatDate(a.publishedAt)}</p>
+                        )}
+                        {a.excerpt && (
+                          <p className="mt-3 line-clamp-3 text-sm leading-relaxed text-stone-600">{a.excerpt}</p>
+                        )}
+                        {a.themes.length > 0 && (
+                          <div className="mt-3 flex flex-wrap gap-1.5">
+                            {a.themes.slice(0, 4).map((t) => (
+                              <span key={t} className="inline-flex items-center rounded-full bg-stone-100 px-2 py-0.5 text-[10px] font-medium text-stone-700">
+                                {t}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                      <ArrowRight className="h-4 w-4 flex-shrink-0 text-stone-400 transition group-hover:translate-x-1 group-hover:text-amber-600" />
+                    </div>
+                  </a>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {s.stories.length > 0 && (
+        <section className="py-12 bg-white">
+          <div className="container mx-auto max-w-3xl">
+            <h2 className="mb-6 inline-flex items-center gap-2 text-2xl font-serif font-bold text-stone-800">
+              <BookOpen className="h-5 w-5 text-amber-700" /> Stories
+            </h2>
+            <div className="grid gap-4">
+              {s.stories.map((st) => (
+                <article key={st.id} className="rounded-lg border border-stone-200 bg-stone-50 p-5">
+                  <h3 className="text-lg font-serif font-bold text-stone-800">{st.title}</h3>
+                  {st.summary && (
+                    <p className="mt-2 text-sm leading-relaxed text-stone-600">{st.summary}</p>
+                  )}
+                  {st.themes && st.themes.length > 0 && (
+                    <div className="mt-3 flex flex-wrap gap-1.5">
+                      {st.themes.slice(0, 4).map((t) => (
+                        <span key={t} className="inline-flex items-center rounded-full bg-stone-100 px-2 py-0.5 text-[10px] font-medium text-stone-700">
+                          {t}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {s.articles.length === 0 && s.stories.length === 0 && (
+        <section className="py-12 bg-stone-50">
+          <div className="container mx-auto max-w-3xl text-center text-stone-600">
+            <ImageIcon className="mx-auto h-8 w-8 text-stone-400" />
+            <p className="mt-3 text-sm">No published content yet — check back soon.</p>
+          </div>
+        </section>
+      )}
+
+      <section className="py-12 bg-white border-t border-stone-200">
+        <div className="container mx-auto max-w-3xl text-center">
+          <Link href="/people">
+            <a className="inline-flex items-center gap-2 text-amber-700 hover:text-amber-800">
+              <ArrowLeft className="h-4 w-4" /> Back to all people
+            </a>
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/client/src/pages/Person.tsx
+++ b/client/src/pages/Person.tsx
@@ -194,21 +194,28 @@ export default function Person({ slug }: { slug: string }) {
             </h2>
             <div className="grid gap-4">
               {s.stories.map((st) => (
-                <article key={st.id} className="rounded-lg border border-stone-200 bg-stone-50 p-5">
-                  <h3 className="text-lg font-serif font-bold text-stone-800">{st.title}</h3>
-                  {st.summary && (
-                    <p className="mt-2 text-sm leading-relaxed text-stone-600">{st.summary}</p>
-                  )}
-                  {st.themes && st.themes.length > 0 && (
-                    <div className="mt-3 flex flex-wrap gap-1.5">
-                      {st.themes.slice(0, 4).map((t) => (
-                        <span key={t} className="inline-flex items-center rounded-full bg-stone-100 px-2 py-0.5 text-[10px] font-medium text-stone-700">
-                          {t}
-                        </span>
-                      ))}
+                <Link key={st.id} href={`/stories/${st.id}`}>
+                  <a className="group block rounded-lg border border-stone-200 bg-stone-50 p-5 transition hover:border-amber-300 hover:shadow-md">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <h3 className="text-lg font-serif font-bold text-stone-800 group-hover:text-amber-700">{st.title}</h3>
+                        {st.summary && (
+                          <p className="mt-2 line-clamp-3 text-sm leading-relaxed text-stone-600">{st.summary}</p>
+                        )}
+                        {st.themes && st.themes.length > 0 && (
+                          <div className="mt-3 flex flex-wrap gap-1.5">
+                            {st.themes.slice(0, 4).map((t) => (
+                              <span key={t} className="inline-flex items-center rounded-full bg-stone-100 px-2 py-0.5 text-[10px] font-medium text-stone-700">
+                                {t}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                      <ArrowRight className="h-4 w-4 flex-shrink-0 text-stone-400 transition group-hover:translate-x-1 group-hover:text-amber-600" />
                     </div>
-                  )}
-                </article>
+                  </a>
+                </Link>
               ))}
             </div>
           </div>

--- a/client/src/pages/Person.tsx
+++ b/client/src/pages/Person.tsx
@@ -51,6 +51,14 @@ export default function Person({ slug }: { slug: string }) {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-stone-50 to-white">
+      <nav className="absolute top-0 left-0 right-0 z-10 px-6 py-4">
+        <Link href="/">
+          <a className="inline-flex items-center gap-2 text-sm font-mono uppercase tracking-wider text-stone-700 hover:text-amber-700">
+            ← The Harvest
+          </a>
+        </Link>
+      </nav>
+
       <section className="pt-32 pb-12 bg-gradient-to-b from-amber-50 to-stone-50">
         <div className="container">
           <Link href="/people">

--- a/client/src/pages/Person.tsx
+++ b/client/src/pages/Person.tsx
@@ -1,7 +1,8 @@
 import { motion } from "framer-motion";
 import { Link } from "wouter";
 import { trpc } from "@/lib/trpc";
-import { ArrowLeft, ArrowRight, MapPin, Newspaper, BookOpen, Image as ImageIcon, Mic } from "lucide-react";
+import { ArrowLeft, ArrowRight, MapPin, Newspaper, BookOpen, Image as ImageIcon, Mic, Hammer } from "lucide-react";
+import { works } from "@/data/works";
 
 const fadeInUp = {
   initial: { opacity: 0, y: 20 },
@@ -48,6 +49,16 @@ export default function Person({ slug }: { slug: string }) {
   }
 
   const s = data;
+  const firstName = s.displayName.toLowerCase().split(/\s+/)[0] ?? "";
+  const fullLower = s.displayName.toLowerCase();
+  const connectedWorks = works.filter((w) =>
+    w.hands.some((h) => {
+      const hn = h.name.toLowerCase();
+      if (hn === fullLower) return true;
+      if (firstName.length >= 3 && hn.split(/\s+/).includes(firstName)) return true;
+      return false;
+    }),
+  );
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-stone-50 to-white">
@@ -232,7 +243,43 @@ export default function Person({ slug }: { slug: string }) {
         </section>
       )}
 
-      {s.articles.length === 0 && s.stories.length === 0 && s.transcripts.length === 0 && s.localPhotos.length === 0 && (
+      {connectedWorks.length > 0 && (
+        <section className="py-12 bg-white">
+          <div className="container mx-auto max-w-3xl">
+            <h2 className="mb-6 inline-flex items-center gap-2 text-2xl font-serif font-bold text-stone-800">
+              <Hammer className="h-5 w-5 text-amber-700" /> Works {firstName.charAt(0).toUpperCase() + firstName.slice(1)} has hands in
+            </h2>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {connectedWorks.map((w) => {
+                const role = w.hands.find((h) => {
+                  const hn = h.name.toLowerCase();
+                  return hn === fullLower || (firstName.length >= 3 && hn.split(/\s+/).includes(firstName));
+                })?.role;
+                return (
+                  <Link key={w.slug} href={`/works/${w.slug}`}>
+                    <a className="group block rounded-lg border border-stone-200 bg-stone-50 p-5 transition hover:border-amber-300 hover:shadow-md">
+                      <h3 className="font-serif font-bold text-stone-800 group-hover:text-amber-700">{w.title}</h3>
+                      {w.subtitle && (
+                        <p className="mt-1 text-sm text-stone-500">{w.subtitle}</p>
+                      )}
+                      {role && (
+                        <p className="mt-3 text-xs text-stone-600">
+                          <span className="font-semibold text-stone-700">{firstName.charAt(0).toUpperCase() + firstName.slice(1)}'s role:</span> {role}
+                        </p>
+                      )}
+                      <p className="mt-3 inline-flex items-center gap-1 text-xs font-semibold text-amber-700">
+                        See the work <ArrowRight className="h-3 w-3" />
+                      </p>
+                    </a>
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {s.articles.length === 0 && s.stories.length === 0 && s.transcripts.length === 0 && s.localPhotos.length === 0 && connectedWorks.length === 0 && (
         <section className="py-12 bg-stone-50">
           <div className="container mx-auto max-w-3xl text-center text-stone-600">
             <ImageIcon className="mx-auto h-8 w-8 text-stone-400" />

--- a/client/src/pages/Person.tsx
+++ b/client/src/pages/Person.tsx
@@ -1,7 +1,7 @@
 import { motion } from "framer-motion";
 import { Link } from "wouter";
 import { trpc } from "@/lib/trpc";
-import { ArrowLeft, ArrowRight, MapPin, Newspaper, BookOpen, Image as ImageIcon } from "lucide-react";
+import { ArrowLeft, ArrowRight, MapPin, Newspaper, BookOpen, Image as ImageIcon, Mic } from "lucide-react";
 
 const fadeInUp = {
   initial: { opacity: 0, y: 20 },
@@ -182,7 +182,35 @@ export default function Person({ slug }: { slug: string }) {
         </section>
       )}
 
-      {s.articles.length === 0 && s.stories.length === 0 && (
+      {s.transcripts.length > 0 && (
+        <section className="py-12 bg-stone-50">
+          <div className="container mx-auto max-w-3xl">
+            <h2 className="mb-2 inline-flex items-center gap-2 text-2xl font-serif font-bold text-stone-800">
+              <Mic className="h-5 w-5 text-amber-700" /> Conversations & recordings
+            </h2>
+            <p className="mb-6 text-sm text-stone-600">
+              Transcripts of recorded sessions. Full text is held in the Harvest archive — reach out if you'd like access.
+            </p>
+            <div className="grid gap-3">
+              {s.transcripts.map((t) => {
+                const mins = t.durationSeconds ? Math.round(t.durationSeconds / 60) : null;
+                return (
+                  <article key={t.id} className="rounded-lg border border-stone-200 bg-white p-4">
+                    <h3 className="font-serif font-bold text-stone-800">{t.title}</h3>
+                    <p className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-stone-500">
+                      {t.recordingDate && <span>Recorded {formatDate(t.recordingDate)}</span>}
+                      {t.wordCount && <span>{t.wordCount.toLocaleString()} words</span>}
+                      {mins && <span>{mins} min</span>}
+                    </p>
+                  </article>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {s.articles.length === 0 && s.stories.length === 0 && s.transcripts.length === 0 && (
         <section className="py-12 bg-stone-50">
           <div className="container mx-auto max-w-3xl text-center text-stone-600">
             <ImageIcon className="mx-auto h-8 w-8 text-stone-400" />

--- a/client/src/pages/StoryDetail.tsx
+++ b/client/src/pages/StoryDetail.tsx
@@ -1,0 +1,178 @@
+import { motion } from "framer-motion";
+import { Link } from "wouter";
+import { trpc } from "@/lib/trpc";
+import { ArrowLeft, ArrowRight, BookOpen, Calendar, Clock } from "lucide-react";
+
+const fadeInUp = {
+  initial: { opacity: 0, y: 20 },
+  animate: { opacity: 1, y: 0 },
+  transition: { duration: 0.5 },
+};
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-AU", { day: "numeric", month: "long", year: "numeric" });
+}
+
+function readingMinutes(words: number | null): number {
+  if (!words) return 1;
+  return Math.max(1, Math.ceil(words / 200));
+}
+
+export default function StoryDetail({ storyId }: { storyId: string }) {
+  const { data, isLoading, error } = trpc.harvest.publicStoryById.useQuery(
+    { storyId },
+    { enabled: !!storyId },
+  );
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-stone-50 pt-32">
+        <div className="container mx-auto max-w-3xl">
+          <div className="h-64 animate-pulse rounded-lg border border-stone-200 bg-white" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="min-h-screen bg-stone-50 pt-32 pb-16">
+        <div className="container mx-auto max-w-3xl text-center">
+          <h1 className="text-3xl font-serif font-bold text-stone-800">No story here.</h1>
+          <p className="mt-4 text-stone-600">
+            This story might be a draft, or it might not be on The Harvest project.
+          </p>
+          <Link href="/people">
+            <a className="mt-6 inline-flex items-center gap-2 text-amber-700 hover:text-amber-800">
+              <ArrowLeft className="h-4 w-4" /> Back to people
+            </a>
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const story = data;
+  const minutes = readingMinutes(story.wordCount);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-stone-50 to-white">
+      <nav className="absolute top-0 left-0 right-0 z-10 px-6 py-4">
+        <Link href="/">
+          <a className="inline-flex items-center gap-2 text-sm font-mono uppercase tracking-wider text-stone-700 hover:text-amber-700">
+            ← The Harvest
+          </a>
+        </Link>
+      </nav>
+
+      <section className="pt-32 pb-12 bg-gradient-to-b from-amber-50 to-stone-50">
+        <div className="container mx-auto max-w-3xl">
+          <Link href={story.author?.slug ? `/people/${story.author.slug}` : "/people"}>
+            <a className="mb-6 inline-flex items-center gap-2 text-sm text-stone-600 hover:text-amber-700">
+              <ArrowLeft className="h-4 w-4" />
+              {story.author?.slug ? `${story.author.displayName}'s profile` : "All people"}
+            </a>
+          </Link>
+
+          <motion.div {...fadeInUp}>
+            <div className="mb-3 inline-flex items-center gap-2 rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800">
+              <BookOpen className="h-3.5 w-3.5" /> Story from The Harvest
+            </div>
+            <h1 className="text-4xl md:text-5xl font-serif font-bold text-stone-800 leading-tight">
+              {story.title}
+            </h1>
+
+            {story.summary && (
+              <p className="mt-4 text-lg text-stone-600 leading-relaxed">{story.summary}</p>
+            )}
+
+            <div className="mt-6 flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-stone-500">
+              {story.author && (
+                <span>
+                  by{" "}
+                  {story.author.slug ? (
+                    <Link href={`/people/${story.author.slug}`}>
+                      <a className="text-amber-700 underline-offset-2 hover:underline">
+                        {story.author.displayName}
+                      </a>
+                    </Link>
+                  ) : (
+                    <span>{story.author.displayName}</span>
+                  )}
+                </span>
+              )}
+              {story.createdAt && (
+                <span className="inline-flex items-center gap-1.5">
+                  <Calendar className="h-3.5 w-3.5" /> {formatDate(story.createdAt)}
+                </span>
+              )}
+              <span className="inline-flex items-center gap-1.5">
+                <Clock className="h-3.5 w-3.5" /> {minutes} min read
+              </span>
+            </div>
+
+            {story.themes.length > 0 && (
+              <div className="mt-4 flex flex-wrap gap-1.5">
+                {story.themes.slice(0, 6).map((t) => (
+                  <span key={t} className="inline-flex items-center rounded-full bg-stone-100 px-2.5 py-0.5 text-[11px] font-medium text-stone-700">
+                    {t}
+                  </span>
+                ))}
+              </div>
+            )}
+          </motion.div>
+        </div>
+      </section>
+
+      <section className="py-12 bg-white">
+        <article className="container mx-auto max-w-3xl">
+          <div className="prose prose-stone max-w-none whitespace-pre-line text-base leading-relaxed text-stone-700 md:text-lg">
+            {story.content}
+          </div>
+        </article>
+      </section>
+
+      {story.author?.slug && (
+        <section className="py-12 bg-stone-50">
+          <div className="container mx-auto max-w-3xl">
+            <Link href={`/people/${story.author.slug}`}>
+              <a className="group flex items-start gap-4 rounded-lg border border-stone-200 bg-white p-5 transition hover:border-amber-300 hover:shadow-md">
+                {story.author.avatarUrl ? (
+                  <img
+                    src={story.author.avatarUrl}
+                    alt={story.author.displayName}
+                    className="h-16 w-16 flex-shrink-0 rounded-full border border-stone-200 object-cover"
+                  />
+                ) : (
+                  <div className="flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-full bg-amber-100">
+                    <span className="text-2xl font-serif font-bold text-amber-700">
+                      {story.author.displayName.charAt(0)}
+                    </span>
+                  </div>
+                )}
+                <div className="min-w-0">
+                  <p className="font-semibold text-stone-800 group-hover:text-amber-700">{story.author.displayName}</p>
+                  <p className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-amber-700">
+                    More from {story.author.displayName.split(" ")[0]} <ArrowRight className="h-3 w-3" />
+                  </p>
+                </div>
+              </a>
+            </Link>
+          </div>
+        </section>
+      )}
+
+      <section className="py-12 bg-white border-t border-stone-200">
+        <div className="container mx-auto max-w-3xl text-center">
+          <Link href="/people">
+            <a className="inline-flex items-center gap-2 text-amber-700 hover:text-amber-800">
+              <ArrowLeft className="h-4 w-4" /> All people of The Harvest
+            </a>
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/client/src/pages/WorkDetail.tsx
+++ b/client/src/pages/WorkDetail.tsx
@@ -1,0 +1,1230 @@
+import { useEffect, useState } from "react";
+import { Link } from "wouter";
+import { motion } from "framer-motion";
+import { ArrowLeft, ArrowRight, ExternalLink, Camera } from "lucide-react";
+import { worksBySlug, works, LIFECYCLE_VOCAB, sortLifecycleTags, type LifecycleTag } from "@/data/works";
+import { trpc } from "@/lib/trpc";
+import { HarvestImage } from "@/components/HarvestImage";
+import { EditableText } from "@/components/EditableText";
+import { useAuth } from "@/_core/hooks/useAuth";
+import { elLinks } from "@/lib/empathyLedger";
+import { optimize } from "@/lib/imageOptimize";
+
+const fadeInUp = {
+  initial: { opacity: 0, y: 30 },
+  whileInView: { opacity: 1, y: 0 },
+  viewport: { once: true, margin: "-50px" },
+  transition: { duration: 0.6 },
+};
+
+
+export default function WorkDetail({ slug }: { slug: string }) {
+  const work = worksBySlug[slug];
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
+  const { data: storytellers } = trpc.harvest.publicStorytellers.useQuery(undefined, { staleTime: 5 * 60_000 });
+
+  // Map a hand name to a /people/:slug link when it matches a curated Harvest storyteller.
+  const storytellerForName = (name: string): { slug: string; displayName: string } | null => {
+    if (!storytellers || storytellers.length === 0) return null;
+    const lower = name.toLowerCase();
+    // Prefer full-name match, fall back to first-name match.
+    const full = storytellers.find((s) => s.displayName.toLowerCase() === lower);
+    if (full) return { slug: full.slug, displayName: full.displayName };
+    return storytellers.find((s) => {
+      const first = s.displayName.toLowerCase().split(/\s+/)[0];
+      return first.length >= 3 && lower.split(/\s+/).includes(first);
+    }) ?? null;
+  };
+
+  useEffect(() => {
+    if (!work) {
+      document.title = "Work not found · The Harvest";
+      return;
+    }
+    document.title = `${work.title} · The Collection · The Harvest`;
+    let meta = document.querySelector('meta[name="description"]') as HTMLMetaElement | null;
+    if (!meta) {
+      meta = document.createElement("meta");
+      meta.name = "description";
+      document.head.appendChild(meta);
+    }
+    meta.content = work.blurb;
+  }, [work]);
+
+  if (!work) {
+    return (
+      <div className="min-h-screen bg-stone-50 flex items-center justify-center px-6">
+        <div className="text-center max-w-md">
+          <p className="font-mono text-stone-400 uppercase tracking-wider text-xs mb-3">
+            Work not in the collection
+          </p>
+          <h1 className="text-3xl font-serif text-stone-800 mb-6">
+            We couldn't find that piece.
+          </h1>
+          <Link
+            href="/works"
+            className="inline-flex items-center gap-2 text-amber-700 underline underline-offset-4 decoration-amber-500 decoration-2"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to the collection
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // Effective lifecycle tags: admin override (DB) wins, else default from works.ts
+  const lifecycleSlot = `${work.slug}-lifecycleTags`;
+  const lifecycleQuery = trpc.content.get.useQuery({ page: "works", slot: lifecycleSlot });
+  const savedTags = (() => {
+    if (!lifecycleQuery.data?.content) return null;
+    try {
+      const parsed = JSON.parse(lifecycleQuery.data.content);
+      return Array.isArray(parsed) ? (parsed as LifecycleTag[]) : null;
+    } catch {
+      return null;
+    }
+  })();
+  const activeTags: LifecycleTag[] = savedTags ?? work.lifecycleTags;
+  const lifecycleTags = sortLifecycleTags(activeTags);
+  const index = works.findIndex((w) => w.slug === work.slug);
+  const number = String(index + 1).padStart(2, "0");
+  const next = works[(index + 1) % works.length];
+
+  return (
+    <div className="min-h-screen bg-stone-50">
+      {/* Top bar — return to collection */}
+      <div className="container pt-8">
+        <Link
+          href="/works"
+          className="inline-flex items-center gap-2 text-stone-600 hover:text-stone-900 text-sm font-mono uppercase tracking-wider"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          The Collection
+        </Link>
+      </div>
+
+      {/* Admin hint + quick-links — only when logged in as admin */}
+      {isAdmin && <AdminQuickBar work={work} />}
+
+      {/* Header */}
+      <section className="pt-12 pb-16 md:pt-16 md:pb-20">
+        <div className="container">
+          <div className="max-w-4xl mx-auto">
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6 }}
+              className="grid md:grid-cols-[auto_1fr] gap-x-8 gap-y-3"
+            >
+              <p className="font-mono text-stone-400 text-2xl tabular-nums">{number}</p>
+              <div>
+                <div className="flex flex-wrap gap-1.5 mb-5">
+                  {lifecycleTags.map((tag) => {
+                    const meta = LIFECYCLE_VOCAB[tag];
+                    return (
+                      <span
+                        key={tag}
+                        className={`inline-flex items-center px-2.5 py-1 text-[11px] font-medium uppercase tracking-wider rounded-full ${meta.badgeClass}`}
+                      >
+                        {meta.label}
+                      </span>
+                    );
+                  })}
+                </div>
+                {isAdmin && (
+                  <LifecycleEditor
+                    workSlug={work.slug}
+                    activeTags={activeTags}
+                  />
+                )}
+                <EditableText
+                  page="works"
+                  slot={`${work.slug}-title`}
+                  defaultContent={work.title}
+                  as="h1"
+                  className="text-4xl md:text-6xl font-serif font-bold text-stone-800 leading-[1.05] mb-4"
+                />
+                <EditableText
+                  page="works"
+                  slot={`${work.slug}-subtitle`}
+                  defaultContent={work.subtitle}
+                  as="p"
+                  className="text-xl md:text-2xl text-stone-600 italic leading-snug"
+                  multiline
+                />
+              </div>
+            </motion.div>
+          </div>
+        </div>
+      </section>
+
+      {/* Hero image — pulls from EL when available, falls back to bundled image */}
+      <WorkHero work={work} />
+
+      {/* Pulse — admin-editable status update for what's happening with this work right now */}
+      <WorkPulseSection work={work} isAdmin={isAdmin} />
+
+      {/* Video — admin pastes a YouTube/Vimeo/MP4 URL; hidden when blank for visitors */}
+      <WorkVideoSection work={work} isAdmin={isAdmin} />
+
+      {/* Museum label */}
+      <section className="py-16 md:py-20">
+        <div className="container">
+          <div className="max-w-4xl mx-auto">
+            <motion.div
+              {...fadeInUp}
+              className="grid sm:grid-cols-2 md:grid-cols-3 gap-8 border-t border-b border-stone-200 py-8"
+            >
+              <div>
+                <p className="font-mono text-stone-400 uppercase tracking-wider text-[11px] mb-2">Year</p>
+                <p className="text-stone-800 font-medium">{work.year}</p>
+              </div>
+              <div>
+                <p className="font-mono text-stone-400 uppercase tracking-wider text-[11px] mb-2">Materials</p>
+                <p className="text-stone-800">{work.materials}</p>
+              </div>
+              <div>
+                <p className="font-mono text-stone-400 uppercase tracking-wider text-[11px] mb-2">Lifecycle</p>
+                <p className="text-stone-800">
+                  {lifecycleTags.map((t) => LIFECYCLE_VOCAB[t].label).join(" · ")}
+                </p>
+              </div>
+            </motion.div>
+          </div>
+        </div>
+      </section>
+
+      {/* What it is */}
+      <Section label="What it is" body={work.whatItIs} slot={`${work.slug}-whatItIs`} />
+
+      {/* Inline feature image — slot 1 (after "What it is") */}
+      <InlineFeatureImage work={work} slotKey="feature-1" caption="What it looks like up close." />
+
+      {/* Why */}
+      <Section label="Why" body={work.why} slot={`${work.slug}-why`} tone="dark" />
+
+      {/* How */}
+      <Section label="How" body={work.how} slot={`${work.slug}-how`} />
+
+      {/* Inline feature image — slot 2 (after "How") */}
+      <InlineFeatureImage work={work} slotKey="feature-2" caption="In the making." />
+
+      {/* Witta thread */}
+      <section className="py-20 md:py-28 bg-stone-100">
+        <div className="container">
+          <div className="max-w-4xl mx-auto">
+            <motion.div {...fadeInUp} className="mb-12">
+              <p className="font-mono text-amber-700 text-sm mb-3 uppercase tracking-[0.2em]">
+                The Witta Thread
+              </p>
+              <h2 className="text-3xl md:text-4xl font-serif font-bold text-stone-800">
+                Why it ties back to this place.
+              </h2>
+              <p className="mt-4 text-stone-600 leading-relaxed text-lg">
+                Every work in the collection is anchored to specific moments in
+                Witta's long story. Here are the threads this one pulls on.
+              </p>
+            </motion.div>
+
+            <div className="space-y-8">
+              {work.wittaThreads.map((t, i) => (
+                <motion.div
+                  key={i}
+                  initial={{ opacity: 0, x: -16 }}
+                  whileInView={{ opacity: 1, x: 0 }}
+                  viewport={{ once: true }}
+                  transition={{ duration: 0.5, delay: i * 0.08 }}
+                  className="grid md:grid-cols-[140px_1fr] gap-x-8 gap-y-3 border-l-2 border-amber-500/40 pl-6"
+                >
+                  <p className="font-mono text-stone-800 font-semibold tracking-wider">
+                    {t.year}
+                  </p>
+                  <div>
+                    <p className="text-stone-700 leading-relaxed mb-2">
+                      <span className="text-stone-500">{t.moment}</span>
+                    </p>
+                    <p className="text-stone-800 leading-relaxed">{t.thread}</p>
+                  </div>
+                </motion.div>
+              ))}
+            </div>
+
+            <div className="mt-10">
+              <Link
+                href="/witta"
+                className="inline-flex items-center gap-2 text-amber-700 hover:text-amber-800 underline underline-offset-4 decoration-amber-500 decoration-2"
+              >
+                Read the full Witta history
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Two-up spread — slots 3 and 4 (between Witta thread and Hands) */}
+      <InlineSpreadImages work={work} />
+
+      {/* Photographs from Empathy Ledger */}
+      <WorkPhotographsSection slug={work.slug} />
+
+      {/* The Hands */}
+      <section className="py-20 md:py-24">
+        <div className="container">
+          <div className="max-w-4xl mx-auto">
+            <motion.div {...fadeInUp} className="mb-10">
+              <p className="font-mono text-stone-400 text-sm mb-3 uppercase tracking-[0.2em]">
+                The Hands
+              </p>
+              <h2 className="text-3xl md:text-4xl font-serif font-bold text-stone-800">
+                Who made it possible.
+              </h2>
+            </motion.div>
+            <ul className="divide-y divide-stone-200 border-t border-b border-stone-200">
+              {work.hands.map((h, i) => {
+                const linked = storytellerForName(h.name);
+                return (
+                  <motion.li
+                    key={i}
+                    initial={{ opacity: 0, y: 10 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    viewport={{ once: true }}
+                    transition={{ duration: 0.4, delay: i * 0.05 }}
+                    className="grid sm:grid-cols-[1fr_2fr] gap-2 py-4"
+                  >
+                    <p className="text-stone-800 font-medium">
+                      {linked ? (
+                        <Link href={`/people/${linked.slug}`}>
+                          <a className="underline-offset-2 hover:text-amber-700 hover:underline">{h.name}</a>
+                        </Link>
+                      ) : (
+                        h.name
+                      )}
+                    </p>
+                    <p className="text-stone-600">{h.role}</p>
+                  </motion.li>
+                );
+              })}
+            </ul>
+
+            {work.link && (
+              <div className="mt-8">
+                <a
+                  href={work.link.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 text-amber-700 hover:text-amber-800 underline underline-offset-4 decoration-amber-500 decoration-2"
+                >
+                  {work.link.label}
+                  <ExternalLink className="h-4 w-4" />
+                </a>
+              </div>
+            )}
+
+            <div className="mt-6">
+              <Link href="/people">
+                <a className="inline-flex items-center gap-2 text-sm font-semibold text-stone-600 hover:text-amber-700">
+                  Meet the people of The Harvest <ArrowRight className="h-4 w-4" />
+                </a>
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Journal — full article library for this work, with Past/Now/Coming filter */}
+      <WorkJournalSection slug={work.slug} workTitle={work.title} />
+
+      {/* Related works */}
+      {work.related && work.related.length > 0 && (
+        <section className="py-16 bg-stone-100 border-t border-stone-200">
+          <div className="container">
+            <div className="max-w-5xl mx-auto">
+              <p className="font-mono text-stone-400 text-sm mb-6 uppercase tracking-[0.2em]">
+                Adjacent works
+              </p>
+              <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                {work.related
+                  .map((slug) => worksBySlug[slug])
+                  .filter(Boolean)
+                  .map((rel) => (
+                    <Link
+                      key={rel.slug}
+                      href={`/works/${rel.slug}`}
+                      className="block group"
+                    >
+                      <div className="aspect-[4/3] overflow-hidden bg-stone-200 rounded-sm">
+                        <img
+                          src={optimize(rel.heroImage, "card")}
+                          alt={rel.heroAlt}
+                          loading="lazy"
+                          decoding="async"
+                          className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+                        />
+                      </div>
+                      <h3 className="mt-3 font-serif text-xl text-stone-800 group-hover:text-amber-700 transition-colors">
+                        {rel.title}
+                      </h3>
+                      <p className="text-stone-600 italic text-sm leading-snug">
+                        {rel.subtitle}
+                      </p>
+                    </Link>
+                  ))}
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Next work */}
+      <section className="py-20 bg-stone-800 text-white">
+        <div className="container">
+          <div className="max-w-4xl mx-auto flex flex-col sm:flex-row sm:items-end sm:justify-between gap-6">
+            <div>
+              <p className="font-mono text-amber-400 text-sm mb-2 uppercase tracking-[0.2em]">
+                Next in the collection
+              </p>
+              <h2 className="text-3xl md:text-4xl font-serif font-bold">
+                {next.title}
+              </h2>
+              <p className="text-stone-300 italic mt-1">{next.subtitle}</p>
+            </div>
+            <Link
+              href={`/works/${next.slug}`}
+              className="inline-flex items-center gap-2 px-6 py-3 rounded-full bg-amber-500 text-stone-900 font-semibold hover:bg-amber-400 transition-colors whitespace-nowrap"
+            >
+              See the next work
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+/**
+ * Lifecycle editor — admin-only chip toggle row. Click chips to add or remove
+ * lifecycle tags for this work. Persists as JSON array in editable_content.
+ */
+function LifecycleEditor({
+  workSlug,
+  activeTags,
+}: {
+  workSlug: string;
+  activeTags: LifecycleTag[];
+}) {
+  const slot = `${workSlug}-lifecycleTags`;
+  const utils = trpc.useUtils();
+  const update = trpc.content.update.useMutation({
+    onSuccess: () => utils.content.get.invalidate({ page: "works", slot }),
+  });
+  const [open, setOpen] = useState(false);
+  const activeSet = new Set<LifecycleTag>(activeTags);
+
+  const toggleTag = async (tag: LifecycleTag) => {
+    const next = new Set(activeSet);
+    if (next.has(tag)) next.delete(tag);
+    else next.add(tag);
+    await update.mutateAsync({
+      page: "works",
+      slot,
+      content: JSON.stringify(Array.from(next)),
+      contentType: "text",
+    });
+  };
+
+  // Group vocab by family for the editor
+  const FAMILY_LABEL = { build: "Build", grow: "Grow", make: "Make", concept: "Concept", open: "Open" } as const;
+  const FAMILY_ORDER = ["build", "grow", "make", "concept", "open"] as const;
+  const grouped = FAMILY_ORDER.map((family) => ({
+    family,
+    label: FAMILY_LABEL[family],
+    items: (Object.entries(LIFECYCLE_VOCAB) as Array<[LifecycleTag, typeof LIFECYCLE_VOCAB[LifecycleTag]]>)
+      .filter(([, meta]) => meta.family === family),
+  }));
+
+  return (
+    <div className="mb-5 -mt-3">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="text-xs font-mono uppercase tracking-wider text-amber-700 hover:text-amber-800 underline underline-offset-4 decoration-amber-500 decoration-2"
+      >
+        {open ? "Close lifecycle editor" : "Edit lifecycle tags"}
+      </button>
+      {open && (
+        <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 space-y-3">
+          <p className="text-xs text-stone-600">
+            Click a chip to add or remove. A work can carry multiple states at once.
+            These tags also drive comms categorisation.
+          </p>
+          {grouped.map((g) => (
+            <div key={g.family}>
+              <p className="font-mono text-[10px] uppercase tracking-wider text-stone-500 mb-1.5">
+                {g.label}
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {g.items.map(([tag, meta]) => {
+                  const active = activeSet.has(tag);
+                  return (
+                    <button
+                      key={tag}
+                      type="button"
+                      onClick={() => toggleTag(tag)}
+                      disabled={update.isPending}
+                      className={`inline-flex items-center px-2.5 py-1 text-[11px] font-medium uppercase tracking-wider rounded-full transition-all ${
+                        active
+                          ? meta.badgeClass + " ring-2 ring-amber-500 ring-offset-2 ring-offset-amber-50"
+                          : "bg-white text-stone-500 border border-stone-300 hover:bg-stone-50"
+                      } disabled:opacity-50`}
+                    >
+                      {meta.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Pulse — short admin-edited line about what's happening with this work right
+ * now. Hidden for visitors when blank; visible (empty + editable) for admins
+ * so they can drop in a quick status update without leaving the page.
+ */
+function WorkPulseSection({
+  work,
+  isAdmin,
+}: {
+  work: import("@/data/works").Work;
+  isAdmin: boolean;
+}) {
+  const slot = `${work.slug}-pulse`;
+  const { data: saved } = trpc.content.get.useQuery({ page: "works", slot });
+  const hasContent = !!(saved?.content && saved.content.trim().length > 0);
+
+  // For non-admins with no pulse set, render nothing
+  if (!isAdmin && !hasContent) return null;
+
+  return (
+    <section className="pt-6 pb-2">
+      <div className="container">
+        <div className="max-w-3xl mx-auto">
+          <p className="font-mono text-amber-700 text-[11px] mb-2 uppercase tracking-[0.2em] inline-flex items-center gap-2">
+            <span className="w-2 h-2 rounded-full bg-emerald-500 animate-pulse" />
+            Now
+          </p>
+          <EditableText
+            page="works"
+            slot={slot}
+            defaultContent={hasContent ? "" : (isAdmin ? "Add a short status update for what's happening with this work right now." : "")}
+            as="p"
+            className="text-lg md:text-xl text-stone-700 italic leading-relaxed"
+            multiline
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/**
+ * Detect a video URL and return the embed src + render mode.
+ * Supports YouTube (watch / youtu.be / shorts / embed), Vimeo, and direct files.
+ */
+function detectVideoEmbed(url: string): { kind: "youtube" | "vimeo" | "file"; src: string } | null {
+  const u = url.trim();
+  if (!u) return null;
+  // YouTube
+  const yt = u.match(
+    /(?:youtube\.com\/(?:watch\?v=|embed\/|shorts\/)|youtu\.be\/)([A-Za-z0-9_-]{6,})/i,
+  );
+  if (yt) return { kind: "youtube", src: `https://www.youtube.com/embed/${yt[1]}` };
+  // Vimeo
+  const vm = u.match(/vimeo\.com\/(?:video\/)?(\d+)/i);
+  if (vm) return { kind: "vimeo", src: `https://player.vimeo.com/video/${vm[1]}` };
+  // Direct file (mp4 / webm / ogg / mov)
+  if (/\.(mp4|webm|ogg|mov)(\?.*)?$/i.test(u)) return { kind: "file", src: u };
+  return null;
+}
+
+/**
+ * Video section — admin pastes a URL; we embed it. Hidden from visitors when blank.
+ */
+function WorkVideoSection({
+  work,
+  isAdmin,
+}: {
+  work: import("@/data/works").Work;
+  isAdmin: boolean;
+}) {
+  const slot = `${work.slug}-videoUrl`;
+  const utils = trpc.useUtils();
+  const { data: saved } = trpc.content.get.useQuery({ page: "works", slot });
+  const update = trpc.content.update.useMutation({
+    onSuccess: () => utils.content.get.invalidate({ page: "works", slot }),
+  });
+
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+
+  const url = saved?.content?.trim() ?? "";
+  const embed = url ? detectVideoEmbed(url) : null;
+
+  // Visitor + no video → render nothing
+  if (!isAdmin && !embed) return null;
+
+  const startEdit = () => {
+    setDraft(url);
+    setEditing(true);
+  };
+  const save = async () => {
+    await update.mutateAsync({
+      page: "works",
+      slot,
+      content: draft.trim(),
+      contentType: "text",
+    });
+    setEditing(false);
+  };
+  const clearVideo = async () => {
+    await update.mutateAsync({
+      page: "works",
+      slot,
+      content: "",
+      contentType: "text",
+    });
+    setEditing(false);
+  };
+
+  return (
+    <section className="py-10 md:py-14">
+      <div className="container">
+        <div className="max-w-5xl mx-auto">
+          {embed ? (
+            <div className="relative">
+              <div className="aspect-video w-full overflow-hidden rounded-sm shadow-md bg-stone-900">
+                {embed.kind === "file" ? (
+                  <video
+                    src={embed.src}
+                    controls
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  <iframe
+                    src={embed.src}
+                    title={`${work.title} — video`}
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                    allowFullScreen
+                    className="w-full h-full border-0"
+                  />
+                )}
+              </div>
+              {isAdmin && !editing && (
+                <div className="absolute top-2 right-2 flex gap-2">
+                  <button
+                    type="button"
+                    onClick={startEdit}
+                    className="inline-flex items-center gap-1 px-3 py-1.5 rounded-full bg-amber-500 text-stone-900 text-xs font-mono uppercase tracking-wider font-semibold shadow"
+                  >
+                    Edit URL
+                  </button>
+                </div>
+              )}
+            </div>
+          ) : (
+            // Admin and no video set → show the inline form (also used when editing)
+            <div className="rounded-md border border-dashed border-stone-300 bg-stone-50 px-6 py-8">
+              <p className="font-mono text-amber-700 text-xs mb-3 uppercase tracking-[0.2em]">
+                Add a video
+              </p>
+              <p className="text-stone-600 mb-4 text-sm">
+                Paste a YouTube, Vimeo, or direct video file URL. Examples:
+                <br />
+                <code className="font-mono text-xs text-stone-500">https://youtu.be/abc123</code> ·
+                <code className="font-mono text-xs text-stone-500"> https://vimeo.com/1234567</code> ·
+                <code className="font-mono text-xs text-stone-500"> https://your.cdn/clip.mp4</code>
+              </p>
+              <VideoUrlForm initial={url} onSave={async (v) => {
+                await update.mutateAsync({
+                  page: "works",
+                  slot,
+                  content: v.trim(),
+                  contentType: "text",
+                });
+              }} />
+            </div>
+          )}
+
+          {/* Edit form overlay when admin clicked Edit URL */}
+          {editing && (
+            <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-4 py-3">
+              <VideoUrlForm
+                initial={draft}
+                onSave={async (v) => {
+                  setDraft(v);
+                  await update.mutateAsync({
+                    page: "works",
+                    slot,
+                    content: v.trim(),
+                    contentType: "text",
+                  });
+                  setEditing(false);
+                }}
+                onCancel={() => setEditing(false)}
+                onClear={clearVideo}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function VideoUrlForm({
+  initial,
+  onSave,
+  onCancel,
+  onClear,
+}: {
+  initial: string;
+  onSave: (url: string) => Promise<void>;
+  onCancel?: () => void;
+  onClear?: () => Promise<void>;
+}) {
+  const [value, setValue] = useState(initial);
+  const [busy, setBusy] = useState(false);
+
+  const handleSave = async () => {
+    setBusy(true);
+    try {
+      await onSave(value);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <input
+        type="url"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="https://..."
+        className="flex-1 min-w-[260px] px-3 py-2 rounded-md border border-stone-300 bg-white text-sm"
+      />
+      <button
+        type="button"
+        onClick={handleSave}
+        disabled={busy}
+        className="inline-flex items-center gap-1 px-4 py-2 rounded-md bg-stone-800 text-amber-300 text-sm font-semibold hover:bg-stone-900 disabled:opacity-50"
+      >
+        {busy ? "Saving…" : "Save video"}
+      </button>
+      {onCancel && (
+        <button
+          type="button"
+          onClick={onCancel}
+          className="inline-flex items-center gap-1 px-3 py-2 rounded-md text-sm text-stone-600 hover:bg-stone-100"
+        >
+          Cancel
+        </button>
+      )}
+      {onClear && (
+        <button
+          type="button"
+          onClick={onClear}
+          className="inline-flex items-center gap-1 px-3 py-2 rounded-md text-sm text-red-600 hover:bg-red-50"
+        >
+          Remove
+        </button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Picks a hero image for a work in this priority order:
+ *   1. Admin-set override in image_overrides for (page="works", slot="<slug>-hero")
+ *      — applied inside HarvestImage; admins can set/revert via the on-image widget
+ *   2. EL photo tagged `special: ["hero"]` for the work
+ *   3. First EL photo for the work
+ *   4. Fallback: hardcoded heroImage from works.ts
+ */
+function WorkHero({ work }: { work: import("@/data/works").Work }) {
+  const query = trpc.gallery.forWork.useQuery({ slug: work.slug, limit: 24 });
+
+  // Wait for the gallery query to settle before picking a fallback. Otherwise
+  // we render with `work.heroImage` first and then swap when EL responds —
+  // visible as a "wrong image then real one" flicker.
+  if (query.isPending) {
+    return (
+      <section>
+        <div className="container">
+          <div className="max-w-5xl mx-auto aspect-[16/10] rounded-sm shadow-md bg-stone-200 animate-pulse" />
+        </div>
+      </section>
+    );
+  }
+
+  const photos = query.data?.media ?? [];
+  const elHero = photos.find((p) => p.special?.includes("hero")) ?? photos[0];
+
+  const fallbackSrc = elHero?.src ?? work.heroImage;
+  const fallbackAlt = elHero?.altText ?? elHero?.title ?? work.heroAlt;
+  // Only show the bundled credit if neither EL nor an override won. HarvestImage
+  // signals override presence visually with its own pip, so we just hide the
+  // credit when an EL photo is in play (we don't have credit metadata for EL assets yet).
+  const credit = elHero ? null : work.heroCredit;
+
+  return (
+    <section>
+      <div className="container">
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.8, delay: 0.2 }}
+          className="max-w-5xl mx-auto"
+        >
+          <HarvestImage
+            page="works"
+            slot={`${work.slug}-hero`}
+            defaultWorkSlug={work.slug}
+            src={fallbackSrc}
+            alt={fallbackAlt}
+            size="hero"
+            priority
+            className="aspect-[16/10] overflow-hidden rounded-sm shadow-md bg-stone-200"
+            imgClassName="w-full h-full object-cover"
+          />
+          {credit && (
+            <p className="text-stone-500 text-xs mt-2 italic text-right">{credit}</p>
+          )}
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+
+/**
+ * Admin quick-action bar — shortcuts to add/manage photos and tag in EL.
+ * Only rendered when the viewer is admin.
+ */
+function AdminQuickBar({ work }: { work: import("@/data/works").Work }) {
+  const photoManagerUrl = elLinks.photoManager();
+  const bulkEditUrl = elLinks.bulkEdit();
+  const galleriesUrl = elLinks.galleries();
+  const articleEditorUrl = elLinks.articles();
+
+  return (
+    <div className="container mt-4">
+      <div className="max-w-4xl mx-auto rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-stone-700">
+          <span className="font-mono text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full bg-amber-500 text-stone-900 font-semibold whitespace-nowrap">
+            Admin
+          </span>
+          <span className="grow text-stone-700">
+            Hover any image to <strong className="text-amber-800">Swap</strong> or
+            <strong className="text-amber-800"> Revert</strong>. Hover any text and
+            click the <strong className="text-amber-800">pencil</strong> to edit.
+          </span>
+        </div>
+        <div className="mt-2 flex flex-wrap gap-2 text-xs">
+          <QuickLink href={photoManagerUrl} label="Add photos" hint={`Tag with: ${work.title}`} />
+          <QuickLink href={galleriesUrl} label="Galleries" />
+          <QuickLink href={bulkEditUrl} label="Bulk-tag photos" />
+          <QuickLink href={articleEditorUrl} label="Write an article" />
+          <span className="text-stone-500 text-[11px] italic ml-auto self-center">
+            Slot prefix: <code className="font-mono bg-white border px-1 py-0.5 rounded">works / {work.slug}-*</code>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function QuickLink({ href, label, hint }: { href: string; label: string; hint?: string }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-white border border-amber-300 text-amber-800 hover:bg-amber-100 transition-colors"
+      title={hint ?? label}
+    >
+      <ExternalLink className="h-3 w-3" />
+      {label}
+    </a>
+  );
+}
+
+/**
+ * A single feature image between text sections. Falls back to the work's
+ * heroImage when no override is set. Admins can swap via the on-image widget.
+ */
+function InlineFeatureImage({
+  work,
+  slotKey,
+  caption,
+}: {
+  work: import("@/data/works").Work;
+  slotKey: string;
+  caption?: string;
+}) {
+  return (
+    <section className="py-12 md:py-16">
+      <div className="container">
+        <div className="max-w-5xl mx-auto">
+          <HarvestImage
+            page="works"
+            slot={`${work.slug}-${slotKey}`}
+            defaultWorkSlug={work.slug}
+            src={work.heroImage}
+            alt={`${work.title} — feature image`}
+            className="aspect-[16/9] overflow-hidden rounded-sm shadow-md bg-stone-200"
+            imgClassName="w-full h-full object-cover"
+          />
+          {caption && (
+            <p className="text-stone-500 text-sm italic mt-3 text-center">{caption}</p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/**
+ * Two-image spread — sits between the Witta thread and The Hands.
+ * Each side is its own slot so admins can swap them independently.
+ */
+function InlineSpreadImages({ work }: { work: import("@/data/works").Work }) {
+  return (
+    <section className="py-12 md:py-16 bg-stone-50">
+      <div className="container">
+        <div className="max-w-5xl mx-auto grid md:grid-cols-2 gap-4 md:gap-6">
+          <HarvestImage
+            page="works"
+            slot={`${work.slug}-spread-left`}
+            defaultWorkSlug={work.slug}
+            src={work.heroImage}
+            alt={`${work.title} — spread, left`}
+            className="aspect-[4/3] overflow-hidden rounded-sm shadow-md bg-stone-200"
+            imgClassName="w-full h-full object-cover"
+          />
+          <HarvestImage
+            page="works"
+            slot={`${work.slug}-spread-right`}
+            defaultWorkSlug={work.slug}
+            src={work.heroImage}
+            alt={`${work.title} — spread, right`}
+            className="aspect-[4/3] overflow-hidden rounded-sm shadow-md bg-stone-200"
+            imgClassName="w-full h-full object-cover"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function WorkPhotographsSection({ slug }: { slug: string }) {
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
+  const query = trpc.gallery.forWork.useQuery({ slug, limit: 24 });
+  const photos = query.data?.media ?? [];
+
+  // For visitors: hide section entirely when there are no photos.
+  // For admins: still render the section so the "Add photo" CTA is reachable.
+  if (query.isLoading) return null;
+  if (photos.length === 0 && !isAdmin) return null;
+
+  return (
+    <section className="py-20 md:py-28 bg-stone-50">
+      <div className="container">
+        <div className="max-w-6xl mx-auto">
+          <motion.div {...fadeInUp} className="mb-12 flex flex-wrap items-end justify-between gap-6">
+            <div className="max-w-2xl">
+              <p className="font-mono text-amber-700 text-sm mb-4 uppercase tracking-[0.2em] inline-flex items-center gap-2">
+                <Camera className="h-4 w-4" />
+                Photographs · {photos.length}
+              </p>
+              <h2 className="text-4xl md:text-6xl font-serif font-bold text-stone-800 leading-[0.95]">
+                From the field.
+              </h2>
+              <p className="mt-5 text-lg text-stone-600 leading-relaxed">
+                Every photograph tagged for this work in Empathy Ledger.
+                {isAdmin && " Hover any image to swap or revert."}
+              </p>
+            </div>
+            {isAdmin && (
+              <a
+                href={elLinks.photoManager()}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-stone-800 text-amber-300 text-sm font-medium hover:bg-stone-900 transition-colors whitespace-nowrap"
+                title="Open EL photo manager in a new tab. Upload a new photo or pick an existing one, then tag it with this work."
+              >
+                <ExternalLink className="h-4 w-4" />
+                Add a photo to this work
+              </a>
+            )}
+          </motion.div>
+
+          {photos.length === 0 && isAdmin && (
+            <div className="mb-10 rounded-md border border-dashed border-stone-300 bg-white px-6 py-10 text-center">
+              <p className="text-stone-600 mb-2">No photos tagged for this work yet.</p>
+              <p className="text-stone-500 text-sm">
+                Click <strong>Add a photo to this work</strong> above. In EL admin, find or
+                upload your photo, then add the <code className="font-mono bg-stone-100 px-1.5 py-0.5 rounded">Milk Create Pavilion</code>{" "}
+                tag (or whichever work this is). It'll appear here within a few minutes.
+              </p>
+            </div>
+          )}
+
+          <div className="columns-1 sm:columns-2 lg:columns-3 gap-4">
+            {photos.map((photo, i) => (
+              <motion.figure
+                key={photo.id}
+                initial={{ opacity: 0, y: 16 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.4, delay: (i % 9) * 0.04 }}
+                className="break-inside-avoid mb-4"
+              >
+                <div className="overflow-hidden rounded-sm shadow-sm bg-stone-200 animate-pulse [&:has(img.loaded)]:animate-none">
+                  <img
+                    src={optimize(photo.src, "thumb")}
+                    alt={photo.altText ?? photo.title ?? slug}
+                    loading="lazy"
+                    decoding="async"
+                    onLoad={(e) => e.currentTarget.classList.add("loaded")}
+                    className="w-full h-auto block hover:scale-[1.02] transition-transform duration-500"
+                  />
+                </div>
+                {(photo.title || photo.description) && (
+                  <figcaption className="mt-2 text-stone-500 text-xs leading-snug">
+                    {photo.title && (
+                      <span className="text-stone-700">{photo.title}</span>
+                    )}
+                    {photo.title && photo.description && " — "}
+                    {photo.description}
+                  </figcaption>
+                )}
+              </motion.figure>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+type JournalBucket = "past" | "present" | "forthcoming";
+
+const PRESENT_WINDOW_DAYS = 30;
+
+function bucketForArticle(publishedAt: string): JournalBucket {
+  const now = Date.now();
+  const t = new Date(publishedAt).getTime();
+  if (Number.isNaN(t)) return "past";
+  if (t > now) return "forthcoming";
+  if (now - t <= PRESENT_WINDOW_DAYS * 24 * 60 * 60 * 1000) return "present";
+  return "past";
+}
+
+function formatJournalDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString("en-AU", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+/**
+ * Journal — chronological library of articles syndicated to The Harvest with
+ * primaryProject matching this work. Filter chips: All / Past / Now / Coming.
+ * The work's living narrative lives here.
+ */
+function WorkJournalSection({ slug, workTitle }: { slug: string; workTitle: string }) {
+  const [filter, setFilter] = useState<"all" | JournalBucket>("all");
+  const query = trpc.blog.list.useQuery({ project: slug, limit: 50 });
+  const articles = query.data?.articles ?? [];
+
+  // Hide the section entirely when there's nothing to show
+  if (query.isLoading || articles.length === 0) return null;
+
+  const grouped: Record<JournalBucket, typeof articles> = {
+    forthcoming: [],
+    present: [],
+    past: [],
+  };
+  for (const a of articles) {
+    grouped[bucketForArticle(a.publishedAt)].push(a);
+  }
+  // Sort: forthcoming asc by date, present + past desc
+  grouped.forthcoming.sort((a, b) => +new Date(a.publishedAt) - +new Date(b.publishedAt));
+  grouped.present.sort((a, b) => +new Date(b.publishedAt) - +new Date(a.publishedAt));
+  grouped.past.sort((a, b) => +new Date(b.publishedAt) - +new Date(a.publishedAt));
+
+  const visible = filter === "all"
+    ? [
+        ...grouped.forthcoming.map((a) => ({ a, b: "forthcoming" as JournalBucket })),
+        ...grouped.present.map((a) => ({ a, b: "present" as JournalBucket })),
+        ...grouped.past.map((a) => ({ a, b: "past" as JournalBucket })),
+      ]
+    : grouped[filter].map((a) => ({ a, b: filter as JournalBucket }));
+
+  const counts = {
+    all: articles.length,
+    past: grouped.past.length,
+    present: grouped.present.length,
+    forthcoming: grouped.forthcoming.length,
+  };
+
+  return (
+    <section className="py-20 md:py-24 bg-stone-100 border-t border-stone-200">
+      <div className="container">
+        <div className="max-w-5xl mx-auto">
+          <motion.div {...fadeInUp} className="mb-10 max-w-2xl">
+            <p className="font-mono text-amber-700 text-sm mb-3 uppercase tracking-[0.2em]">
+              Journal · {articles.length}
+            </p>
+            <h2 className="text-3xl md:text-4xl font-serif font-bold text-stone-800">
+              The narrative of {workTitle}.
+            </h2>
+            <p className="mt-3 text-stone-600 leading-relaxed">
+              Past dispatches, what's happening now, and what's coming next. Every
+              article on the Harvest site whose primary project is this work, in
+              order.
+            </p>
+          </motion.div>
+
+          {/* Filter chips */}
+          <div className="flex flex-wrap gap-2 mb-8">
+            {(["all", "past", "present", "forthcoming"] as const).map((b) => {
+              const active = filter === b;
+              const label = { all: "All", past: "Past", present: "Now", forthcoming: "Coming" }[b];
+              return (
+                <button
+                  key={b}
+                  type="button"
+                  onClick={() => setFilter(b)}
+                  className={`px-4 py-1.5 rounded-full text-sm font-medium border transition-colors ${
+                    active
+                      ? "bg-stone-800 text-amber-300 border-stone-800"
+                      : "bg-white text-stone-700 border-stone-300 hover:bg-stone-50"
+                  }`}
+                >
+                  {label} <span className="ml-1 text-stone-400">·</span>
+                  <span className={`ml-1 ${active ? "text-amber-200" : "text-stone-400"}`}>{counts[b]}</span>
+                </button>
+              );
+            })}
+          </div>
+
+          {visible.length === 0 ? (
+            <p className="text-stone-500 italic py-10 text-center">
+              Nothing in this window yet. Try another filter.
+            </p>
+          ) : (
+            <ol className="relative border-l-2 border-amber-400/40 ml-3 space-y-8">
+              {visible.map(({ a, b }, i) => (
+                <motion.li
+                  key={a.id}
+                  initial={{ opacity: 0, x: -10 }}
+                  whileInView={{ opacity: 1, x: 0 }}
+                  viewport={{ once: true }}
+                  transition={{ duration: 0.4, delay: (i % 8) * 0.04 }}
+                  className="relative pl-8"
+                >
+                  <span className={`absolute -left-[9px] top-1 w-4 h-4 rounded-full ring-4 ring-stone-100 ${
+                    b === "forthcoming" ? "bg-amber-300" : b === "present" ? "bg-emerald-500" : "bg-stone-400"
+                  }`} />
+                  <div className="grid md:grid-cols-[140px_1fr] gap-x-6 gap-y-2">
+                    <div>
+                      <p className="font-mono text-xs uppercase tracking-wider text-stone-500">
+                        {formatJournalDate(a.publishedAt)}
+                      </p>
+                      <p className={`font-mono text-[10px] uppercase tracking-wider mt-1 ${
+                        b === "forthcoming" ? "text-amber-700" : b === "present" ? "text-emerald-700" : "text-stone-400"
+                      }`}>
+                        {b === "forthcoming" ? "Coming" : b === "present" ? "Now" : "Past"} · {a.articleType ?? "dispatch"}
+                      </p>
+                    </div>
+                    <Link href={`/blog/${a.slug}`} className="group block">
+                      <h3 className="font-serif text-xl md:text-2xl font-bold text-stone-800 leading-snug group-hover:text-amber-700 transition-colors">
+                        {a.title}
+                      </h3>
+                      {a.subtitle && (
+                        <p className="text-stone-600 italic leading-snug mt-1">{a.subtitle}</p>
+                      )}
+                      {a.excerpt && (
+                        <p className="text-stone-700 mt-2 leading-relaxed line-clamp-2">{a.excerpt}</p>
+                      )}
+                      <p className="mt-2 inline-flex items-center gap-1.5 text-amber-700 text-sm font-medium group-hover:gap-2.5 transition-all">
+                        Read
+                        <ArrowRight className="h-3.5 w-3.5" />
+                      </p>
+                    </Link>
+                  </div>
+                </motion.li>
+              ))}
+            </ol>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Section({
+  label,
+  body,
+  slot,
+  tone = "light",
+}: {
+  label: string;
+  body: string;
+  /** When provided, body becomes admin-editable and persists to image_overrides' sibling table image content. */
+  slot?: string;
+  tone?: "light" | "dark";
+}) {
+  const isDark = tone === "dark";
+  const bodyClass = `text-xl md:text-2xl leading-relaxed ${isDark ? "text-stone-100" : "text-stone-800"}`;
+  return (
+    <section className={`py-20 md:py-24 ${isDark ? "bg-stone-900 text-white" : ""}`}>
+      <div className="container">
+        <div className="max-w-3xl mx-auto">
+          <motion.div {...fadeInUp}>
+            <p className={`font-mono text-sm mb-4 uppercase tracking-[0.2em] ${isDark ? "text-amber-400" : "text-amber-700"}`}>
+              {label}
+            </p>
+            {slot ? (
+              <EditableText
+                page="works"
+                slot={slot}
+                defaultContent={body}
+                as="p"
+                className={bodyClass}
+                multiline
+              />
+            ) : (
+              <p className={bodyClass}>{body}</p>
+            )}
+          </motion.div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/pages/Works.tsx
+++ b/client/src/pages/Works.tsx
@@ -1,0 +1,189 @@
+import { useEffect } from "react";
+import { Link } from "wouter";
+import { motion } from "framer-motion";
+import { ArrowRight } from "lucide-react";
+import { works, LIFECYCLE_VOCAB, sortLifecycleTags } from "@/data/works";
+import { EditableText } from "@/components/EditableText";
+
+const fadeInUp = {
+  initial: { opacity: 0, y: 30 },
+  whileInView: { opacity: 1, y: 0 },
+  viewport: { once: true, margin: "-50px" },
+  transition: { duration: 0.6 },
+};
+
+
+export default function Works() {
+  useEffect(() => {
+    document.title = "The Collection · The Harvest";
+    const desc = "The works of The Harvest — a living collection on Jinibara Country, Witta. Each piece carries a thread back to the history of the place.";
+    let meta = document.querySelector('meta[name="description"]') as HTMLMetaElement | null;
+    if (!meta) {
+      meta = document.createElement("meta");
+      meta.name = "description";
+      document.head.appendChild(meta);
+    }
+    meta.content = desc;
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-stone-50">
+      {/* Hero */}
+      <section className="relative py-24 md:py-32 bg-stone-100">
+        <div className="container">
+          <motion.div
+            initial={{ opacity: 0, y: 40 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8 }}
+            className="max-w-3xl mx-auto text-center"
+          >
+            <p className="text-amber-600 font-mono text-sm mb-4 uppercase tracking-[0.2em]">
+              The Collection · {works.length} works
+            </p>
+            <h1 className="text-5xl md:text-7xl font-serif font-bold text-stone-800 mb-8 leading-[0.95]">
+              Everything here<br />is a piece.
+            </h1>
+            <p className="text-xl text-stone-600 leading-relaxed max-w-2xl mx-auto">
+              The Harvest is a slow, living collection. Some works are built.
+              Some are growing. Some are still forthcoming. Each one carries a
+              thread back to the history of this place.
+            </p>
+            <div className="mt-10">
+              <Link
+                href="/witta"
+                className="inline-flex items-center gap-2 text-stone-700 hover:text-stone-900 underline underline-offset-4 decoration-amber-500 decoration-2"
+              >
+                Read the Witta history first
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </div>
+          </motion.div>
+        </div>
+      </section>
+
+      {/* Works grid */}
+      <section className="py-20 md:py-28">
+        <div className="container">
+          <div className="max-w-6xl mx-auto grid gap-10 md:gap-14 md:grid-cols-2">
+            {works.map((work, i) => {
+              const lifecycleTags = sortLifecycleTags(work.lifecycleTags);
+              const number = String(i + 1).padStart(2, "0");
+
+              return (
+                <motion.article
+                  key={work.slug}
+                  {...fadeInUp}
+                  transition={{ duration: 0.6, delay: (i % 2) * 0.1 }}
+                  className="group"
+                >
+                  {/* Image plate — clickable */}
+                  <Link
+                    href={`/works/${work.slug}`}
+                    className="block relative aspect-[4/3] overflow-hidden bg-stone-200 rounded-sm shadow-sm group-hover:shadow-md transition-shadow"
+                  >
+                    <img
+                      src={work.heroImage}
+                      alt={work.heroAlt}
+                      loading="lazy"
+                      className="w-full h-full object-cover transition-transform duration-700 group-hover:scale-105"
+                    />
+                    <div className="absolute top-4 left-4 flex flex-wrap gap-1.5">
+                      {lifecycleTags.map((tag) => {
+                        const meta = LIFECYCLE_VOCAB[tag];
+                        return (
+                          <span
+                            key={tag}
+                            className={`inline-flex items-center px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider rounded-full ${meta.badgeClass}`}
+                          >
+                            {meta.label}
+                          </span>
+                        );
+                      })}
+                    </div>
+                  </Link>
+
+                  {/* Museum label — text outside the Link so EditableText pencils don't navigate */}
+                  <div className="mt-6 grid grid-cols-[auto_1fr] gap-x-6">
+                    <p className="font-mono text-stone-400 text-sm tabular-nums pt-1">
+                      {number}
+                    </p>
+                    <div>
+                      <Link href={`/works/${work.slug}`}>
+                        <h2 className="text-2xl md:text-3xl font-serif font-bold text-stone-800 group-hover:text-amber-700 transition-colors cursor-pointer">
+                          {work.title}
+                        </h2>
+                      </Link>
+                      <EditableText
+                        page="works-index"
+                        slot={`${work.slug}-subtitle`}
+                        defaultContent={work.subtitle}
+                        as="p"
+                        className="text-stone-600 italic mt-1 leading-snug"
+                        multiline
+                      />
+                      <div className="mt-4 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-sm">
+                        <span className="font-mono text-stone-400 uppercase tracking-wider text-[10px] pt-1">Year</span>
+                        <span className="text-stone-700">{work.year}</span>
+                        <span className="font-mono text-stone-400 uppercase tracking-wider text-[10px] pt-1">Materials</span>
+                        <span className="text-stone-700">{work.materials}</span>
+                      </div>
+                      <EditableText
+                        page="works-index"
+                        slot={`${work.slug}-blurb`}
+                        defaultContent={work.blurb}
+                        as="p"
+                        className="mt-5 text-stone-600 leading-relaxed"
+                        multiline
+                      />
+                      <Link
+                        href={`/works/${work.slug}`}
+                        className="mt-4 inline-flex items-center gap-1.5 text-amber-700 font-medium text-sm group-hover:gap-2.5 transition-all"
+                      >
+                        See the work
+                        <ArrowRight className="h-4 w-4" />
+                      </Link>
+                    </div>
+                  </div>
+                </motion.article>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* Closing band */}
+      <section className="py-24 bg-stone-800 text-white">
+        <div className="container">
+          <motion.div {...fadeInUp} className="max-w-3xl mx-auto text-center">
+            <p className="text-amber-400 font-mono text-sm mb-4 uppercase tracking-[0.2em]">
+              The Collection grows
+            </p>
+            <h2 className="text-3xl md:text-4xl font-serif font-bold mb-6">
+              The next pieces will be made with you.
+            </h2>
+            <p className="text-lg text-stone-300 leading-relaxed mb-10">
+              Each season brings a new work — sometimes a structure, sometimes a
+              practice, sometimes a partnership. Add a memory, share a skill, or
+              come and help build one.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link
+                href="/witta"
+                className="inline-flex items-center justify-center gap-2 px-7 py-3 rounded-full bg-amber-500 text-stone-900 font-semibold hover:bg-amber-400 transition-colors"
+              >
+                Add to Witta history
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center gap-2 px-7 py-3 rounded-full border border-stone-500 text-stone-200 hover:bg-stone-700 transition-colors"
+              >
+                Back to The Harvest
+              </Link>
+            </div>
+          </motion.div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/client/src/pages/admin/MediaLibraryAdmin.tsx
+++ b/client/src/pages/admin/MediaLibraryAdmin.tsx
@@ -1170,6 +1170,60 @@ function StorytellersPanel() {
   const storytellersQuery = trpc.mediaLibrary.harvestStorytellers.useQuery(undefined, { staleTime: 60_000 });
   const orphansQuery = trpc.mediaLibrary.orphanedHarvestArticles.useQuery(undefined, { staleTime: 60_000 });
 
+  // Phase 2 write state
+  const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [addRole, setAddRole] = useState<"participant" | "contributor" | "subject" | "owner">("participant");
+  const [editingBioId, setEditingBioId] = useState<string | null>(null);
+  const [bioDraft, setBioDraft] = useState("");
+  const [creatingStoryFor, setCreatingStoryFor] = useState<string | null>(null);
+  const [storyTitle, setStoryTitle] = useState("");
+  const [storyContent, setStoryContent] = useState("");
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebouncedQuery(searchQuery.trim()), 300);
+    return () => clearTimeout(handle);
+  }, [searchQuery]);
+
+  const searchResultsQuery = trpc.mediaLibrary.searchStorytellers.useQuery(
+    { query: debouncedQuery },
+    { enabled: debouncedQuery.length >= 2, staleTime: 30_000 },
+  );
+
+  const refetchAll = () => {
+    storytellersQuery.refetch();
+    statsQuery.refetch();
+    searchResultsQuery.refetch();
+  };
+
+  const addStoryteller = trpc.mediaLibrary.addStorytellerToHarvest.useMutation({
+    onSuccess: (r, vars) => {
+      toast.success(r.alreadyMember ? "Already a member." : `Added storyteller as ${vars.role}.`);
+      setSearchQuery("");
+      refetchAll();
+    },
+    onError: (e) => toast.error(`Add failed: ${e.message}`),
+  });
+  const updateBio = trpc.mediaLibrary.updateStorytellerBio.useMutation({
+    onSuccess: () => {
+      toast.success("Bio updated.");
+      setEditingBioId(null);
+      setBioDraft("");
+      storytellersQuery.refetch();
+    },
+    onError: (e) => toast.error(`Bio update failed: ${e.message}`),
+  });
+  const createStory = trpc.mediaLibrary.createHarvestStory.useMutation({
+    onSuccess: (r) => {
+      toast.success(`Story created (id ${r.id.slice(0, 8)}…).`);
+      setCreatingStoryFor(null);
+      setStoryTitle("");
+      setStoryContent("");
+      refetchAll();
+    },
+    onError: (e) => toast.error(`Story create failed: ${e.message}`),
+  });
+
   const tagAsHarvest = trpc.mediaLibrary.tagArticleAsHarvest.useMutation({
     onSuccess: (result) => {
       if (result.updated) {
@@ -1222,6 +1276,60 @@ function StorytellersPanel() {
         )}
       </div>
 
+      <div className="border-b border-stone-200 p-5">
+        <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-stone-500">add storyteller to the harvest</p>
+        <div className="mt-2 grid gap-2 sm:grid-cols-[1fr_auto]">
+          <div className="relative">
+            <Input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search EL storytellers by name (≥ 2 chars)…"
+              className="border-stone-300"
+            />
+            {debouncedQuery.length >= 2 && (searchResultsQuery.data ?? []).length > 0 && (
+              <div className="absolute z-20 mt-1 w-full max-h-72 overflow-y-auto border border-stone-300 bg-white shadow-lg">
+                {(searchResultsQuery.data ?? []).map((r) => (
+                  <button
+                    key={r.id}
+                    type="button"
+                    disabled={r.alreadyOnHarvest || addStoryteller.isPending}
+                    onClick={() => addStoryteller.mutate({ storytellerId: r.id, role: addRole })}
+                    className={`flex w-full items-center justify-between gap-2 border-b border-stone-100 px-3 py-2 text-left text-sm transition ${
+                      r.alreadyOnHarvest ? "cursor-not-allowed bg-stone-50 text-stone-400" : "hover:bg-[#C4922A]/8"
+                    }`}
+                  >
+                    <span className="min-w-0 truncate">
+                      <span className="font-semibold">{r.displayName ?? "(unnamed)"}</span>
+                      <span className="ml-2 text-xs text-stone-500">{r.location ?? "no location"}</span>
+                      {!r.isActive && <span className="ml-1 text-[10px] text-amber-700">(inactive)</span>}
+                    </span>
+                    {r.alreadyOnHarvest ? (
+                      <span className="shrink-0 text-[10px] font-mono uppercase text-[#4A6741]">on harvest</span>
+                    ) : (
+                      <span className="shrink-0 text-[10px] font-mono uppercase text-stone-500">add as {addRole}</span>
+                    )}
+                  </button>
+                ))}
+              </div>
+            )}
+            {debouncedQuery.length >= 2 && searchResultsQuery.data?.length === 0 && !searchResultsQuery.isLoading && (
+              <p className="absolute z-20 mt-1 w-full border border-stone-300 bg-white px-3 py-2 text-xs text-stone-600 shadow-lg">No matches.</p>
+            )}
+          </div>
+          <select
+            value={addRole}
+            onChange={(e) => setAddRole(e.target.value as typeof addRole)}
+            className="border border-stone-300 bg-white px-2 text-sm"
+          >
+            <option value="participant">participant</option>
+            <option value="contributor">contributor</option>
+            <option value="subject">subject</option>
+            <option value="owner">owner</option>
+          </select>
+        </div>
+      </div>
+
       <div className="grid gap-4 p-5 sm:grid-cols-2">
         {isLoading ? (
           Array.from({ length: 2 }).map((_, i) => (
@@ -1269,8 +1377,31 @@ function StorytellersPanel() {
                   </div>
                 </header>
 
-                {s.bio && (
-                  <p className="line-clamp-3 text-sm leading-relaxed text-stone-700">{s.bio}</p>
+                {editingBioId === s.id ? (
+                  <div className="grid gap-2">
+                    <textarea
+                      value={bioDraft}
+                      onChange={(e) => setBioDraft(e.target.value)}
+                      rows={6}
+                      maxLength={5000}
+                      className="w-full resize-y border border-stone-300 bg-white p-2 text-sm leading-relaxed text-stone-800"
+                    />
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Button
+                        size="sm"
+                        onClick={() => updateBio.mutate({ storytellerId: s.id, bio: bioDraft })}
+                        disabled={updateBio.isPending || bioDraft === (s.bio ?? "")}
+                      >
+                        {updateBio.isPending ? "Saving…" : "Save bio"}
+                      </Button>
+                      <Button size="sm" variant="outline" onClick={() => { setEditingBioId(null); setBioDraft(""); }}>
+                        Cancel
+                      </Button>
+                      <span className="text-[10px] text-stone-500">{bioDraft.length} / 5000</span>
+                    </div>
+                  </div>
+                ) : (
+                  s.bio && <p className="line-clamp-3 text-sm leading-relaxed text-stone-700">{s.bio}</p>
                 )}
 
                 <div className="flex flex-wrap gap-1.5">
@@ -1312,13 +1443,68 @@ function StorytellersPanel() {
                   </div>
                 )}
 
-                {elProfileUrl && (
-                  <div className="flex flex-wrap gap-2 border-t border-stone-100 pt-3">
+                <div className="flex flex-wrap gap-2 border-t border-stone-100 pt-3">
+                  {elProfileUrl && (
                     <Button variant="outline" size="sm" asChild>
                       <a href={elProfileUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-xs">
                         Open in EL <ExternalLink className="h-3 w-3" />
                       </a>
                     </Button>
+                  )}
+                  {editingBioId !== s.id && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => { setEditingBioId(s.id); setBioDraft(s.bio ?? ""); }}
+                    >
+                      Edit bio
+                    </Button>
+                  )}
+                  {creatingStoryFor !== s.id && (
+                    <Button
+                      size="sm"
+                      onClick={() => { setCreatingStoryFor(s.id); setStoryTitle(""); setStoryContent(""); }}
+                    >
+                      + Story
+                    </Button>
+                  )}
+                </div>
+
+                {creatingStoryFor === s.id && (
+                  <div className="grid gap-2 border-t border-[#C4922A] bg-[#C4922A]/8 p-3">
+                    <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-[#8B4A2A]">new story · author: {s.displayName}</p>
+                    <Input
+                      value={storyTitle}
+                      onChange={(e) => setStoryTitle(e.target.value)}
+                      placeholder="Story title"
+                      maxLength={255}
+                    />
+                    <textarea
+                      value={storyContent}
+                      onChange={(e) => setStoryContent(e.target.value)}
+                      rows={8}
+                      placeholder="Story content (markdown ok)…"
+                      maxLength={50000}
+                      className="w-full resize-y border border-stone-300 bg-white p-2 text-sm leading-relaxed text-stone-800"
+                    />
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Button
+                        size="sm"
+                        onClick={() => createStory.mutate({
+                          title: storyTitle,
+                          content: storyContent,
+                          authorStorytellerId: s.id,
+                          isPublic: false,
+                        })}
+                        disabled={createStory.isPending || !storyTitle.trim() || !storyContent.trim()}
+                      >
+                        {createStory.isPending ? "Creating…" : "Create draft"}
+                      </Button>
+                      <Button size="sm" variant="outline" onClick={() => { setCreatingStoryFor(null); setStoryTitle(""); setStoryContent(""); }}>
+                        Cancel
+                      </Button>
+                      <span className="text-[10px] text-stone-500">draft · is_public=false · project_id=Harvest</span>
+                    </div>
                   </div>
                 )}
               </article>

--- a/client/src/pages/admin/MediaLibraryAdmin.tsx
+++ b/client/src/pages/admin/MediaLibraryAdmin.tsx
@@ -1166,6 +1166,7 @@ function LocalVideoImportPanel({
 }
 
 function StorytellersPanel() {
+  const statsQuery = trpc.mediaLibrary.harvestProjectStats.useQuery(undefined, { staleTime: 60_000 });
   const storytellersQuery = trpc.mediaLibrary.harvestStorytellers.useQuery(undefined, { staleTime: 60_000 });
   const orphansQuery = trpc.mediaLibrary.orphanedHarvestArticles.useQuery(undefined, { staleTime: 60_000 });
 
@@ -1195,6 +1196,7 @@ function StorytellersPanel() {
     onError: (err) => toast.error(`Claim failed: ${err.message}`),
   });
 
+  const stats = statsQuery.data;
   const storytellers = storytellersQuery.data ?? [];
   const orphans = orphansQuery.data ?? [];
   const isLoading = storytellersQuery.isLoading || orphansQuery.isLoading;
@@ -1202,11 +1204,22 @@ function StorytellersPanel() {
   return (
     <section className="mt-8 border border-stone-300 bg-[#FFFDF7]">
       <div className="border-b border-stone-200 p-5">
-        <p className="font-mono text-xs uppercase tracking-[0.2em] text-[#8B4A2A]">storytellers</p>
-        <h2 className="mt-2 text-3xl font-black leading-tight">The people behind the work.</h2>
+        <p className="font-mono text-xs uppercase tracking-[0.2em] text-[#8B4A2A]">the harvest · empathy ledger</p>
+        <h2 className="mt-2 text-3xl font-black leading-tight">People, stories, transcripts, photos.</h2>
         <p className="mt-3 max-w-3xl text-sm leading-relaxed text-stone-700 md:text-base">
-          Curated Harvest storytellers (Sophie, Barry, …). Their stories, articles and media uploads roll up here so you can see at a glance who has content live and what's still drafting. Add new IDs in <code className="rounded bg-stone-200 px-1 font-mono text-[11px]">HARVEST_STORYTELLER_IDS</code> in <code className="rounded bg-stone-200 px-1 font-mono text-[11px]">server/empathyLedgerAdmin.ts</code>.
+          This mirrors the EL admin's "The Harvest" project view. Storytellers come from the <code className="rounded bg-stone-200 px-1 font-mono text-[11px]">project_storytellers</code> join — anyone added to the project in EL admin shows up here automatically.
+          <a href="https://empathyledger.com/admin/projects/the-harvest" target="_blank" rel="noopener noreferrer" className="ml-1 inline-flex items-center gap-1 text-[#8B4A2A] underline">Open project in EL <ExternalLink className="h-3 w-3" /></a>
         </p>
+        {stats && (
+          <div className="mt-4 grid grid-cols-3 gap-2 text-xs sm:grid-cols-6">
+            <div className="border border-stone-200 bg-white p-2"><p className="font-mono text-[10px] uppercase text-stone-500">people</p><p className="text-lg font-black text-stone-900">{stats.storytellerCount}</p></div>
+            <div className="border border-stone-200 bg-white p-2"><p className="font-mono text-[10px] uppercase text-stone-500">stories</p><p className="text-lg font-black text-stone-900">{stats.storyCount}</p></div>
+            <div className="border border-stone-200 bg-white p-2"><p className="font-mono text-[10px] uppercase text-stone-500">transcripts</p><p className="text-lg font-black text-stone-900">{stats.transcriptCount}</p></div>
+            <div className="border border-stone-200 bg-white p-2" title="media_assets.project_id = HARVEST_PROJECT_ID"><p className="font-mono text-[10px] uppercase text-stone-500">photos · project</p><p className="text-lg font-black text-stone-900">{stats.mediaByProjectId}</p></div>
+            <div className="border border-stone-200 bg-white p-2" title="gallery_media_associations rows"><p className="font-mono text-[10px] uppercase text-stone-500">photos · gallery</p><p className="text-lg font-black text-stone-900">{stats.mediaByGalleryAssoc}</p></div>
+            <div className="border border-stone-200 bg-white p-2" title="legacy media_assets.collection_id"><p className="font-mono text-[10px] uppercase text-stone-500">photos · collection</p><p className="text-lg font-black text-stone-900">{stats.mediaByCollectionId}</p></div>
+          </div>
+        )}
       </div>
 
       <div className="grid gap-4 p-5 sm:grid-cols-2">
@@ -1240,9 +1253,18 @@ function StorytellersPanel() {
                   )}
                   <div className="min-w-0">
                     <h3 className="text-lg font-black leading-tight text-stone-900">{s.displayName ?? "(unnamed)"}</h3>
-                    <p className="mt-0.5 text-xs text-stone-500">
-                      {s.location ?? "no location"}
-                      {!s.isActive && <span className="ml-2 inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-900">inactive</span>}
+                    <p className="mt-0.5 flex flex-wrap items-center gap-1.5 text-xs text-stone-500">
+                      <span>{s.location ?? "no location"}</span>
+                      {s.projectRole && (
+                        <span className="inline-flex items-center rounded-full bg-[#4A6741]/15 px-2 py-0.5 text-[10px] font-semibold text-[#4A6741]">
+                          {s.projectRole}
+                        </span>
+                      )}
+                      {!s.isActive && (
+                        <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-900">
+                          profile inactive
+                        </span>
+                      )}
                     </p>
                   </div>
                 </header>
@@ -1255,10 +1277,11 @@ function StorytellersPanel() {
                   <TagChip label={`${s.stories.length} stories`} tone={s.stories.length > 0 ? "work" : "neutral"} />
                   <TagChip label={`${harvestStories} Harvest-tagged`} tone={harvestStories > 0 ? "work" : "warn"} />
                   <TagChip label={`${publishedArticles} published`} tone={publishedArticles > 0 ? "work" : "neutral"} />
+                  <TagChip label={`${s.transcripts.length} transcripts`} tone={s.transcripts.length > 0 ? "work" : "neutral"} />
                   <TagChip label={`${s.mediaCount} uploads`} />
                 </div>
 
-                {(s.stories.length > 0 || s.articles.length > 0) && (
+                {(s.stories.length > 0 || s.articles.length > 0 || s.transcripts.length > 0) && (
                   <div className="grid gap-1 border-t border-stone-100 pt-3 text-xs text-stone-700">
                     {s.stories.map((story) => (
                       <p key={story.id} className="flex items-center gap-2">
@@ -1275,6 +1298,15 @@ function StorytellersPanel() {
                         </span>
                         <span className="truncate">{article.title ?? "(no title)"}</span>
                         {!article.isHarvestTagged && <span className="shrink-0 text-amber-700">(not Harvest-tagged)</span>}
+                      </p>
+                    ))}
+                    {s.transcripts.map((tr) => (
+                      <p key={tr.id} className="flex items-center gap-2">
+                        <span className="inline-flex shrink-0 items-center rounded bg-[#8B4A2A]/15 px-1.5 py-0.5 font-mono text-[9px] uppercase text-[#8B4A2A]">
+                          tr
+                        </span>
+                        <span className="truncate">{tr.title ?? "(untitled transcript)"}</span>
+                        {tr.wordCount && <span className="shrink-0 text-stone-500">· {tr.wordCount.toLocaleString()} words</span>}
                       </p>
                     ))}
                   </div>

--- a/client/src/pages/admin/MediaLibraryAdmin.tsx
+++ b/client/src/pages/admin/MediaLibraryAdmin.tsx
@@ -616,6 +616,8 @@ export default function MediaLibraryAdmin() {
           onRecipeChange={setRecipeKey}
         />
 
+        <StorytellersPanel />
+
         <AllMediaWorkbench
           media={media}
           filteredMedia={filteredMedia}
@@ -1159,6 +1161,180 @@ function LocalVideoImportPanel({
           )}
         </div>
       </div>
+    </section>
+  );
+}
+
+function StorytellersPanel() {
+  const storytellersQuery = trpc.mediaLibrary.harvestStorytellers.useQuery(undefined, { staleTime: 60_000 });
+  const orphansQuery = trpc.mediaLibrary.orphanedHarvestArticles.useQuery(undefined, { staleTime: 60_000 });
+
+  const tagAsHarvest = trpc.mediaLibrary.tagArticleAsHarvest.useMutation({
+    onSuccess: (result) => {
+      if (result.updated) {
+        toast.success(
+          result.preservedInRelated
+            ? `Tagged as Harvest. Previous "${result.preservedInRelated}" preserved in related_projects.`
+            : "Tagged as Harvest.",
+        );
+      } else {
+        toast.message("Already tagged as Harvest — no change.");
+      }
+      orphansQuery.refetch();
+      storytellersQuery.refetch();
+    },
+    onError: (err) => toast.error(`Tag failed: ${err.message}`),
+  });
+
+  const claimForStoryteller = trpc.mediaLibrary.claimArticleForStoryteller.useMutation({
+    onSuccess: (result) => {
+      toast.success(result.updated ? "Article claimed by storyteller." : "Already claimed.");
+      orphansQuery.refetch();
+      storytellersQuery.refetch();
+    },
+    onError: (err) => toast.error(`Claim failed: ${err.message}`),
+  });
+
+  const storytellers = storytellersQuery.data ?? [];
+  const orphans = orphansQuery.data ?? [];
+  const isLoading = storytellersQuery.isLoading || orphansQuery.isLoading;
+
+  return (
+    <section className="mt-8 border border-stone-300 bg-[#FFFDF7]">
+      <div className="border-b border-stone-200 p-5">
+        <p className="font-mono text-xs uppercase tracking-[0.2em] text-[#8B4A2A]">storytellers</p>
+        <h2 className="mt-2 text-3xl font-black leading-tight">The people behind the work.</h2>
+        <p className="mt-3 max-w-3xl text-sm leading-relaxed text-stone-700 md:text-base">
+          Curated Harvest storytellers (Sophie, Barry, …). Their stories, articles and media uploads roll up here so you can see at a glance who has content live and what's still drafting. Add new IDs in <code className="rounded bg-stone-200 px-1 font-mono text-[11px]">HARVEST_STORYTELLER_IDS</code> in <code className="rounded bg-stone-200 px-1 font-mono text-[11px]">server/empathyLedgerAdmin.ts</code>.
+        </p>
+      </div>
+
+      <div className="grid gap-4 p-5 sm:grid-cols-2">
+        {isLoading ? (
+          Array.from({ length: 2 }).map((_, i) => (
+            <div key={i} className="h-44 animate-pulse border border-stone-200 bg-stone-100" />
+          ))
+        ) : storytellers.length === 0 ? (
+          <div className="col-span-full border border-dashed border-stone-300 bg-stone-50 p-5 text-sm text-stone-600">
+            No curated storytellers configured.
+          </div>
+        ) : (
+          storytellers.map((s) => {
+            const elProfileUrl = s.profileId ? `https://empathyledger.com/admin/storytellers/${s.id}` : null;
+            const publishedArticles = s.articles.filter((a) => a.status === "published").length;
+            const harvestStories = s.stories.filter((st) => st.isHarvestProject).length;
+            return (
+              <article key={s.id} className="grid gap-3 border border-stone-200 bg-white p-4">
+                <header className="flex items-start gap-3">
+                  {s.avatarUrl ? (
+                    <img
+                      src={s.avatarUrl}
+                      alt={s.displayName ?? "Storyteller"}
+                      className="h-14 w-14 flex-shrink-0 rounded-full border border-stone-200 object-cover"
+                      loading="lazy"
+                    />
+                  ) : (
+                    <div className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-full border border-stone-200 bg-stone-100 text-base font-black text-stone-500">
+                      {(s.displayName ?? "?").slice(0, 1).toUpperCase()}
+                    </div>
+                  )}
+                  <div className="min-w-0">
+                    <h3 className="text-lg font-black leading-tight text-stone-900">{s.displayName ?? "(unnamed)"}</h3>
+                    <p className="mt-0.5 text-xs text-stone-500">
+                      {s.location ?? "no location"}
+                      {!s.isActive && <span className="ml-2 inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-900">inactive</span>}
+                    </p>
+                  </div>
+                </header>
+
+                {s.bio && (
+                  <p className="line-clamp-3 text-sm leading-relaxed text-stone-700">{s.bio}</p>
+                )}
+
+                <div className="flex flex-wrap gap-1.5">
+                  <TagChip label={`${s.stories.length} stories`} tone={s.stories.length > 0 ? "work" : "neutral"} />
+                  <TagChip label={`${harvestStories} Harvest-tagged`} tone={harvestStories > 0 ? "work" : "warn"} />
+                  <TagChip label={`${publishedArticles} published`} tone={publishedArticles > 0 ? "work" : "neutral"} />
+                  <TagChip label={`${s.mediaCount} uploads`} />
+                </div>
+
+                {(s.stories.length > 0 || s.articles.length > 0) && (
+                  <div className="grid gap-1 border-t border-stone-100 pt-3 text-xs text-stone-700">
+                    {s.stories.map((story) => (
+                      <p key={story.id} className="flex items-center gap-2">
+                        <span className={`inline-flex shrink-0 items-center rounded px-1.5 py-0.5 font-mono text-[9px] uppercase ${story.isPublic ? "bg-[#4A6741] text-white" : "bg-stone-200 text-stone-700"}`}>
+                          {story.isPublic ? "pub" : "draft"}
+                        </span>
+                        <span className="truncate">{story.title ?? "(no title)"}</span>
+                      </p>
+                    ))}
+                    {s.articles.map((article) => (
+                      <p key={article.id} className="flex items-center gap-2">
+                        <span className={`inline-flex shrink-0 items-center rounded px-1.5 py-0.5 font-mono text-[9px] uppercase ${article.status === "published" ? "bg-[#4A6741] text-white" : "bg-stone-200 text-stone-700"}`}>
+                          {article.status ?? "?"}
+                        </span>
+                        <span className="truncate">{article.title ?? "(no title)"}</span>
+                        {!article.isHarvestTagged && <span className="shrink-0 text-amber-700">(not Harvest-tagged)</span>}
+                      </p>
+                    ))}
+                  </div>
+                )}
+
+                {elProfileUrl && (
+                  <div className="flex flex-wrap gap-2 border-t border-stone-100 pt-3">
+                    <Button variant="outline" size="sm" asChild>
+                      <a href={elProfileUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-xs">
+                        Open in EL <ExternalLink className="h-3 w-3" />
+                      </a>
+                    </Button>
+                  </div>
+                )}
+              </article>
+            );
+          })
+        )}
+      </div>
+
+      {orphans.length > 0 && (
+        <div className="border-t border-stone-200 p-5">
+          <h3 className="text-base font-black text-stone-900">Orphaned Harvest content</h3>
+          <p className="mt-1 max-w-3xl text-sm text-stone-600">
+            Articles whose title or slug suggests Harvest content but that aren't tagged with <code className="rounded bg-stone-200 px-1 font-mono text-[11px]">primary_project="the-harvest"</code>. One click adds the tag (preserving any existing project value in <code className="rounded bg-stone-200 px-1 font-mono text-[11px]">related_projects</code>).
+          </p>
+          <div className="mt-3 grid gap-3">
+            {orphans.map((o) => (
+              <div key={o.id} className="grid gap-2 border border-amber-200 bg-amber-50 p-3 sm:grid-cols-[1fr_auto] sm:items-center">
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-stone-900">{o.title ?? "(no title)"}</p>
+                  <p className="mt-0.5 truncate font-mono text-[10px] text-stone-600">
+                    {o.slug ?? "(no slug)"} · {o.status ?? "?"} · by {o.authorName ?? "unknown"} · primary={o.primaryProject ?? "(none)"} · related={JSON.stringify(o.relatedProjects ?? [])}
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    onClick={() => tagAsHarvest.mutate({ articleId: o.id })}
+                    disabled={tagAsHarvest.isPending}
+                  >
+                    Tag as Harvest
+                  </Button>
+                  {!o.authorStorytellerId && storytellers.map((s) => (
+                    <Button
+                      key={s.id}
+                      size="sm"
+                      variant="outline"
+                      onClick={() => claimForStoryteller.mutate({ articleId: o.id, storytellerId: s.id })}
+                      disabled={claimForStoryteller.isPending}
+                    >
+                      Claim for {s.displayName?.split(" ")[0]}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </section>
   );
 }

--- a/client/src/pages/admin/MediaLibraryAdmin.tsx
+++ b/client/src/pages/admin/MediaLibraryAdmin.tsx
@@ -1179,6 +1179,10 @@ function StorytellersPanel() {
   const [creatingStoryFor, setCreatingStoryFor] = useState<string | null>(null);
   const [storyTitle, setStoryTitle] = useState("");
   const [storyContent, setStoryContent] = useState("");
+  const [editingStoryId, setEditingStoryId] = useState<string | null>(null);
+  const [editTitle, setEditTitle] = useState("");
+  const [editContent, setEditContent] = useState("");
+  const [editIsPublic, setEditIsPublic] = useState(false);
 
   useEffect(() => {
     const handle = setTimeout(() => setDebouncedQuery(searchQuery.trim()), 300);
@@ -1222,6 +1226,37 @@ function StorytellersPanel() {
       refetchAll();
     },
     onError: (e) => toast.error(`Story create failed: ${e.message}`),
+  });
+
+  const editingStoryQuery = trpc.mediaLibrary.getHarvestStory.useQuery(
+    { storyId: editingStoryId ?? "" },
+    { enabled: !!editingStoryId, staleTime: 0 },
+  );
+  // Seed edit fields once the fetch lands.
+  useEffect(() => {
+    if (editingStoryQuery.data && editingStoryQuery.data.id === editingStoryId) {
+      setEditTitle(editingStoryQuery.data.title ?? "");
+      setEditContent(editingStoryQuery.data.content ?? "");
+      setEditIsPublic(editingStoryQuery.data.isPublic);
+    }
+  }, [editingStoryQuery.data, editingStoryId]);
+
+  const updateStory = trpc.mediaLibrary.updateHarvestStory.useMutation({
+    onSuccess: (r) => {
+      toast.success(r.published ? "Story saved & public." : "Story saved as draft.");
+      setEditingStoryId(null);
+      refetchAll();
+    },
+    onError: (e) => toast.error(`Story save failed: ${e.message}`),
+  });
+
+  const deleteStory = trpc.mediaLibrary.deleteHarvestStory.useMutation({
+    onSuccess: () => {
+      toast.success("Story deleted.");
+      setEditingStoryId(null);
+      refetchAll();
+    },
+    onError: (e) => toast.error(`Delete failed: ${e.message}`),
   });
 
   const tagAsHarvest = trpc.mediaLibrary.tagArticleAsHarvest.useMutation({
@@ -1414,14 +1449,90 @@ function StorytellersPanel() {
 
                 {(s.stories.length > 0 || s.articles.length > 0 || s.transcripts.length > 0) && (
                   <div className="grid gap-1 border-t border-stone-100 pt-3 text-xs text-stone-700">
-                    {s.stories.map((story) => (
-                      <p key={story.id} className="flex items-center gap-2">
-                        <span className={`inline-flex shrink-0 items-center rounded px-1.5 py-0.5 font-mono text-[9px] uppercase ${story.isPublic ? "bg-[#4A6741] text-white" : "bg-stone-200 text-stone-700"}`}>
-                          {story.isPublic ? "pub" : "draft"}
-                        </span>
-                        <span className="truncate">{story.title ?? "(no title)"}</span>
-                      </p>
-                    ))}
+                    {s.stories.map((story) => {
+                      const isEditing = editingStoryId === story.id;
+                      if (isEditing) {
+                        const isLoading = editingStoryQuery.isLoading || editingStoryQuery.data?.id !== story.id;
+                        return (
+                          <div key={story.id} className="grid gap-2 border border-[#C4922A] bg-[#C4922A]/8 p-3">
+                            <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-[#8B4A2A]">edit story · id {story.id.slice(0, 8)}…</p>
+                            {isLoading ? (
+                              <p className="text-xs text-stone-600">Loading content…</p>
+                            ) : (
+                              <>
+                                <Input
+                                  value={editTitle}
+                                  onChange={(e) => setEditTitle(e.target.value)}
+                                  placeholder="Story title"
+                                  maxLength={255}
+                                />
+                                <textarea
+                                  value={editContent}
+                                  onChange={(e) => setEditContent(e.target.value)}
+                                  rows={10}
+                                  maxLength={50000}
+                                  className="w-full resize-y border border-stone-300 bg-white p-2 text-sm leading-relaxed text-stone-800"
+                                />
+                                <label className="flex items-center gap-2 text-xs text-stone-700">
+                                  <input
+                                    type="checkbox"
+                                    checked={editIsPublic}
+                                    onChange={(e) => setEditIsPublic(e.target.checked)}
+                                  />
+                                  <span>Public (is_public + privacy_level=public)</span>
+                                </label>
+                                <div className="flex flex-wrap items-center gap-2">
+                                  <Button
+                                    size="sm"
+                                    onClick={() => updateStory.mutate({
+                                      storyId: story.id,
+                                      title: editTitle,
+                                      content: editContent,
+                                      isPublic: editIsPublic,
+                                    })}
+                                    disabled={updateStory.isPending || !editTitle.trim() || !editContent.trim()}
+                                  >
+                                    {updateStory.isPending ? "Saving…" : "Save"}
+                                  </Button>
+                                  <Button size="sm" variant="outline" onClick={() => setEditingStoryId(null)}>
+                                    Cancel
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => {
+                                      if (window.confirm(`Delete story "${editTitle}"? This cannot be undone.`)) {
+                                        deleteStory.mutate({ storyId: story.id });
+                                      }
+                                    }}
+                                    disabled={deleteStory.isPending}
+                                    className="border-red-300 text-red-700 hover:bg-red-50"
+                                  >
+                                    {deleteStory.isPending ? "Deleting…" : "Delete"}
+                                  </Button>
+                                  <span className="text-[10px] text-stone-500">{editContent.length} / 50000</span>
+                                </div>
+                              </>
+                            )}
+                          </div>
+                        );
+                      }
+                      return (
+                        <div key={story.id} className="flex items-center gap-2">
+                          <span className={`inline-flex shrink-0 items-center rounded px-1.5 py-0.5 font-mono text-[9px] uppercase ${story.isPublic ? "bg-[#4A6741] text-white" : "bg-stone-200 text-stone-700"}`}>
+                            {story.isPublic ? "pub" : "draft"}
+                          </span>
+                          <span className="min-w-0 flex-1 truncate">{story.title ?? "(no title)"}</span>
+                          <button
+                            type="button"
+                            onClick={() => setEditingStoryId(story.id)}
+                            className="shrink-0 px-1.5 py-0.5 font-mono text-[9px] uppercase text-stone-500 hover:bg-stone-100 hover:text-stone-900"
+                          >
+                            edit
+                          </button>
+                        </div>
+                      );
+                    })}
                     {s.articles.map((article) => (
                       <p key={article.id} className="flex items-center gap-2">
                         <span className={`inline-flex shrink-0 items-center rounded px-1.5 py-0.5 font-mono text-[9px] uppercase ${article.status === "published" ? "bg-[#4A6741] text-white" : "bg-stone-200 text-stone-700"}`}>

--- a/client/src/pages/admin/MediaLibraryAdmin.tsx
+++ b/client/src/pages/admin/MediaLibraryAdmin.tsx
@@ -480,6 +480,35 @@ export default function MediaLibraryAdmin() {
     staleTime: 60 * 1000,
   });
 
+  // Photo→storyteller attribution map for showing chips on each photo card.
+  // Same query key as StorytellersPanel so React Query dedupes.
+  const photoAttributionsQuery = trpc.mediaLibrary.harvestMediaForAttribution.useQuery(
+    { limit: 500, work: null },
+    { enabled: isAuthenticated && user?.role === "admin", staleTime: 60_000 },
+  );
+  const harvestStorytellersForChipsQuery = trpc.mediaLibrary.harvestStorytellers.useQuery(
+    undefined,
+    { enabled: isAuthenticated && user?.role === "admin", staleTime: 60_000 },
+  );
+  const storytellerSlugsByMediaId = useMemo(() => {
+    const nameMap = new Map<string, { displayName: string }>();
+    for (const s of harvestStorytellersForChipsQuery.data ?? []) {
+      nameMap.set(s.id, { displayName: s.displayName ?? "(unnamed)" });
+    }
+    const map = new Map<string, Array<{ id: string; displayName: string }>>();
+    for (const p of photoAttributionsQuery.data ?? []) {
+      if (p.taggedStorytellerIds.length === 0) continue;
+      map.set(
+        p.id,
+        p.taggedStorytellerIds.map((id: string) => ({
+          id,
+          displayName: nameMap.get(id)?.displayName ?? id.slice(0, 8),
+        })),
+      );
+    }
+    return map;
+  }, [photoAttributionsQuery.data, harvestStorytellersForChipsQuery.data]);
+
   const media = useMemo(() => {
     const first = (firstPage.data?.media ?? []) as AdminMediaAsset[];
     const second = (secondPage.data?.media ?? []) as AdminMediaAsset[];
@@ -640,6 +669,7 @@ export default function MediaLibraryAdmin() {
           onSelectFiltered={selectFilteredMedia}
           onClearSelected={clearSelectedMedia}
           pageUsesByAsset={pageUsesByAsset}
+          storytellerSlugsByMediaId={storytellerSlugsByMediaId}
         />
 
         <div className="mt-8 grid gap-6 lg:grid-cols-[1.25fr_0.75fr]">
@@ -1184,6 +1214,7 @@ function StorytellersPanel() {
   const [editContent, setEditContent] = useState("");
   const [editIsPublic, setEditIsPublic] = useState(false);
   const [taggingPhotosFor, setTaggingPhotosFor] = useState<string | null>(null);
+  const [photoPickerWork, setPhotoPickerWork] = useState<string | null>(null);
 
   useEffect(() => {
     const handle = setTimeout(() => setDebouncedQuery(searchQuery.trim()), 300);
@@ -1261,9 +1292,12 @@ function StorytellersPanel() {
   });
 
   const photosForAttribution = trpc.mediaLibrary.harvestMediaForAttribution.useQuery(
-    { limit: 200 },
+    { limit: 200, work: photoPickerWork ?? undefined },
     { enabled: !!taggingPhotosFor, staleTime: 30_000 },
   );
+
+  // (storyteller-chip lookup lives in MediaLibraryAdmin scope and is shared
+  // across this panel + AllMediaWorkbench via React Query's dedupe.)
   const tagMediaMutation = trpc.mediaLibrary.tagMediaWithStorytellers.useMutation({
     onSuccess: () => {
       photosForAttribution.refetch();
@@ -1605,6 +1639,30 @@ function StorytellersPanel() {
                     <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-[#8B4A2A]">
                       tag photos · click to attach/detach {s.displayName?.split(" ")[0]}
                     </p>
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      <span className="font-mono text-[10px] uppercase text-stone-500">filter by work:</span>
+                      {[
+                        { slug: null as string | null, label: "all" },
+                        { slug: "milk-crate-pavilion", label: "pavilion" },
+                        { slug: "the-cedar", label: "cedar" },
+                        { slug: "the-garden", label: "garden" },
+                        { slug: "the-sauna", label: "sauna" },
+                        { slug: "the-shop", label: "shop" },
+                      ].map((w) => (
+                        <button
+                          key={w.slug ?? "all"}
+                          type="button"
+                          onClick={() => setPhotoPickerWork(w.slug)}
+                          className={`px-2 py-1 text-[10px] font-mono uppercase border transition ${
+                            photoPickerWork === w.slug
+                              ? "border-[#4A6741] bg-[#4A6741] text-white"
+                              : "border-stone-300 bg-white text-stone-600 hover:border-stone-500"
+                          }`}
+                        >
+                          {w.label}
+                        </button>
+                      ))}
+                    </div>
                     {photosForAttribution.isLoading ? (
                       <p className="text-xs text-stone-600">Loading recent Harvest photos…</p>
                     ) : (
@@ -1761,6 +1819,7 @@ function AllMediaWorkbench({
   onSelectFiltered,
   onClearSelected,
   pageUsesByAsset,
+  storytellerSlugsByMediaId,
 }: {
   media: AdminMediaAsset[];
   filteredMedia: AdminMediaAsset[];
@@ -1783,6 +1842,7 @@ function AllMediaWorkbench({
   onSelectFiltered: () => void;
   onClearSelected: () => void;
   pageUsesByAsset: Map<string, AssetPageUse[]>;
+  storytellerSlugsByMediaId: Map<string, Array<{ id: string; displayName: string }>>;
 }) {
   const [tagMode, setTagMode] = useState<TagMode>("replace");
   const [extraTag, setExtraTag] = useState("");
@@ -1941,6 +2001,7 @@ function AllMediaWorkbench({
               item={item}
               selected={selectedMediaIds.includes(item.id)}
               pageUses={pageUsesByAsset.get(item.id) ?? []}
+              storytellers={storytellerSlugsByMediaId.get(item.id) ?? []}
               onToggleSelected={() => onToggleSelected(item.id)}
             />
           ))
@@ -1983,11 +2044,13 @@ function MediaLibraryCard({
   item,
   selected,
   pageUses,
+  storytellers,
   onToggleSelected,
 }: {
   item: AdminMediaAsset;
   selected: boolean;
   pageUses: AssetPageUse[];
+  storytellers: Array<{ id: string; displayName: string }>;
   onToggleSelected: () => void;
 }) {
   const video = isVideoAsset(item.src);
@@ -2032,6 +2095,16 @@ function MediaLibraryCard({
           {item.themes?.map((theme) => <TagChip key={theme} label={theme} />)}
           {item.category && <TagChip label={item.category} />}
         </div>
+        {storytellers.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1">
+            <span className="font-mono text-[9px] uppercase text-stone-400 self-center">depicts:</span>
+            {storytellers.map((st) => (
+              <span key={st.id} className="inline-flex items-center rounded-full bg-[#4A6741]/15 px-2 py-0.5 text-[10px] font-semibold text-[#4A6741]">
+                {st.displayName.split(" ")[0]}
+              </span>
+            ))}
+          </div>
+        )}
         <PageUseChips uses={pageUses} />
       </div>
     </article>

--- a/client/src/pages/admin/MediaLibraryAdmin.tsx
+++ b/client/src/pages/admin/MediaLibraryAdmin.tsx
@@ -1183,6 +1183,7 @@ function StorytellersPanel() {
   const [editTitle, setEditTitle] = useState("");
   const [editContent, setEditContent] = useState("");
   const [editIsPublic, setEditIsPublic] = useState(false);
+  const [taggingPhotosFor, setTaggingPhotosFor] = useState<string | null>(null);
 
   useEffect(() => {
     const handle = setTimeout(() => setDebouncedQuery(searchQuery.trim()), 300);
@@ -1257,6 +1258,17 @@ function StorytellersPanel() {
       refetchAll();
     },
     onError: (e) => toast.error(`Delete failed: ${e.message}`),
+  });
+
+  const photosForAttribution = trpc.mediaLibrary.harvestMediaForAttribution.useQuery(
+    { limit: 200 },
+    { enabled: !!taggingPhotosFor, staleTime: 30_000 },
+  );
+  const tagMediaMutation = trpc.mediaLibrary.tagMediaWithStorytellers.useMutation({
+    onSuccess: () => {
+      photosForAttribution.refetch();
+    },
+    onError: (e) => toast.error(`Tag failed: ${e.message}`),
   });
 
   const tagAsHarvest = trpc.mediaLibrary.tagArticleAsHarvest.useMutation({
@@ -1579,7 +1591,66 @@ function StorytellersPanel() {
                       + Story
                     </Button>
                   )}
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setTaggingPhotosFor(taggingPhotosFor === s.id ? null : s.id)}
+                  >
+                    {taggingPhotosFor === s.id ? "Close photos" : "+ Tag photos"}
+                  </Button>
                 </div>
+
+                {taggingPhotosFor === s.id && (
+                  <div className="grid gap-3 border-t border-[#C4922A] bg-[#C4922A]/8 p-3">
+                    <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-[#8B4A2A]">
+                      tag photos · click to attach/detach {s.displayName?.split(" ")[0]}
+                    </p>
+                    {photosForAttribution.isLoading ? (
+                      <p className="text-xs text-stone-600">Loading recent Harvest photos…</p>
+                    ) : (
+                      <div className="grid grid-cols-3 gap-1.5 sm:grid-cols-4 lg:grid-cols-5 max-h-96 overflow-y-auto">
+                        {(photosForAttribution.data ?? []).map((photo) => {
+                          const isTagged = photo.taggedStorytellerIds.includes(s.id);
+                          return (
+                            <button
+                              key={photo.id}
+                              type="button"
+                              disabled={tagMediaMutation.isPending}
+                              onClick={() => tagMediaMutation.mutate({
+                                mediaIds: [photo.id],
+                                storytellerIds: isTagged
+                                  ? photo.taggedStorytellerIds.filter((id: string) => id !== s.id)
+                                  : [...photo.taggedStorytellerIds, s.id],
+                                mode: "replace",
+                              })}
+                              className={`relative aspect-square overflow-hidden border-2 transition ${
+                                isTagged ? "border-[#4A6741] ring-2 ring-[#4A6741]/30" : "border-stone-200 hover:border-[#C4922A]"
+                              }`}
+                              title={photo.originalFilename ?? photo.id}
+                            >
+                              {(photo.thumbnailUrl || photo.cdnUrl) ? (
+                                <img
+                                  src={photo.thumbnailUrl ?? photo.cdnUrl ?? ""}
+                                  alt={photo.originalFilename ?? "Harvest photo"}
+                                  loading="lazy"
+                                  className="h-full w-full object-cover"
+                                />
+                              ) : (
+                                <div className="flex h-full w-full items-center justify-center bg-stone-100 text-[10px] text-stone-500">no preview</div>
+                              )}
+                              {isTagged && (
+                                <span className="absolute right-1 top-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-[#4A6741] text-[10px] font-bold text-white">✓</span>
+                              )}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    )}
+                    <p className="text-[10px] text-stone-500">
+                      Showing the {photosForAttribution.data?.length ?? 0} most recent Harvest photos. Tagged photos surface on /people/{s.displayName?.toLowerCase().replace(/\s+/g, "-")} under "Moments".
+                    </p>
+                  </div>
+                )}
 
                 {creatingStoryFor === s.id && (
                   <div className="grid gap-2 border-t border-[#C4922A] bg-[#C4922A]/8 p-3">

--- a/client/src/pages/admin/MediaLibraryAdmin.tsx
+++ b/client/src/pages/admin/MediaLibraryAdmin.tsx
@@ -1215,6 +1215,16 @@ function StorytellersPanel() {
   const [editIsPublic, setEditIsPublic] = useState(false);
   const [taggingPhotosFor, setTaggingPhotosFor] = useState<string | null>(null);
   const [photoPickerWork, setPhotoPickerWork] = useState<string | null>(null);
+  const [creatingArticleFor, setCreatingArticleFor] = useState<string | null>(null);
+  const [articleTitle, setArticleTitle] = useState("");
+  const [articleContent, setArticleContent] = useState("");
+  const [articleExcerpt, setArticleExcerpt] = useState("");
+  const [articlePublish, setArticlePublish] = useState(false);
+  const [editingArticleId, setEditingArticleId] = useState<string | null>(null);
+  const [editArticleTitle, setEditArticleTitle] = useState("");
+  const [editArticleContent, setEditArticleContent] = useState("");
+  const [editArticleExcerpt, setEditArticleExcerpt] = useState("");
+  const [editArticlePublish, setEditArticlePublish] = useState(false);
 
   useEffect(() => {
     const handle = setTimeout(() => setDebouncedQuery(searchQuery.trim()), 300);
@@ -1303,6 +1313,50 @@ function StorytellersPanel() {
       photosForAttribution.refetch();
     },
     onError: (e) => toast.error(`Tag failed: ${e.message}`),
+  });
+
+  const createArticle = trpc.mediaLibrary.createHarvestArticle.useMutation({
+    onSuccess: (r) => {
+      toast.success(`Article ${articlePublish ? "published" : "saved as draft"} (${r.slug}).`);
+      setCreatingArticleFor(null);
+      setArticleTitle("");
+      setArticleContent("");
+      setArticleExcerpt("");
+      setArticlePublish(false);
+      refetchAll();
+    },
+    onError: (e) => toast.error(`Article create failed: ${e.message}`),
+  });
+
+  const editingArticleQuery = trpc.mediaLibrary.getHarvestArticle.useQuery(
+    { articleId: editingArticleId ?? "" },
+    { enabled: !!editingArticleId, staleTime: 0 },
+  );
+  useEffect(() => {
+    if (editingArticleQuery.data && editingArticleQuery.data.id === editingArticleId) {
+      setEditArticleTitle(editingArticleQuery.data.title ?? "");
+      setEditArticleContent(editingArticleQuery.data.content ?? "");
+      setEditArticleExcerpt(editingArticleQuery.data.excerpt ?? "");
+      setEditArticlePublish(editingArticleQuery.data.status === "published");
+    }
+  }, [editingArticleQuery.data, editingArticleId]);
+
+  const updateArticle = trpc.mediaLibrary.updateHarvestArticle.useMutation({
+    onSuccess: (r) => {
+      toast.success(r.published ? "Article saved & public." : "Article saved as draft.");
+      setEditingArticleId(null);
+      refetchAll();
+    },
+    onError: (e) => toast.error(`Article save failed: ${e.message}`),
+  });
+
+  const deleteArticle = trpc.mediaLibrary.deleteHarvestArticle.useMutation({
+    onSuccess: () => {
+      toast.success("Article deleted.");
+      setEditingArticleId(null);
+      refetchAll();
+    },
+    onError: (e) => toast.error(`Delete failed: ${e.message}`),
   });
 
   const tagAsHarvest = trpc.mediaLibrary.tagArticleAsHarvest.useMutation({
@@ -1579,15 +1633,80 @@ function StorytellersPanel() {
                         </div>
                       );
                     })}
-                    {s.articles.map((article) => (
-                      <p key={article.id} className="flex items-center gap-2">
-                        <span className={`inline-flex shrink-0 items-center rounded px-1.5 py-0.5 font-mono text-[9px] uppercase ${article.status === "published" ? "bg-[#4A6741] text-white" : "bg-stone-200 text-stone-700"}`}>
-                          {article.status ?? "?"}
-                        </span>
-                        <span className="truncate">{article.title ?? "(no title)"}</span>
-                        {!article.isHarvestTagged && <span className="shrink-0 text-amber-700">(not Harvest-tagged)</span>}
-                      </p>
-                    ))}
+                    {s.articles.map((article) => {
+                      const isEditing = editingArticleId === article.id;
+                      if (isEditing) {
+                        const isLoading = editingArticleQuery.isLoading || editingArticleQuery.data?.id !== article.id;
+                        return (
+                          <div key={article.id} className="grid gap-2 border border-[#8B4A2A] bg-[#8B4A2A]/8 p-3">
+                            <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-[#8B4A2A]">edit article · slug {editingArticleQuery.data?.slug ?? article.slug ?? "—"}</p>
+                            {isLoading ? (
+                              <p className="text-xs text-stone-600">Loading content…</p>
+                            ) : (
+                              <>
+                                <Input value={editArticleTitle} onChange={(e) => setEditArticleTitle(e.target.value)} placeholder="Title" maxLength={255} />
+                                <Input value={editArticleExcerpt} onChange={(e) => setEditArticleExcerpt(e.target.value)} placeholder="Excerpt" maxLength={500} />
+                                <textarea
+                                  value={editArticleContent}
+                                  onChange={(e) => setEditArticleContent(e.target.value)}
+                                  rows={12}
+                                  maxLength={100000}
+                                  className="w-full resize-y border border-stone-300 bg-white p-2 text-sm leading-relaxed text-stone-800"
+                                />
+                                <label className="flex items-center gap-2 text-xs text-stone-700">
+                                  <input type="checkbox" checked={editArticlePublish} onChange={(e) => setEditArticlePublish(e.target.checked)} />
+                                  <span>Published</span>
+                                </label>
+                                <div className="flex flex-wrap items-center gap-2">
+                                  <Button
+                                    size="sm"
+                                    onClick={() => updateArticle.mutate({
+                                      articleId: article.id,
+                                      title: editArticleTitle,
+                                      content: editArticleContent,
+                                      excerpt: editArticleExcerpt,
+                                      status: editArticlePublish ? "published" : "draft",
+                                    })}
+                                    disabled={updateArticle.isPending || !editArticleTitle.trim() || !editArticleContent.trim()}
+                                  >
+                                    {updateArticle.isPending ? "Saving…" : "Save"}
+                                  </Button>
+                                  <Button size="sm" variant="outline" onClick={() => setEditingArticleId(null)}>Cancel</Button>
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => {
+                                      if (window.confirm(`Delete article "${editArticleTitle}"?`)) deleteArticle.mutate({ articleId: article.id });
+                                    }}
+                                    disabled={deleteArticle.isPending}
+                                    className="border-red-300 text-red-700 hover:bg-red-50"
+                                  >
+                                    {deleteArticle.isPending ? "Deleting…" : "Delete"}
+                                  </Button>
+                                  <span className="text-[10px] text-stone-500">{editArticleContent.length} / 100000</span>
+                                </div>
+                              </>
+                            )}
+                          </div>
+                        );
+                      }
+                      return (
+                        <div key={article.id} className="flex items-center gap-2">
+                          <span className={`inline-flex shrink-0 items-center rounded px-1.5 py-0.5 font-mono text-[9px] uppercase ${article.status === "published" ? "bg-[#4A6741] text-white" : "bg-stone-200 text-stone-700"}`}>
+                            {article.status ?? "?"}
+                          </span>
+                          <span className="min-w-0 flex-1 truncate">{article.title ?? "(no title)"}</span>
+                          {!article.isHarvestTagged && <span className="shrink-0 text-amber-700">(not Harvest)</span>}
+                          <button
+                            type="button"
+                            onClick={() => setEditingArticleId(article.id)}
+                            className="shrink-0 px-1.5 py-0.5 font-mono text-[9px] uppercase text-stone-500 hover:bg-stone-100 hover:text-stone-900"
+                          >
+                            edit
+                          </button>
+                        </div>
+                      );
+                    })}
                     {s.transcripts.map((tr) => (
                       <p key={tr.id} className="flex items-center gap-2">
                         <span className="inline-flex shrink-0 items-center rounded bg-[#8B4A2A]/15 px-1.5 py-0.5 font-mono text-[9px] uppercase text-[#8B4A2A]">
@@ -1625,6 +1744,14 @@ function StorytellersPanel() {
                       + Story
                     </Button>
                   )}
+                  {creatingArticleFor !== s.id && (
+                    <Button
+                      size="sm"
+                      onClick={() => { setCreatingArticleFor(s.id); setArticleTitle(""); setArticleContent(""); setArticleExcerpt(""); setArticlePublish(false); }}
+                    >
+                      + Article
+                    </Button>
+                  )}
                   <Button
                     size="sm"
                     variant="outline"
@@ -1633,6 +1760,60 @@ function StorytellersPanel() {
                     {taggingPhotosFor === s.id ? "Close photos" : "+ Tag photos"}
                   </Button>
                 </div>
+
+                {creatingArticleFor === s.id && (
+                  <div className="grid gap-2 border-t border-[#8B4A2A] bg-[#8B4A2A]/8 p-3">
+                    <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-[#8B4A2A]">new article · author: {s.displayName}</p>
+                    <Input
+                      value={articleTitle}
+                      onChange={(e) => setArticleTitle(e.target.value)}
+                      placeholder="Article title"
+                      maxLength={255}
+                    />
+                    <Input
+                      value={articleExcerpt}
+                      onChange={(e) => setArticleExcerpt(e.target.value)}
+                      placeholder="Excerpt / dek (optional, ≤500 chars)"
+                      maxLength={500}
+                    />
+                    <textarea
+                      value={articleContent}
+                      onChange={(e) => setArticleContent(e.target.value)}
+                      rows={10}
+                      placeholder="Article body (markdown ok)…"
+                      maxLength={100000}
+                      className="w-full resize-y border border-stone-300 bg-white p-2 text-sm leading-relaxed text-stone-800"
+                    />
+                    <label className="flex items-center gap-2 text-xs text-stone-700">
+                      <input
+                        type="checkbox"
+                        checked={articlePublish}
+                        onChange={(e) => setArticlePublish(e.target.checked)}
+                      />
+                      <span>Publish immediately (otherwise save as draft)</span>
+                    </label>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Button
+                        size="sm"
+                        onClick={() => createArticle.mutate({
+                          title: articleTitle,
+                          content: articleContent,
+                          excerpt: articleExcerpt || undefined,
+                          authorStorytellerId: s.id,
+                          status: articlePublish ? "published" : "draft",
+                          articleType: "story_feature",
+                        })}
+                        disabled={createArticle.isPending || !articleTitle.trim() || !articleContent.trim()}
+                      >
+                        {createArticle.isPending ? "Saving…" : (articlePublish ? "Publish" : "Save draft")}
+                      </Button>
+                      <Button size="sm" variant="outline" onClick={() => { setCreatingArticleFor(null); setArticleTitle(""); setArticleContent(""); setArticleExcerpt(""); setArticlePublish(false); }}>
+                        Cancel
+                      </Button>
+                      <span className="text-[10px] text-stone-500">primary_project=harvest · slug auto-generated · type=story_feature</span>
+                    </div>
+                  </div>
+                )}
 
                 {taggingPhotosFor === s.id && (
                   <div className="grid gap-3 border-t border-[#C4922A] bg-[#C4922A]/8 p-3">

--- a/client/src/pages/admin/MediaLibraryAdmin.tsx
+++ b/client/src/pages/admin/MediaLibraryAdmin.tsx
@@ -1,0 +1,1732 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  ArrowLeft,
+  Camera,
+  Check,
+  CheckCircle2,
+  CheckSquare,
+  ExternalLink,
+  FileUp,
+  Film,
+  FileVideo,
+  Image as ImageIcon,
+  Images,
+  Link2,
+  Loader2,
+  LogIn,
+  MapPinned,
+  Plus,
+  RefreshCw,
+  Replace,
+  Search,
+  ShieldAlert,
+  Square,
+  Tags,
+  Upload,
+  Video,
+  X,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { HarvestPhotoPicker, type PickedPhoto } from "@/components/HarvestPhotoPicker";
+import { trpc } from "@/lib/trpc";
+import { optimize } from "@/lib/imageOptimize";
+import { elLinks } from "@/lib/empathyLedger";
+import { getLoginUrl } from "@/const";
+import { useAuth } from "@/_core/hooks/useAuth";
+
+type AdminMediaAsset = {
+  id: string;
+  src: string;
+  title: string | null;
+  description: string | null;
+  altText: string | null;
+  category: string | null;
+  tags: string[];
+  themes: string[];
+  special?: string[];
+  works?: string[];
+};
+
+type HarvestRecipePayload = {
+  work: string;
+  themes: string[];
+  categories: string[];
+  title: string;
+  extraTags?: Array<{ slug: string; category: string }>;
+};
+
+type TagMode = "merge" | "replace";
+
+type ImageOverrideRow = {
+  id: number;
+  page: string;
+  slot: string;
+  mediaAssetId: string;
+  src: string;
+  altText: string | null;
+  title: string | null;
+};
+
+type AssetPageUse = {
+  label: string;
+  href: string;
+  source: "slot" | "work" | "tag";
+};
+
+type LocalVideoAsset = {
+  id: string;
+  fileName: string;
+  relativePath: string;
+  contentType: string;
+  size: number;
+  kind: "video" | "gif";
+  elStatus?: "local-only" | "synced" | "unknown";
+  elMatches?: Array<{
+    id: string;
+    title: string | null;
+    src: string | null;
+    works: string[];
+    themes: string[];
+    categories: string[];
+    tags: string[];
+    createdAt: string | null;
+  }>;
+};
+
+type MediaSet = {
+  key: string;
+  title: string;
+  description: string;
+  work: string;
+  themes: string[];
+  category: string;
+  categoryTags: string[];
+  publicUse: string;
+};
+
+type PageSlot = {
+  label: string;
+  page: string;
+  slot: string;
+  defaultWorkSlug: string;
+  publicUrl: string;
+  note: string;
+};
+
+const mediaSets: MediaSet[] = [
+  {
+    key: "garden",
+    title: "Garden now",
+    description: "Seedlings, beds, soil, shade and visible Garden progress.",
+    work: "the-garden",
+    themes: ["grow", "gather"],
+    category: "during",
+    categoryTags: ["during"],
+    publicUse: "/new-look-test#work, /works/the-garden, Garden updates",
+  },
+  {
+    key: "pavilion",
+    title: "Milk crate pavilion",
+    description: "Crates, scaffold, people making, details and the first roof.",
+    work: "milk-crate-pavilion",
+    themes: ["make", "gather"],
+    category: "during or milestone",
+    categoryTags: ["during", "milestone"],
+    publicUse: "/new-look-test#work, /works/milk-crate-pavilion, event updates",
+  },
+  {
+    key: "timber",
+    title: "Timber paths",
+    description: "St Mary's timber, Barry's shed, tools, source tracing and walkway pieces.",
+    work: "the-cedar",
+    themes: ["make", "gather"],
+    category: "during",
+    categoryTags: ["during"],
+    publicUse: "/new-look-test#work, /works/the-cedar, Witta timber stories",
+  },
+  {
+    key: "shop",
+    title: "Shop and table",
+    description: "Produce shelf tests, co-op shop ideas, local food, growers and makers.",
+    work: "the-shop",
+    themes: ["eat", "gather"],
+    category: "general or during",
+    categoryTags: ["general-harvest", "during"],
+    publicUse: "/new-look-test#work, /works/the-shop, shop updates",
+  },
+];
+
+const publicSlots: PageSlot[] = [
+  {
+    label: "Garden card",
+    page: "new-look-test",
+    slot: "garden-area-card",
+    defaultWorkSlug: "the-garden",
+    publicUrl: "/new-look-test#work",
+    note: "Main Garden-first card on the test page.",
+  },
+  {
+    label: "Milk crate pavilion card",
+    page: "new-look-test",
+    slot: "milk-crate-pavilion-card",
+    defaultWorkSlug: "milk-crate-pavilion",
+    publicUrl: "/new-look-test#work",
+    note: "Card for the giant milk crate pavilion.",
+  },
+  {
+    label: "Timber walkways card",
+    page: "new-look-test",
+    slot: "timber-walkways-card",
+    defaultWorkSlug: "the-cedar",
+    publicUrl: "/new-look-test#work",
+    note: "Card for St Mary's timber and paths.",
+  },
+  {
+    label: "Shop table card",
+    page: "new-look-test",
+    slot: "co-op-shop-card",
+    defaultWorkSlug: "the-shop",
+    publicUrl: "/new-look-test#work",
+    note: "Card for the produce shelf / co-op type shop.",
+  },
+  {
+    label: "Garden work hero",
+    page: "works",
+    slot: "the-garden-hero",
+    defaultWorkSlug: "the-garden",
+    publicUrl: "/works/the-garden",
+    note: "Hero image for The Garden work page.",
+  },
+  {
+    label: "Pavilion work hero",
+    page: "works",
+    slot: "milk-crate-pavilion-hero",
+    defaultWorkSlug: "milk-crate-pavilion",
+    publicUrl: "/works/milk-crate-pavilion",
+    note: "Hero image for the pavilion work page.",
+  },
+  {
+    label: "Timber work hero",
+    page: "works",
+    slot: "the-cedar-hero",
+    defaultWorkSlug: "the-cedar",
+    publicUrl: "/works/the-cedar",
+    note: "Hero image for the timber work page.",
+  },
+  {
+    label: "Shop work hero",
+    page: "works",
+    slot: "the-shop-hero",
+    defaultWorkSlug: "the-shop",
+    publicUrl: "/works/the-shop",
+    note: "Hero image for the shop work page.",
+  },
+];
+
+const videoSources = [
+  "/images/compendium/hero-aerial.mp4",
+  "/images/compendium/oyster-lease.mp4",
+  "/images/social-tiles/milk-crates.gif",
+  "18 WhatsApp source MP4s in docs/communications/debriefs/_whatsapp-exports",
+];
+
+const workFilters = [
+  { value: "all", label: "All works" },
+  { value: "unpinned", label: "Needs work tag" },
+  ...mediaSets.map((set) => ({ value: set.work, label: set.title })),
+];
+
+const themeFilters = [
+  { value: "all", label: "All themes" },
+  { value: "grow", label: "Grow" },
+  { value: "make", label: "Make" },
+  { value: "gather", label: "Gather" },
+  { value: "eat", label: "Eat" },
+];
+
+const categoryFilters = [
+  { value: "all", label: "All categories" },
+  { value: "during", label: "During" },
+  { value: "milestone", label: "Milestone" },
+  { value: "general-harvest", label: "General" },
+  { value: "general", label: "General fallback" },
+  { value: "before", label: "Before" },
+  { value: "after", label: "After" },
+];
+
+const extraTagCategories = [
+  { value: "harvest-page", label: "Page" },
+  { value: "harvest-special", label: "Special" },
+  { value: "harvest-custom", label: "Custom" },
+];
+
+const workPageUses: Record<string, AssetPageUse[]> = {
+  "the-garden": [
+    { label: "Garden work page", href: "/works/the-garden", source: "work" },
+    { label: "New-look work grid", href: "/new-look-test#work", source: "work" },
+    { label: "Garden updates", href: "/new-look-test#updates", source: "work" },
+  ],
+  "milk-crate-pavilion": [
+    { label: "Pavilion work page", href: "/works/milk-crate-pavilion", source: "work" },
+    { label: "New-look work grid", href: "/new-look-test#work", source: "work" },
+    { label: "Event updates", href: "/new-look-test#updates", source: "work" },
+  ],
+  "the-cedar": [
+    { label: "Timber work page", href: "/works/the-cedar", source: "work" },
+    { label: "New-look work grid", href: "/new-look-test#work", source: "work" },
+  ],
+  "the-shop": [
+    { label: "Shop work page", href: "/works/the-shop", source: "work" },
+    { label: "New-look work grid", href: "/new-look-test#work", source: "work" },
+  ],
+};
+
+const pageTagUses: Record<string, AssetPageUse> = {
+  home: { label: "Home gallery", href: "/", source: "tag" },
+  stories: { label: "Stories", href: "/stories", source: "tag" },
+  updates: { label: "Updates", href: "/new-look-test#updates", source: "tag" },
+  works: { label: "Works", href: "/new-look-test#work", source: "tag" },
+  garden: { label: "Garden", href: "/works/the-garden", source: "tag" },
+};
+
+function isVideoAsset(src: string): boolean {
+  return /\.(mp4|mov|m4v|webm|gif)(\?.*)?$/i.test(src);
+}
+
+function countByWork(media: AdminMediaAsset[], work: string): number {
+  return media.filter((item) => item.works?.includes(work)).length;
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function readFileAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error(`Could not read ${file.name}`));
+    reader.onload = () => {
+      const value = String(reader.result ?? "");
+      resolve(value.includes(",") ? value.split(",")[1] : value);
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+function recipePayload(set: MediaSet, extraTags: Array<{ slug: string; category: string }> = []): HarvestRecipePayload {
+  return {
+    work: set.work,
+    themes: set.themes,
+    categories: set.categoryTags,
+    title: set.title,
+    ...(extraTags.length > 0 ? { extraTags } : {}),
+  };
+}
+
+function normaliseExtraTag(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function pageUseKey(use: AssetPageUse) {
+  return `${use.label}:${use.href}:${use.source}`;
+}
+
+function pageUsesForAsset(item: AdminMediaAsset, overrides: ImageOverrideRow[]): AssetPageUse[] {
+  const uses: AssetPageUse[] = [];
+
+  item.works?.forEach((work) => {
+    uses.push(...(workPageUses[work] ?? []));
+  });
+
+  item.tags?.forEach((tag) => {
+    const use = pageTagUses[tag];
+    if (use) uses.push(use);
+  });
+
+  overrides
+    .filter((override) => override.mediaAssetId === item.id)
+    .forEach((override) => {
+      const slot = publicSlots.find((candidate) => candidate.page === override.page && candidate.slot === override.slot);
+      uses.unshift({
+        label: slot?.label ?? `${override.page} / ${override.slot}`,
+        href: slot?.publicUrl ?? `/${override.page}`,
+        source: "slot",
+      });
+    });
+
+  const seen = new Set<string>();
+  return uses.filter((use) => {
+    const key = pageUseKey(use);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function localMotionPreviewUrl(file: LocalVideoAsset) {
+  return `/api/admin/media-library/local-motion?path=${encodeURIComponent(file.relativePath)}`;
+}
+
+function LazyVideo({
+  src,
+  className,
+  controls,
+  muted = true,
+  playsInline = true,
+}: {
+  src: string;
+  className?: string;
+  controls?: boolean;
+  muted?: boolean;
+  playsInline?: boolean;
+}) {
+  const ref = useRef<HTMLVideoElement>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node || inView) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setInView(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "300px" },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [inView]);
+
+  return (
+    <video
+      ref={ref}
+      src={inView ? src : undefined}
+      className={className}
+      controls={controls}
+      muted={muted}
+      playsInline={playsInline}
+      preload={inView ? "metadata" : "none"}
+    />
+  );
+}
+
+function isLocalVideoAlignedToRecipe(file: LocalVideoAsset, recipe: MediaSet) {
+  return (file.elMatches ?? []).some((match) => (
+    match.works.includes(recipe.work) &&
+    recipe.themes.every((theme) => match.themes.includes(theme)) &&
+    recipe.categoryTags.some((category) => match.categories.includes(category))
+  ));
+}
+
+function localVideoSyncCopy(file: LocalVideoAsset, recipe: MediaSet) {
+  if (file.elStatus === "unknown") {
+    return {
+      label: "EL status unknown",
+      detail: "Could not check Empathy Ledger right now.",
+      tone: "warn" as const,
+    };
+  }
+
+  if (!(file.elMatches ?? []).length) {
+    return {
+      label: "Local only",
+      detail: "Not synced to Empathy Ledger yet.",
+      tone: "warn" as const,
+    };
+  }
+
+  if (isLocalVideoAlignedToRecipe(file, recipe)) {
+    return {
+      label: `Aligned to ${recipe.title}`,
+      detail: "Synced in EL with this work/theme/category spine.",
+      tone: "work" as const,
+    };
+  }
+
+  return {
+    label: "Synced, needs tags",
+    detail: `In EL, but not aligned to ${recipe.title}.`,
+    tone: "neutral" as const,
+  };
+}
+
+export default function MediaLibraryAdmin() {
+  const { user, isAuthenticated, loading: authLoading } = useAuth();
+
+  const firstPage = trpc.gallery.fromEL.useQuery(
+    { limit: 100, page: 1 },
+    { enabled: isAuthenticated && user?.role === "admin", staleTime: 5 * 60 * 1000 },
+  );
+  const secondPage = trpc.gallery.fromEL.useQuery(
+    { limit: 100, page: 2 },
+    {
+      enabled: Boolean(isAuthenticated && user?.role === "admin" && firstPage.data?.pagination?.hasMore),
+      staleTime: 5 * 60 * 1000,
+    },
+  );
+  const overridesQuery = trpc.imageOverrides.list.useQuery(undefined, {
+    enabled: isAuthenticated && user?.role === "admin",
+    staleTime: 60 * 1000,
+  });
+
+  const media = useMemo(() => {
+    const first = (firstPage.data?.media ?? []) as AdminMediaAsset[];
+    const second = (secondPage.data?.media ?? []) as AdminMediaAsset[];
+    return [...first, ...second];
+  }, [firstPage.data?.media, secondPage.data?.media]);
+
+  const [mediaSearch, setMediaSearch] = useState("");
+  const [workFilter, setWorkFilter] = useState("all");
+  const [themeFilter, setThemeFilter] = useState("all");
+  const [categoryFilter, setCategoryFilter] = useState("all");
+  const [kindFilter, setKindFilter] = useState<"all" | "image" | "video">("all");
+  const [recipeKey, setRecipeKey] = useState(mediaSets[0].key);
+  const [selectedMediaIds, setSelectedMediaIds] = useState<string[]>([]);
+
+  const totalReported = firstPage.data?.pagination?.total ?? media.length;
+  const unpinned = media.filter((item) => !item.works || item.works.length === 0);
+  const videoCount = media.filter((item) => isVideoAsset(item.src)).length;
+  const selectedRecipe = mediaSets.find((set) => set.key === recipeKey) ?? mediaSets[0];
+  const selectedMedia = media.filter((item) => selectedMediaIds.includes(item.id));
+  const pageUsesByAsset = useMemo(() => {
+    const overrides = (overridesQuery.data ?? []) as ImageOverrideRow[];
+    return new Map(media.map((item) => [item.id, pageUsesForAsset(item, overrides)]));
+  }, [media, overridesQuery.data]);
+
+  const filteredMedia = useMemo(() => {
+    const needle = mediaSearch.trim().toLowerCase();
+    return media.filter((item) => {
+      const isVideo = isVideoAsset(item.src);
+      if (kindFilter === "image" && isVideo) return false;
+      if (kindFilter === "video" && !isVideo) return false;
+      if (workFilter === "unpinned" && item.works?.length) return false;
+      if (workFilter !== "all" && workFilter !== "unpinned" && !item.works?.includes(workFilter)) return false;
+      if (themeFilter !== "all" && !item.themes?.includes(themeFilter)) return false;
+      if (categoryFilter !== "all" && item.category !== categoryFilter) return false;
+      if (!needle) return true;
+
+      const haystack = [
+        item.id,
+        item.title,
+        item.description,
+        item.altText,
+        item.category,
+        ...(item.tags ?? []),
+        ...(item.themes ?? []),
+        ...(item.works ?? []),
+        ...(item.special ?? []),
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+
+      return haystack.includes(needle);
+    });
+  }, [categoryFilter, kindFilter, media, mediaSearch, themeFilter, workFilter]);
+
+  const toggleSelectedMedia = (id: string) => {
+    setSelectedMediaIds((current) =>
+      current.includes(id) ? current.filter((item) => item !== id) : [...current, id],
+    );
+  };
+
+  const selectFilteredMedia = () => {
+    const next = filteredMedia.map((item) => item.id);
+    setSelectedMediaIds(next);
+  };
+
+  const clearSelectedMedia = () => setSelectedMediaIds([]);
+
+  if (authLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-stone-100">
+        <Loader2 className="h-8 w-8 animate-spin text-stone-700" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <AdminAccessCard mode="login" />;
+  }
+
+  if (user?.role !== "admin") {
+    return <AdminAccessCard mode="denied" />;
+  }
+
+  return (
+    <main className="min-h-screen bg-[#F5F0E8] text-stone-900">
+      <header className="border-b border-stone-300 bg-[#1C1917] text-[#F5F0E8]">
+        <div className="mx-auto max-w-7xl px-5 py-8 md:px-8">
+          <a href="/admin" className="inline-flex items-center gap-2 text-sm text-white/70 hover:text-white">
+            <ArrowLeft className="h-4 w-4" />
+            Admin dashboard
+          </a>
+          <div className="mt-6 grid gap-6 lg:grid-cols-[1fr_auto] lg:items-end">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.22em] text-[#C4922A]">
+                backend media library
+              </p>
+              <h1 className="mt-3 text-4xl font-black leading-none md:text-6xl">
+                Organise photos, video and public slots.
+              </h1>
+              <p className="mt-5 max-w-3xl text-lg leading-relaxed text-white/72">
+                Empathy Ledger stays the source of truth. Use this page to see what is
+                tagged, what is missing, and which public Harvest page slots are using
+                which EL assets.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <AdminLink href={elLinks.photoManager()} label="Photo manager" />
+              <AdminLink href={elLinks.bulkEdit()} label="Bulk tag" />
+              <AdminLink href={elLinks.galleries()} label="EL galleries" />
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <section className="mx-auto max-w-7xl px-5 py-8 md:px-8 md:py-10">
+        <div className="grid gap-4 md:grid-cols-5">
+          <StatCard label="EL assets" value={String(totalReported)} detail="visible through Harvest API" />
+          <StatCard label="Garden" value={String(countByWork(media, "the-garden"))} detail="tagged the-garden" />
+          <StatCard label="Pavilion" value={String(countByWork(media, "milk-crate-pavilion"))} detail="tagged milk-crate-pavilion" />
+          <StatCard label="Unpinned" value={String(unpinned.length)} detail="needs work tag" tone={unpinned.length ? "warn" : "ok"} />
+          <StatCard label="EL video" value={String(videoCount)} detail="motion assets returned" tone={videoCount ? "ok" : "warn"} />
+        </div>
+
+        <AddMediaPanel
+          selectedRecipe={selectedRecipe}
+          recipeKey={recipeKey}
+          onRecipeChange={setRecipeKey}
+        />
+
+        <LocalVideoImportPanel
+          selectedRecipe={selectedRecipe}
+          recipeKey={recipeKey}
+          onRecipeChange={setRecipeKey}
+        />
+
+        <AllMediaWorkbench
+          media={media}
+          filteredMedia={filteredMedia}
+          selectedMedia={selectedMedia}
+          selectedMediaIds={selectedMediaIds}
+          selectedRecipe={selectedRecipe}
+          recipeKey={recipeKey}
+          mediaSearch={mediaSearch}
+          workFilter={workFilter}
+          themeFilter={themeFilter}
+          categoryFilter={categoryFilter}
+          kindFilter={kindFilter}
+          onRecipeChange={setRecipeKey}
+          onSearchChange={setMediaSearch}
+          onWorkFilterChange={setWorkFilter}
+          onThemeFilterChange={setThemeFilter}
+          onCategoryFilterChange={setCategoryFilter}
+          onKindFilterChange={setKindFilter}
+          onToggleSelected={toggleSelectedMedia}
+          onSelectFiltered={selectFilteredMedia}
+          onClearSelected={clearSelectedMedia}
+          pageUsesByAsset={pageUsesByAsset}
+        />
+
+        <div className="mt-8 grid gap-6 lg:grid-cols-[1.25fr_0.75fr]">
+          <section className="space-y-5">
+            <SectionIntro
+              eyebrow="tag sets"
+              title="Review the working media sets."
+              body="These are the tag recipes that decide where assets appear publicly. If a set reads 0, the photos may exist but need the right work/theme/category tags in Empathy Ledger."
+            />
+            <div className="grid gap-5 xl:grid-cols-2">
+              {mediaSets.map((set) => (
+                <MediaSetCard key={set.work} set={set} media={media} />
+              ))}
+            </div>
+          </section>
+
+          <aside className="space-y-5">
+            <ProcessCard />
+            <VideoPassCard />
+          </aside>
+        </div>
+
+        <section className="mt-10">
+          <SectionIntro
+            eyebrow="public placement"
+            title="Send EL assets into public page slots."
+            body="Pick a photo from Empathy Ledger for a specific public slot. The override stays linked to the EL media asset id, so we know what is being used where."
+          />
+          <div className="mt-5 grid gap-4 lg:grid-cols-2">
+            {publicSlots.map((slot) => (
+              <PublicSlotCard key={`${slot.page}-${slot.slot}`} slot={slot} />
+            ))}
+          </div>
+        </section>
+
+        <section className="mt-10">
+          <SectionIntro
+            eyebrow="needs attention"
+            title="Assets visible in EL but not pinned to a work."
+            body="These need a work tag before they can reliably appear in Garden, Works, Stories or Updates."
+          />
+          <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {firstPage.isLoading ? (
+              Array.from({ length: 4 }).map((_, index) => (
+                <div key={index} className="aspect-[4/3] animate-pulse bg-stone-200" />
+              ))
+            ) : unpinned.length === 0 ? (
+              <div className="border border-stone-300 bg-white p-5 text-sm text-stone-600">
+                Everything returned by the Harvest API has a work tag.
+              </div>
+            ) : (
+              unpinned.slice(0, 12).map((item) => <MediaThumb key={item.id} item={item} />)
+            )}
+          </div>
+        </section>
+      </section>
+    </main>
+  );
+}
+
+function AdminAccessCard({ mode }: { mode: "login" | "denied" }) {
+  const denied = mode === "denied";
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-stone-100 px-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-stone-100">
+            {denied ? <ShieldAlert className="h-7 w-7 text-red-600" /> : <LogIn className="h-7 w-7 text-stone-700" />}
+          </div>
+          <CardTitle>{denied ? "Access denied" : "Admin access required"}</CardTitle>
+          <CardDescription>
+            {denied
+              ? "You do not have permission to manage the Harvest media library."
+              : "Sign in to organise Harvest media and public page slots."}
+          </CardDescription>
+        </CardHeader>
+        <CardFooter className="justify-center">
+          <Button onClick={() => (window.location.href = denied ? "/" : getLoginUrl())}>
+            {denied ? "Return home" : "Sign in"}
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}
+
+function AdminLink({ href, label }: { href: string; label: string }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex min-h-10 items-center gap-2 border border-white/18 px-4 text-sm font-semibold text-[#F5F0E8] transition hover:bg-white/10"
+    >
+      {label}
+      <ExternalLink className="h-4 w-4" />
+    </a>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  detail,
+  tone = "neutral",
+}: {
+  label: string;
+  value: string;
+  detail: string;
+  tone?: "neutral" | "ok" | "warn";
+}) {
+  const toneClass =
+    tone === "ok" ? "border-[#4A6741]" : tone === "warn" ? "border-[#C4922A]" : "border-stone-300";
+  return (
+    <div className={`border bg-[#FFFDF7] p-4 ${toneClass}`}>
+      <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-stone-500">{label}</p>
+      <p className="mt-2 text-3xl font-black">{value}</p>
+      <p className="mt-1 text-xs leading-relaxed text-stone-600">{detail}</p>
+    </div>
+  );
+}
+
+function SectionIntro({ eyebrow, title, body }: { eyebrow: string; title: string; body: string }) {
+  return (
+    <div className="max-w-3xl">
+      <p className="font-mono text-xs uppercase tracking-[0.2em] text-[#8B4A2A]">{eyebrow}</p>
+      <h2 className="mt-2 text-3xl font-black leading-tight">{title}</h2>
+      <p className="mt-3 text-sm leading-relaxed text-stone-700 md:text-base">{body}</p>
+    </div>
+  );
+}
+
+function AddMediaPanel({
+  selectedRecipe,
+  recipeKey,
+  onRecipeChange,
+}: {
+  selectedRecipe: MediaSet;
+  recipeKey: string;
+  onRecipeChange: (key: string) => void;
+}) {
+  const [files, setFiles] = useState<File[]>([]);
+  const [lastUploaded, setLastUploaded] = useState<Array<{ id: string; fileName: string }>>([]);
+  const utils = trpc.useUtils();
+  const uploadMutation = trpc.mediaLibrary.uploadToEL.useMutation({
+    onSuccess: async (result) => {
+      await utils.gallery.fromEL.invalidate();
+      setLastUploaded(result.uploaded.map((item) => ({ id: item.id, fileName: item.fileName })));
+      if (result.uploaded.length > 0) {
+        setFiles([]);
+        toast.success(`${result.uploaded.length} file${result.uploaded.length === 1 ? "" : "s"} uploaded and tagged in EL.`);
+      }
+      if (result.failed.length > 0) {
+        toast.error(`${result.failed.length} file${result.failed.length === 1 ? "" : "s"} could not upload.`, {
+          description: result.failed.slice(0, 2).map((item) => `${item.fileName}: ${item.error}`).join("\n"),
+        });
+      }
+    },
+    onError: (error) => toast.error("Upload failed", { description: error.message }),
+  });
+  const totalSize = files.reduce((sum, file) => sum + file.size, 0);
+
+  const handleUpload = async () => {
+    if (files.length === 0) {
+      toast.error("Choose at least one file first.");
+      return;
+    }
+
+    const maxFileBytes = 35 * 1024 * 1024;
+    const oversized = files.find((file) => file.size > maxFileBytes);
+    if (oversized) {
+      toast.error(`${oversized.name} is too large for this quick uploader.`, {
+        description: "Use smaller selects here for now, or upload large originals in EL.",
+      });
+      return;
+    }
+
+    const uploadFiles = await Promise.all(
+      files.map(async (file) => ({
+        fileName: file.name,
+        contentType: file.type || "application/octet-stream",
+        base64Data: await readFileAsBase64(file),
+      })),
+    );
+
+    await uploadMutation.mutateAsync({
+      recipe: recipePayload(selectedRecipe),
+      files: uploadFiles,
+    });
+  };
+
+  return (
+    <section className="mt-8 border border-stone-300 bg-[#FFFDF7]">
+      <div className="grid gap-5 border-b border-stone-200 p-5 lg:grid-cols-[1fr_auto] lg:items-end">
+        <div>
+          <p className="font-mono text-xs uppercase tracking-[0.2em] text-[#8B4A2A]">add media</p>
+          <h2 className="mt-2 text-3xl font-black leading-tight">Upload and tag photos and video.</h2>
+          <p className="mt-3 max-w-3xl text-sm leading-relaxed text-stone-700 md:text-base">
+            Choose the files, pick the tags, then this page creates the EL assets and applies the work/theme/category tags.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" asChild>
+            <a href={elLinks.galleries()} target="_blank" rel="noopener noreferrer">
+              <Upload className="mr-2 h-4 w-4" />
+              Open EL
+            </a>
+          </Button>
+          <Button onClick={handleUpload} disabled={files.length === 0 || uploadMutation.isPending}>
+            {uploadMutation.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Upload className="mr-2 h-4 w-4" />}
+            {uploadMutation.isPending ? "Uploading..." : "Upload + tag"}
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-5 p-5 lg:grid-cols-[0.85fr_1.15fr]">
+        <label className="flex min-h-52 cursor-pointer flex-col items-center justify-center border border-dashed border-stone-300 bg-stone-50 p-6 text-center transition hover:bg-white">
+          <FileUp className="h-9 w-9 text-[#8B4A2A]" />
+          <span className="mt-3 text-lg font-black">Choose photos or video</span>
+          <span className="mt-1 text-sm text-stone-600">Images, GIFs and motion files for the Garden, works and stories.</span>
+          <input
+            className="sr-only"
+            type="file"
+            accept="image/*,video/*,.gif,.mp4,.mov,.m4v,.webm"
+            multiple
+            onChange={(event) => setFiles(Array.from(event.target.files ?? []))}
+          />
+        </label>
+
+        <div className="grid gap-4">
+          <div className="grid gap-3 md:grid-cols-[220px_1fr]">
+            <label className="text-sm font-semibold text-stone-700" htmlFor="media-recipe">
+              Tags to apply
+            </label>
+            <select
+              id="media-recipe"
+              value={recipeKey}
+              onChange={(event) => onRecipeChange(event.target.value)}
+              className="min-h-10 border border-stone-300 bg-white px-3 text-sm font-semibold text-stone-900 outline-none focus:border-[#8B4A2A]"
+            >
+              {mediaSets.map((set) => (
+                <option key={set.key} value={set.key}>
+                  {set.title}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="border border-stone-200 bg-white p-4">
+            <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-stone-500">EL tag spine</p>
+            <p className="mt-2 text-sm leading-relaxed text-stone-800">
+              <strong>{selectedRecipe.work}</strong> + {selectedRecipe.themes.join("/")} + {selectedRecipe.category}
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <TagChip label={`work:${selectedRecipe.work}`} />
+              {selectedRecipe.themes.map((theme) => <TagChip key={theme} label={`theme:${theme}`} />)}
+              {selectedRecipe.categoryTags.map((category) => <TagChip key={category} label={`category:${category}`} />)}
+            </div>
+          </div>
+
+          {files.length > 0 ? (
+            <div className="border border-stone-200 bg-white p-4">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <p className="text-sm font-black">
+                  {files.length} file{files.length === 1 ? "" : "s"} staged · {formatFileSize(totalSize)}
+                </p>
+                <Button size="sm" variant="outline" onClick={() => setFiles([])}>
+                  <X className="mr-2 h-4 w-4" />
+                  Clear
+                </Button>
+              </div>
+              <ul className="mt-3 grid gap-2 text-xs text-stone-600 sm:grid-cols-2">
+                {files.slice(0, 8).map((file) => (
+                  <li key={`${file.name}-${file.size}`} className="border-t border-stone-200 pt-2">
+                    <span className="font-semibold text-stone-800">{file.name}</span>
+                    <br />
+                    {file.type || "unknown type"} · {formatFileSize(file.size)}
+                  </li>
+                ))}
+              </ul>
+              {files.length > 8 && (
+                <p className="mt-3 text-xs text-stone-500">+ {files.length - 8} more files</p>
+              )}
+            </div>
+          ) : (
+            <div className="border border-stone-200 bg-white p-4 text-sm leading-relaxed text-stone-600">
+              No files staged yet. Use this for the next Garden batch, timber path evidence, shop tests and video selects.
+            </div>
+          )}
+
+          {lastUploaded.length > 0 && (
+            <div className="border border-[#4A6741]/35 bg-[#4A6741]/10 p-4 text-sm leading-relaxed text-[#2F472B]">
+              <p className="font-black">Last upload created {lastUploaded.length} EL asset{lastUploaded.length === 1 ? "" : "s"}.</p>
+              <ul className="mt-2 grid gap-1 text-xs">
+                {lastUploaded.slice(0, 6).map((item) => (
+                  <li key={item.id}>
+                    <span className="font-semibold">{item.fileName}</span> · <code>{item.id}</code>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function LocalVideoImportPanel({
+  selectedRecipe,
+  recipeKey,
+  onRecipeChange,
+}: {
+  selectedRecipe: MediaSet;
+  recipeKey: string;
+  onRecipeChange: (key: string) => void;
+}) {
+  const [selectedPaths, setSelectedPaths] = useState<string[]>([]);
+  const localVideosQuery = trpc.mediaLibrary.localVideos.useQuery(undefined, { staleTime: 60 * 1000 });
+  const utils = trpc.useUtils();
+  const importMutation = trpc.mediaLibrary.importLocalVideos.useMutation({
+    onSuccess: async (result) => {
+      await Promise.all([
+        utils.gallery.fromEL.invalidate(),
+        utils.mediaLibrary.localVideos.invalidate(),
+      ]);
+      setSelectedPaths([]);
+      if (result.uploaded.length > 0) {
+        toast.success(`${result.uploaded.length} motion file${result.uploaded.length === 1 ? "" : "s"} imported to EL.`);
+      }
+      if (result.failed.length > 0) {
+        toast.error(`${result.failed.length} motion file${result.failed.length === 1 ? "" : "s"} could not import.`, {
+          description: result.failed.slice(0, 2).map((item) => `${item.fileName}: ${item.error}`).join("\n"),
+        });
+      }
+    },
+    onError: (error) => toast.error("Video import failed", { description: error.message }),
+  });
+
+  const files = (localVideosQuery.data ?? []) as LocalVideoAsset[];
+  const selectedFiles = files.filter((file) => selectedPaths.includes(file.relativePath));
+  const selectedSize = selectedFiles.reduce((sum, file) => sum + file.size, 0);
+  const syncedCount = files.filter((file) => (file.elMatches ?? []).length > 0).length;
+  const localOnlyCount = files.length - syncedCount;
+  const alignedCount = files.filter((file) => isLocalVideoAlignedToRecipe(file, selectedRecipe)).length;
+
+  const togglePath = (path: string) => {
+    setSelectedPaths((current) => (
+      current.includes(path) ? current.filter((item) => item !== path) : [...current, path]
+    ));
+  };
+
+  const selectLocalOnly = () => setSelectedPaths(files.filter((file) => !(file.elMatches ?? []).length).map((file) => file.relativePath));
+  const clear = () => setSelectedPaths([]);
+
+  const importSelected = async () => {
+    if (selectedPaths.length === 0) {
+      toast.error("Select at least one local video first.");
+      return;
+    }
+
+    await importMutation.mutateAsync({
+      paths: selectedPaths,
+      recipe: recipePayload(selectedRecipe),
+    });
+  };
+
+  return (
+    <section className="mt-8 border border-stone-300 bg-[#FFFDF7]">
+      <div className="grid gap-5 border-b border-stone-200 p-5 lg:grid-cols-[1fr_auto] lg:items-end">
+        <div>
+          <p className="font-mono text-xs uppercase tracking-[0.2em] text-[#8B4A2A]">codebase video</p>
+          <h2 className="mt-2 text-3xl font-black leading-tight">Import existing motion files into EL.</h2>
+          <p className="mt-3 max-w-3xl text-sm leading-relaxed text-stone-700 md:text-base">
+            These are the MP4 and GIF files already in the site repo, excluding archived WhatsApp duplicates. Pick the right tag set, import selected files into the Harvest EL gallery, then run another batch for a different work area.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" onClick={() => localVideosQuery.refetch()} disabled={localVideosQuery.isFetching}>
+            <RefreshCw className={`mr-2 h-4 w-4 ${localVideosQuery.isFetching ? "animate-spin" : ""}`} />
+            Rescan
+          </Button>
+          <Button onClick={importSelected} disabled={selectedPaths.length === 0 || importMutation.isPending}>
+            {importMutation.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <FileVideo className="mr-2 h-4 w-4" />}
+            {importMutation.isPending ? "Importing..." : "Import selected"}
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-5 p-5 lg:grid-cols-[280px_1fr]">
+        <div className="space-y-4">
+          <FilterSelect
+            label="Tags to apply"
+            value={recipeKey}
+            options={mediaSets.map((set) => ({ value: set.key, label: set.title }))}
+            onChange={onRecipeChange}
+          />
+          <div className="border border-stone-200 bg-white p-4">
+            <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-stone-500">selected</p>
+            <p className="mt-2 text-2xl font-black">{selectedPaths.length} of {files.length}</p>
+            <p className="mt-1 text-xs text-stone-600">{formatFileSize(selectedSize)} selected</p>
+            <div className="mt-3 grid grid-cols-3 gap-2 text-center">
+              <div className="border border-stone-200 bg-stone-50 p-2">
+                <p className="text-lg font-black">{localOnlyCount}</p>
+                <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-stone-500">local</p>
+              </div>
+              <div className="border border-[#4A6741]/25 bg-[#4A6741]/8 p-2">
+                <p className="text-lg font-black">{syncedCount}</p>
+                <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-stone-500">in EL</p>
+              </div>
+              <div className="border border-[#C4922A]/30 bg-[#C4922A]/8 p-2">
+                <p className="text-lg font-black">{alignedCount}</p>
+                <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-stone-500">aligned</p>
+              </div>
+            </div>
+            <p className="mt-3 text-xs leading-relaxed text-stone-600">
+              Importing adds these as EL assets, links them to the Harvest gallery and applies <strong>{selectedRecipe.work}</strong> + {selectedRecipe.themes.join("/")} + {selectedRecipe.category}.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button size="sm" variant="outline" onClick={selectLocalOnly} disabled={localOnlyCount === 0}>
+              <CheckSquare className="mr-2 h-4 w-4" />
+              Select local only
+            </Button>
+            <Button size="sm" variant="outline" onClick={clear} disabled={selectedPaths.length === 0}>
+              <X className="mr-2 h-4 w-4" />
+              Clear
+            </Button>
+          </div>
+        </div>
+
+        <div className="grid max-h-[520px] gap-3 overflow-y-auto pr-1 md:grid-cols-2">
+          {localVideosQuery.isLoading ? (
+            Array.from({ length: 4 }).map((_, index) => (
+              <div key={index} className="h-44 animate-pulse border border-stone-200 bg-stone-100" />
+            ))
+          ) : files.length === 0 ? (
+            <div className="border border-dashed border-stone-300 bg-stone-50 p-5 text-sm text-stone-600">
+              No local motion files found in the configured Harvest folders.
+            </div>
+          ) : (
+            files.map((file) => {
+              const selected = selectedPaths.includes(file.relativePath);
+              const sync = localVideoSyncCopy(file, selectedRecipe);
+              const previewSrc = localMotionPreviewUrl(file);
+              const firstMatch = file.elMatches?.[0];
+              return (
+                <article
+                  key={file.relativePath}
+                  className={`grid gap-3 border p-3 transition ${
+                    selected ? "border-[#C4922A] bg-[#C4922A]/8 ring-2 ring-[#C4922A]/20" : "border-stone-200 bg-white"
+                  }`}
+                >
+                  <div className="grid gap-3 sm:grid-cols-[170px_1fr]">
+                    <div className="overflow-hidden border border-stone-200 bg-stone-950">
+                      {file.kind === "gif" ? (
+                        <img
+                          src={previewSrc}
+                          alt={`${file.fileName} preview`}
+                          className="aspect-video h-full w-full object-cover"
+                          loading="lazy"
+                        />
+                      ) : (
+                        <LazyVideo
+                          src={previewSrc}
+                          className="aspect-video h-full w-full object-cover"
+                          controls
+                        />
+                      )}
+                    </div>
+                    <div>
+                      <div className="flex flex-wrap items-start justify-between gap-2">
+                        <div className="min-w-0">
+                          <h3 className="break-words text-base font-black leading-tight text-stone-900">{file.fileName}</h3>
+                          <p className="mt-1 break-all font-mono text-[10px] leading-relaxed text-stone-500">{file.relativePath}</p>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => togglePath(file.relativePath)}
+                          className={`inline-flex min-h-9 items-center gap-2 border px-3 text-xs font-semibold transition ${
+                            selected
+                              ? "border-[#C4922A] bg-[#C4922A]/18 text-stone-950"
+                              : "border-stone-300 bg-white text-stone-800 hover:border-stone-500"
+                          }`}
+                        >
+                          {selected ? <CheckSquare className="h-4 w-4" /> : <Square className="h-4 w-4" />}
+                          {selected ? "Selected" : "Select"}
+                        </button>
+                      </div>
+
+                      <div className="mt-3 flex flex-wrap gap-1.5">
+                        <TagChip label={file.kind === "gif" ? "GIF" : "MP4"} tone="work" />
+                        <TagChip label={formatFileSize(file.size)} />
+                        <TagChip label={sync.label} tone={sync.tone} />
+                      </div>
+
+                      <div className="mt-3 border-t border-stone-100 pt-3 text-xs leading-relaxed text-stone-600">
+                        <p className="flex items-center gap-1.5 font-semibold text-stone-800">
+                          {sync.tone === "work" ? <CheckCircle2 className="h-4 w-4 text-[#4A6741]" /> : <Video className="h-4 w-4 text-[#8B4A2A]" />}
+                          {sync.detail}
+                        </p>
+                        {firstMatch ? (
+                          <div className="mt-2 grid gap-1">
+                            <p className="font-mono text-[10px] text-stone-500">EL asset: {firstMatch.id}</p>
+                            <p>
+                              <strong>EL tags:</strong>{" "}
+                              {[...firstMatch.works, ...firstMatch.themes, ...firstMatch.categories].slice(0, 8).join(", ") || "no Harvest spine tags yet"}
+                            </p>
+                          </div>
+                        ) : (
+                          <p className="mt-2">Import it once, then this card will show the EL asset id and tag alignment.</p>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </article>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function AllMediaWorkbench({
+  media,
+  filteredMedia,
+  selectedMedia,
+  selectedMediaIds,
+  selectedRecipe,
+  recipeKey,
+  mediaSearch,
+  workFilter,
+  themeFilter,
+  categoryFilter,
+  kindFilter,
+  onRecipeChange,
+  onSearchChange,
+  onWorkFilterChange,
+  onThemeFilterChange,
+  onCategoryFilterChange,
+  onKindFilterChange,
+  onToggleSelected,
+  onSelectFiltered,
+  onClearSelected,
+  pageUsesByAsset,
+}: {
+  media: AdminMediaAsset[];
+  filteredMedia: AdminMediaAsset[];
+  selectedMedia: AdminMediaAsset[];
+  selectedMediaIds: string[];
+  selectedRecipe: MediaSet;
+  recipeKey: string;
+  mediaSearch: string;
+  workFilter: string;
+  themeFilter: string;
+  categoryFilter: string;
+  kindFilter: "all" | "image" | "video";
+  onRecipeChange: (key: string) => void;
+  onSearchChange: (value: string) => void;
+  onWorkFilterChange: (value: string) => void;
+  onThemeFilterChange: (value: string) => void;
+  onCategoryFilterChange: (value: string) => void;
+  onKindFilterChange: (value: "all" | "image" | "video") => void;
+  onToggleSelected: (id: string) => void;
+  onSelectFiltered: () => void;
+  onClearSelected: () => void;
+  pageUsesByAsset: Map<string, AssetPageUse[]>;
+}) {
+  const [tagMode, setTagMode] = useState<TagMode>("replace");
+  const [extraTag, setExtraTag] = useState("");
+  const [extraTagCategory, setExtraTagCategory] = useState(extraTagCategories[0].value);
+  const utils = trpc.useUtils();
+  const applyTagsMutation = trpc.mediaLibrary.applyTags.useMutation({
+    onSuccess: async (result) => {
+      await utils.gallery.fromEL.invalidate();
+      toast.success(`Applied tags to ${result.updated} asset${result.updated === 1 ? "" : "s"}.`);
+    },
+    onError: (error) => toast.error("Could not apply tags", { description: error.message }),
+  });
+
+  const applySelectedRecipe = async () => {
+    if (selectedMediaIds.length === 0) {
+      toast.error("Select at least one asset first.");
+      return;
+    }
+
+    const cleanedExtraTag = normaliseExtraTag(extraTag);
+    await applyTagsMutation.mutateAsync({
+      mediaIds: selectedMediaIds,
+      recipe: recipePayload(
+        selectedRecipe,
+        cleanedExtraTag ? [{ slug: cleanedExtraTag, category: extraTagCategory }] : [],
+      ),
+      mode: tagMode,
+    });
+  };
+
+  return (
+    <section className="mt-8 border border-stone-300 bg-[#FFFDF7]">
+      <div className="border-b border-stone-200 p-5">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <SectionIntro
+            eyebrow="all media"
+            title="Tag existing EL assets here."
+            body="Search or filter, select the photos, choose the tags, then apply them. No copy-paste step."
+          />
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline" onClick={onSelectFiltered} disabled={filteredMedia.length === 0}>
+              <CheckSquare className="mr-2 h-4 w-4" />
+              Select shown
+            </Button>
+            <Button variant="outline" onClick={onClearSelected} disabled={selectedMediaIds.length === 0}>
+              <X className="mr-2 h-4 w-4" />
+              Clear
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-5 grid gap-3 lg:grid-cols-[1fr_auto_auto_auto_auto]">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-stone-400" />
+            <Input
+              value={mediaSearch}
+              onChange={(event) => onSearchChange(event.target.value)}
+              placeholder="Search title, source, id, work or tag"
+              className="h-10 rounded-none border-stone-300 bg-white pl-9"
+            />
+          </div>
+          <FilterSelect label="Work" value={workFilter} options={workFilters} onChange={onWorkFilterChange} />
+          <FilterSelect label="Theme" value={themeFilter} options={themeFilters} onChange={onThemeFilterChange} />
+          <FilterSelect label="Category" value={categoryFilter} options={categoryFilters} onChange={onCategoryFilterChange} />
+          <FilterSelect
+            label="Kind"
+            value={kindFilter}
+            options={[
+              { value: "all", label: "All media" },
+              { value: "image", label: "Images" },
+              { value: "video", label: "Video" },
+            ]}
+            onChange={(value) => onKindFilterChange(value as "all" | "image" | "video")}
+          />
+        </div>
+
+        <div className="mt-4 grid gap-3 border border-stone-200 bg-white p-3 text-sm lg:grid-cols-[1fr_auto] lg:items-end">
+          <div className="grid gap-3 md:grid-cols-[220px_1fr] md:items-end">
+            <FilterSelect
+              label="Tags to apply"
+              value={recipeKey}
+              options={mediaSets.map((set) => ({ value: set.key, label: set.title }))}
+              onChange={onRecipeChange}
+            />
+            <div>
+              <p className="font-semibold text-stone-800">
+                Showing {filteredMedia.length} of {media.length} loaded assets · {selectedMedia.length} selected
+              </p>
+              <p className="mt-1 text-xs text-stone-600">
+                {tagMode === "replace" ? "Change mode replaces old work/theme/category tags." : "Add mode keeps existing tags and adds the new set."}
+                {" "}Selected assets become <strong>{selectedRecipe.work}</strong> + {selectedRecipe.themes.join("/")} + {selectedRecipe.category}.
+                {extraTag.trim() ? ` Extra tag: ${normaliseExtraTag(extraTag)}.` : ""}
+              </p>
+            </div>
+          </div>
+          <div className="grid gap-2 sm:grid-cols-[170px_1fr_auto]">
+            <FilterSelect
+              label="Mode"
+              value={tagMode}
+              options={[
+                { value: "replace", label: "Change spine" },
+                { value: "merge", label: "Add only" },
+              ]}
+              onChange={(value) => setTagMode(value as TagMode)}
+            />
+            <label className="grid gap-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-stone-500">
+              Quick tag
+              <div className="grid gap-2 sm:grid-cols-[1fr_120px]">
+                <Input
+                  value={extraTag}
+                  onChange={(event) => setExtraTag(event.target.value)}
+                  placeholder="home, featured, june-20..."
+                  className="h-10 rounded-none border-stone-300 bg-white text-sm normal-case tracking-normal"
+                />
+                <select
+                  value={extraTagCategory}
+                  onChange={(event) => setExtraTagCategory(event.target.value)}
+                  className="h-10 border border-stone-300 bg-white px-3 text-sm normal-case tracking-normal text-stone-900 outline-none focus:border-[#8B4A2A]"
+                >
+                  {extraTagCategories.map((category) => (
+                    <option key={category.value} value={category.value}>
+                      {category.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </label>
+            <Button
+              size="sm"
+              className="self-end"
+              disabled={selectedMediaIds.length === 0 || applyTagsMutation.isPending}
+              onClick={applySelectedRecipe}
+            >
+              {applyTagsMutation.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : tagMode === "replace" ? (
+                <Replace className="mr-2 h-4 w-4" />
+              ) : (
+                <Plus className="mr-2 h-4 w-4" />
+              )}
+              {applyTagsMutation.isPending ? "Applying..." : tagMode === "replace" ? "Change tags" : "Add tags"}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-3 p-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {filteredMedia.length === 0 ? (
+          <div className="col-span-full border border-dashed border-stone-300 bg-stone-50 p-6 text-sm text-stone-600">
+            No assets match the current filters.
+          </div>
+        ) : (
+          filteredMedia.map((item) => (
+            <MediaLibraryCard
+              key={item.id}
+              item={item}
+              selected={selectedMediaIds.includes(item.id)}
+              pageUses={pageUsesByAsset.get(item.id) ?? []}
+              onToggleSelected={() => onToggleSelected(item.id)}
+            />
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+function FilterSelect({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: Array<{ value: string; label: string }>;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label className="grid gap-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-stone-500">
+      {label}
+      <select
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="h-10 min-w-36 border border-stone-300 bg-white px-3 text-sm normal-case tracking-normal text-stone-900 outline-none focus:border-[#8B4A2A]"
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function MediaLibraryCard({
+  item,
+  selected,
+  pageUses,
+  onToggleSelected,
+}: {
+  item: AdminMediaAsset;
+  selected: boolean;
+  pageUses: AssetPageUse[];
+  onToggleSelected: () => void;
+}) {
+  const video = isVideoAsset(item.src);
+
+  return (
+    <article className={`border bg-white ${selected ? "border-[#C4922A] ring-2 ring-[#C4922A]/30" : "border-stone-200"}`}>
+      <button
+        type="button"
+        onClick={onToggleSelected}
+        className="relative block aspect-[4/3] w-full overflow-hidden bg-stone-200 text-left"
+        aria-pressed={selected}
+      >
+        {video ? (
+          <LazyVideo src={item.src} className="h-full w-full object-cover" />
+        ) : (
+          <img
+            src={optimize(item.src, "thumb")}
+            alt={item.altText ?? item.title ?? "Harvest media"}
+            className="h-full w-full object-cover"
+            loading="lazy"
+          />
+        )}
+        <span className="absolute left-2 top-2 inline-flex items-center gap-1 bg-stone-950/75 px-2 py-1 font-mono text-[9px] uppercase tracking-[0.12em] text-white">
+          {video ? <Film className="h-3 w-3" /> : <ImageIcon className="h-3 w-3" />}
+          {video ? "video" : "image"}
+        </span>
+        <span className="absolute right-2 top-2 bg-white/90 p-1 text-stone-900">
+          {selected ? <CheckSquare className="h-4 w-4" /> : <Square className="h-4 w-4" />}
+        </span>
+      </button>
+      <div className="p-3">
+        <h3 className="line-clamp-2 min-h-10 text-sm font-black leading-tight">
+          {item.title || item.altText || "Untitled media"}
+        </h3>
+        <p className="mt-1 truncate font-mono text-[10px] text-stone-500">{item.id}</p>
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {(item.works && item.works.length > 0) ? (
+            item.works.map((work) => <TagChip key={work} label={work} tone="work" />)
+          ) : (
+            <TagChip label="no work tag" tone="warn" />
+          )}
+          {item.themes?.map((theme) => <TagChip key={theme} label={theme} />)}
+          {item.category && <TagChip label={item.category} />}
+        </div>
+        <PageUseChips uses={pageUses} />
+      </div>
+    </article>
+  );
+}
+
+function PageUseChips({ uses }: { uses: AssetPageUse[] }) {
+  return (
+    <div className="mt-3 border-t border-stone-100 pt-3">
+      <p className="mb-2 flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-stone-500">
+        <MapPinned className="h-3.5 w-3.5" />
+        shows in
+      </p>
+      {uses.length === 0 ? (
+        <span className="inline-flex border border-dashed border-stone-300 px-2 py-1 text-[10px] font-semibold text-stone-500">
+          not on a page yet
+        </span>
+      ) : (
+        <div className="flex flex-wrap gap-1.5">
+          {uses.slice(0, 4).map((use) => (
+            <a
+              key={pageUseKey(use)}
+              href={use.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`inline-flex items-center gap-1 border px-2 py-1 text-[10px] font-semibold transition hover:bg-stone-100 ${
+                use.source === "slot"
+                  ? "border-[#4A6741]/35 bg-[#4A6741]/10 text-[#2F472B]"
+                  : "border-stone-200 bg-stone-50 text-stone-700"
+              }`}
+            >
+              {use.source === "slot" ? <Link2 className="h-3 w-3" /> : <ExternalLink className="h-3 w-3" />}
+              {use.label}
+            </a>
+          ))}
+          {uses.length > 4 && (
+            <span className="inline-flex border border-stone-200 bg-stone-50 px-2 py-1 text-[10px] font-semibold text-stone-500">
+              +{uses.length - 4} more
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TagChip({ label, tone = "neutral" }: { label: string; tone?: "neutral" | "work" | "warn" }) {
+  const className =
+    tone === "work"
+      ? "border-[#4A6741]/35 bg-[#4A6741]/10 text-[#2F472B]"
+      : tone === "warn"
+        ? "border-[#C4922A]/45 bg-[#C4922A]/12 text-[#7A4C07]"
+        : "border-stone-200 bg-stone-100 text-stone-700";
+
+  return (
+    <span className={`inline-flex items-center border px-2 py-0.5 text-[10px] font-semibold ${className}`}>
+      {label}
+    </span>
+  );
+}
+
+function MediaSetCard({ set, media }: { set: MediaSet; media: AdminMediaAsset[] }) {
+  const assets = media.filter((item) => item.works?.includes(set.work));
+  return (
+    <article className="border border-stone-300 bg-[#FFFDF7]">
+      <div className="border-b border-stone-200 p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#8B4A2A]">
+              {assets.length ? "tagged" : "needs tagging"}
+            </p>
+            <h3 className="mt-2 text-2xl font-black">{set.title}</h3>
+          </div>
+          <span className="border border-stone-300 px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.16em]">
+            {assets.length} in EL
+          </span>
+        </div>
+        <p className="mt-3 text-sm leading-relaxed text-stone-700">{set.description}</p>
+        <div className="mt-4 grid gap-2 text-xs text-stone-600">
+          <p>
+            <strong>Tag spine:</strong> {set.work} + {set.themes.join("/")} + {set.category}
+          </p>
+          <p>
+            <strong>Public use:</strong> {set.publicUse}
+          </p>
+        </div>
+      </div>
+      <div className="grid grid-cols-3 gap-2 p-4">
+        {assets.length === 0 ? (
+          <div className="col-span-3 border border-dashed border-stone-300 bg-stone-50 p-5 text-sm leading-relaxed text-stone-600">
+            Open Empathy Ledger and add the work tag <code className="bg-white px-1.5 py-0.5">{set.work}</code>.
+          </div>
+        ) : (
+          assets.slice(0, 6).map((item) => <MediaThumb key={item.id} item={item} compact />)
+        )}
+      </div>
+    </article>
+  );
+}
+
+function ProcessCard() {
+  const steps = [
+    "Upload new selects or import local videos into EL.",
+    "Change the work/theme/category spine in this page.",
+    "Add quick page or feature tags when needed.",
+    "Check the shows-in chips before using an asset publicly.",
+    "Assign hero and card slots from the same linked EL assets.",
+  ];
+
+  return (
+    <article className="border border-stone-300 bg-[#1C1917] p-5 text-[#F5F0E8]">
+      <div className="flex items-center gap-3">
+        <Tags className="h-5 w-5 text-[#C4922A]" />
+        <h3 className="text-2xl font-black">Workflow</h3>
+      </div>
+      <ol className="mt-5 space-y-3 text-sm leading-relaxed text-white/72">
+        {steps.map((step, index) => (
+          <li key={step} className="grid grid-cols-[auto_1fr] gap-3 border-t border-white/12 pt-3">
+            <span className="font-mono text-[#C4922A]">{String(index + 1).padStart(2, "0")}</span>
+            <span>{step}</span>
+          </li>
+        ))}
+      </ol>
+    </article>
+  );
+}
+
+function VideoPassCard() {
+  return (
+    <article className="border border-stone-300 bg-[#FFFDF7] p-5">
+      <div className="flex items-center gap-3">
+        <Film className="h-5 w-5 text-[#8B4A2A]" />
+        <h3 className="text-2xl font-black">Video pass</h3>
+      </div>
+      <p className="mt-3 text-sm leading-relaxed text-stone-700">
+        The importer above scans the repo for non-archive motion files and sends selected MP4/GIF assets into the same EL gallery as the photos.
+      </p>
+      <ul className="mt-4 space-y-2 text-xs leading-relaxed text-stone-600">
+        {videoSources.map((source) => (
+          <li key={source} className="border-t border-stone-200 pt-2">{source}</li>
+        ))}
+      </ul>
+    </article>
+  );
+}
+
+function PublicSlotCard({ slot }: { slot: PageSlot }) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const utils = trpc.useUtils();
+  const overrideQuery = trpc.imageOverrides.get.useQuery({ page: slot.page, slot: slot.slot });
+  const setMutation = trpc.imageOverrides.set.useMutation({
+    onSuccess: () => {
+      utils.imageOverrides.get.invalidate({ page: slot.page, slot: slot.slot });
+      toast.success("Public slot updated.");
+    },
+    onError: (error) => toast.error("Could not update slot", { description: error.message }),
+  });
+  const clearMutation = trpc.imageOverrides.clear.useMutation({
+    onSuccess: () => {
+      utils.imageOverrides.get.invalidate({ page: slot.page, slot: slot.slot });
+      toast.success("Slot reverted.");
+    },
+    onError: (error) => toast.error("Could not revert slot", { description: error.message }),
+  });
+
+  const override = overrideQuery.data;
+
+  const handlePick = async (photo: PickedPhoto) => {
+    await setMutation.mutateAsync({
+      page: slot.page,
+      slot: slot.slot,
+      mediaAssetId: photo.mediaAssetId,
+      src: photo.src,
+      altText: photo.altText ?? undefined,
+      title: photo.title ?? undefined,
+    });
+  };
+
+  return (
+    <article className="grid gap-4 border border-stone-300 bg-[#FFFDF7] p-4 sm:grid-cols-[150px_1fr]">
+      <div className="aspect-[4/3] overflow-hidden bg-stone-200">
+        {override?.src ? (
+          <img
+            src={optimize(override.src, "thumb")}
+            alt={override.altText ?? override.title ?? slot.label}
+            className="h-full w-full object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-stone-400">
+            <Images className="h-8 w-8" />
+          </div>
+        )}
+      </div>
+      <div>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h3 className="text-xl font-black">{slot.label}</h3>
+            <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.16em] text-stone-500">
+              {slot.page} / {slot.slot}
+            </p>
+          </div>
+          {override && (
+            <span className="inline-flex items-center gap-1 bg-[#4A6741]/10 px-2 py-1 text-xs font-semibold text-[#4A6741]">
+              <Check className="h-3.5 w-3.5" />
+              EL linked
+            </span>
+          )}
+        </div>
+        <p className="mt-3 text-sm leading-relaxed text-stone-700">{slot.note}</p>
+        {override?.title && (
+          <p className="mt-2 text-xs leading-relaxed text-stone-500">Current: {override.title}</p>
+        )}
+        <div className="mt-4 flex flex-wrap gap-2">
+          <Button size="sm" onClick={() => setPickerOpen(true)} disabled={setMutation.isPending}>
+            <Camera className="mr-2 h-4 w-4" />
+            Pick from EL
+          </Button>
+          <Button size="sm" variant="outline" asChild>
+            <a href={slot.publicUrl} target="_blank" rel="noopener noreferrer">
+              View public slot
+            </a>
+          </Button>
+          {override && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => clearMutation.mutate({ page: slot.page, slot: slot.slot })}
+              disabled={clearMutation.isPending}
+            >
+              Revert
+            </Button>
+          )}
+        </div>
+      </div>
+      <HarvestPhotoPicker
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+        onPick={handlePick}
+        defaultWorkSlug={slot.defaultWorkSlug}
+      />
+    </article>
+  );
+}
+
+function MediaThumb({ item, compact = false }: { item: AdminMediaAsset; compact?: boolean }) {
+  const video = isVideoAsset(item.src);
+  return (
+    <figure className={compact ? "" : "border border-stone-200 bg-white p-2"}>
+      <div className="relative aspect-[4/3] overflow-hidden bg-stone-200">
+        {video ? (
+          <LazyVideo src={item.src} className="h-full w-full object-cover" />
+        ) : (
+          <img
+            src={optimize(item.src, "thumb")}
+            alt={item.altText ?? item.title ?? "Harvest media"}
+            className="h-full w-full object-cover"
+            loading="lazy"
+          />
+        )}
+        <span className="absolute left-2 top-2 bg-stone-950/75 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] text-white">
+          {video ? "video" : "image"}
+        </span>
+      </div>
+      {!compact && (
+        <figcaption className="mt-2 text-xs leading-relaxed text-stone-600">
+          <span className="font-semibold text-stone-800">{item.title ?? "Untitled"}</span>
+          <br />
+          {(item.works && item.works.length > 0) ? item.works.join(", ") : "No work tag"}
+        </figcaption>
+      )}
+    </figure>
+  );
+}

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -261,7 +261,7 @@ export const editableContent = pgTable("editable_content", {
   /** Page identifier (e.g., "journey", "home", "about") */
   page: varchar("page", { length: 100 }).notNull(),
   /** Slot identifier within the page (e.g., "hero-title", "event-1-description") */
-  slot: varchar("slot", { length: 100 }).notNull(),
+  slot: varchar("slot", { length: 200 }).notNull(),
   /** The actual content - can be plain text or markdown */
   content: text("content").notNull(),
   /** Content type for rendering hints */
@@ -338,3 +338,63 @@ export const eventFeedback = pgTable("event_feedback", {
 
 export type EventFeedback = typeof eventFeedback.$inferSelect;
 export type InsertEventFeedback = typeof eventFeedback.$inferInsert;
+
+/**
+ * Witta history community contributions.
+ * Anyone can submit a memory, correction, or photo tied to a year/era.
+ * Admins approve before it appears on /witta.
+ */
+const wittaContributionStatusEnum = pgEnum("witta_contribution_status", [
+  "pending",
+  "approved",
+  "rejected",
+]);
+
+export const wittaContributions = pgTable("witta_contributions", {
+  id: serial("id").primaryKey(),
+  authorName: varchar("author_name", { length: 255 }).notNull(),
+  authorEmail: varchar("author_email", { length: 320 }),
+  /** Free-text year/era anchor — e.g. "1916", "1980s", "Today", "Pre-contact" */
+  yearOrEra: varchar("year_or_era", { length: 100 }).notNull(),
+  /** The contribution itself — memory, correction, story */
+  memory: text("memory").notNull(),
+  /** Optional uploaded image URL */
+  photoUrl: varchar("photo_url", { length: 1000 }),
+  status: wittaContributionStatusEnum("status").default("pending").notNull(),
+  /** Admin notes — visible only to admins */
+  adminNotes: text("admin_notes"),
+  /** Timestamps */
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  approvedAt: timestamp("approved_at", { withTimezone: true }),
+  approvedBy: integer("approved_by"),
+});
+
+export type WittaContribution = typeof wittaContributions.$inferSelect;
+export type InsertWittaContribution = typeof wittaContributions.$inferInsert;
+
+/**
+ * Image overrides — admins can pick an Empathy Ledger photo for any
+ * (page, slot) on the site without redeploying. Public users see the
+ * override; if none set, the page falls back to its bundled default.
+ *
+ * Slot examples:
+ *   page="works"  slot="milk-crate-pavilion-hero"
+ *   page="home"   slot="hero-aerial"
+ */
+export const imageOverrides = pgTable("image_overrides", {
+  id: serial("id").primaryKey(),
+  page: varchar("page", { length: 100 }).notNull(),
+  slot: varchar("slot", { length: 200 }).notNull(),
+  /** EL media_asset UUID — provenance, lookups, future re-fetches */
+  mediaAssetId: varchar("media_asset_id", { length: 64 }).notNull(),
+  /** Cached CDN URL so we don't hit EL on every page render */
+  src: varchar("src", { length: 1000 }).notNull(),
+  altText: varchar("alt_text", { length: 500 }),
+  title: varchar("title", { length: 255 }),
+  setBy: integer("set_by"),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export type ImageOverride = typeof imageOverrides.$inferSelect;
+export type InsertImageOverride = typeof imageOverrides.$inferInsert;

--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -3,6 +3,8 @@ import dotenv from "dotenv";
 dotenv.config({ path: ".env.local", override: true });
 import path from "path";
 import express from "express";
+import { createReadStream } from "fs";
+import { stat } from "fs/promises";
 import { createServer } from "http";
 import net from "net";
 import { createExpressMiddleware } from "@trpc/server/adapters/express";
@@ -10,6 +12,7 @@ import { appRouter } from "../routers";
 import { createContext } from "./context";
 import { serveStatic, setupVite } from "./vite";
 import { getApprovedBusinesses, getApprovedEvents } from "../db";
+import { listHarvestLocalMotionFiles } from "../empathyLedgerAdmin";
 import { generateImage, generateSketch } from "../gemini";
 import { refreshGHLToken, persistTokens } from "../gohighlevel";
 
@@ -39,6 +42,65 @@ const requireRegistryToken = (req: express.Request) => {
     return "Invalid registry token.";
   }
   return null;
+};
+
+const isLocalhostRequest = (req: express.Request) => {
+  const host = (req.hostname || req.get("host") || "").toString();
+  return host === "localhost" || host.startsWith("localhost:") || host === "127.0.0.1" || host.startsWith("127.0.0.1:");
+};
+
+const streamLocalMotionPreview = async (req: express.Request, res: express.Response) => {
+  if (process.env.NODE_ENV === "production" || !isLocalhostRequest(req)) {
+    return res.status(404).send("Not found");
+  }
+
+  const requestedPath = typeof req.query.path === "string" ? req.query.path : "";
+  if (!requestedPath) {
+    return res.status(400).send("Missing path");
+  }
+
+  const files = await listHarvestLocalMotionFiles(process.cwd());
+  const file = files.find((candidate) => candidate.relativePath === requestedPath);
+  if (!file) {
+    return res.status(404).send("Motion file not found");
+  }
+
+  const absolutePath = path.resolve(process.cwd(), file.relativePath);
+  const workspaceRoot = path.resolve(process.cwd());
+  if (!absolutePath.startsWith(`${workspaceRoot}${path.sep}`)) {
+    return res.status(400).send("Invalid path");
+  }
+
+  const fileStat = await stat(absolutePath);
+  const range = req.headers.range;
+
+  res.setHeader("Content-Type", file.contentType);
+  res.setHeader("Accept-Ranges", "bytes");
+  res.setHeader("Cache-Control", "no-store");
+
+  if (!range) {
+    res.setHeader("Content-Length", fileStat.size);
+    return createReadStream(absolutePath).pipe(res);
+  }
+
+  const match = /^bytes=(\d*)-(\d*)$/.exec(range);
+  if (!match) {
+    res.setHeader("Content-Range", `bytes */${fileStat.size}`);
+    return res.status(416).end();
+  }
+
+  const start = match[1] ? Number(match[1]) : 0;
+  const end = match[2] ? Math.min(Number(match[2]), fileStat.size - 1) : fileStat.size - 1;
+
+  if (start > end || start >= fileStat.size) {
+    res.setHeader("Content-Range", `bytes */${fileStat.size}`);
+    return res.status(416).end();
+  }
+
+  res.status(206);
+  res.setHeader("Content-Range", `bytes ${start}-${end}/${fileStat.size}`);
+  res.setHeader("Content-Length", end - start + 1);
+  return createReadStream(absolutePath, { start, end }).pipe(res);
 };
 
 const toIsoString = (value: Date | string | null | undefined) => {
@@ -74,6 +136,16 @@ async function startServer() {
   // Configure body parser with larger size limit for file uploads
   app.use(express.json({ limit: "50mb" }));
   app.use(express.urlencoded({ limit: "50mb", extended: true }));
+
+  app.get("/api/admin/media-library/local-motion", async (req, res) => {
+    try {
+      await streamLocalMotionPreview(req, res);
+    } catch (error) {
+      console.error("[MediaLibrary] Local motion preview failed:", error);
+      res.status(500).send("Could not load local motion preview");
+    }
+  });
+
   app.get("/api/registry", async (req, res) => {
     const authError = requireRegistryToken(req);
     if (authError) {

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,4 +1,4 @@
-import { eq, desc } from "drizzle-orm";
+import { eq, desc, and } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import {
@@ -24,6 +24,12 @@ import {
   eventFeedback,
   InsertEventFeedback,
   EventFeedback,
+  wittaContributions,
+  InsertWittaContribution,
+  WittaContribution,
+  imageOverrides,
+  InsertImageOverride,
+  ImageOverride,
 } from "../drizzle/schema.js";
 // Blog posts are now fetched from Empathy Ledger Content Hub API
 // See server/empathyLedgerClient.ts for the integration
@@ -730,6 +736,175 @@ export async function getAllEventFeedback(): Promise<EventFeedback[]> {
     return await db.select().from(eventFeedback).orderBy(desc(eventFeedback.createdAt));
   } catch (error) {
     console.error("[Database] Failed to get all event feedback:", error);
+    return [];
+  }
+}
+
+// Witta community contributions
+export async function createWittaContribution(
+  input: InsertWittaContribution,
+): Promise<WittaContribution | undefined> {
+  const db = await getDb();
+  if (!db) {
+    console.warn("[Database] Cannot create witta contribution: database not available");
+    return undefined;
+  }
+
+  try {
+    const result = await db.insert(wittaContributions).values(input).returning();
+    return result[0];
+  } catch (error) {
+    console.error("[Database] Failed to create witta contribution:", error);
+    throw error;
+  }
+}
+
+export async function getApprovedWittaContributions(): Promise<WittaContribution[]> {
+  const db = await getDb();
+  if (!db) return [];
+
+  try {
+    return await db
+      .select()
+      .from(wittaContributions)
+      .where(eq(wittaContributions.status, "approved"))
+      .orderBy(desc(wittaContributions.approvedAt));
+  } catch (error) {
+    console.error("[Database] Failed to get approved witta contributions:", error);
+    return [];
+  }
+}
+
+export async function getPendingWittaContributions(): Promise<WittaContribution[]> {
+  const db = await getDb();
+  if (!db) return [];
+
+  try {
+    return await db
+      .select()
+      .from(wittaContributions)
+      .where(eq(wittaContributions.status, "pending"))
+      .orderBy(desc(wittaContributions.createdAt));
+  } catch (error) {
+    console.error("[Database] Failed to get pending witta contributions:", error);
+    return [];
+  }
+}
+
+export async function updateWittaContributionStatus(
+  id: number,
+  status: "approved" | "rejected",
+  approvedBy: number,
+  adminNotes?: string,
+): Promise<WittaContribution | undefined> {
+  const db = await getDb();
+  if (!db) return undefined;
+
+  try {
+    const updates: Partial<InsertWittaContribution> = {
+      status,
+      adminNotes: adminNotes ?? null,
+    };
+    if (status === "approved") {
+      updates.approvedAt = new Date();
+      updates.approvedBy = approvedBy;
+    }
+
+    const result = await db
+      .update(wittaContributions)
+      .set(updates)
+      .where(eq(wittaContributions.id, id))
+      .returning();
+    return result[0];
+  } catch (error) {
+    console.error("[Database] Failed to update witta contribution status:", error);
+    throw error;
+  }
+}
+
+// Image overrides — admin-set EL photo for a (page, slot)
+export async function getImageOverride(
+  page: string,
+  slot: string,
+): Promise<ImageOverride | undefined> {
+  const db = await getDb();
+  if (!db) return undefined;
+  try {
+    const rows = await db
+      .select()
+      .from(imageOverrides)
+      .where(and(eq(imageOverrides.page, page), eq(imageOverrides.slot, slot)))
+      .limit(1);
+    return rows[0];
+  } catch (error) {
+    console.error("[Database] Failed to get image override:", error);
+    return undefined;
+  }
+}
+
+export async function setImageOverride(
+  input: InsertImageOverride,
+): Promise<ImageOverride | undefined> {
+  const db = await getDb();
+  if (!db) return undefined;
+  try {
+    const existing = await db
+      .select()
+      .from(imageOverrides)
+      .where(and(eq(imageOverrides.page, input.page), eq(imageOverrides.slot, input.slot)))
+      .limit(1);
+
+    if (existing.length > 0) {
+      const updated = await db
+        .update(imageOverrides)
+        .set({
+          mediaAssetId: input.mediaAssetId,
+          src: input.src,
+          altText: input.altText ?? null,
+          title: input.title ?? null,
+          setBy: input.setBy ?? null,
+          updatedAt: new Date(),
+        })
+        .where(eq(imageOverrides.id, existing[0].id))
+        .returning();
+      return updated[0];
+    }
+
+    const created = await db.insert(imageOverrides).values(input).returning();
+    return created[0];
+  } catch (error) {
+    console.error("[Database] Failed to set image override:", error);
+    throw error;
+  }
+}
+
+export async function clearImageOverride(
+  page: string,
+  slot: string,
+): Promise<boolean> {
+  const db = await getDb();
+  if (!db) return false;
+  try {
+    await db
+      .delete(imageOverrides)
+      .where(and(eq(imageOverrides.page, page), eq(imageOverrides.slot, slot)));
+    return true;
+  } catch (error) {
+    console.error("[Database] Failed to clear image override:", error);
+    return false;
+  }
+}
+
+export async function listImageOverrides(): Promise<ImageOverride[]> {
+  const db = await getDb();
+  if (!db) return [];
+  try {
+    return await db
+      .select()
+      .from(imageOverrides)
+      .orderBy(desc(imageOverrides.updatedAt));
+  } catch (error) {
+    console.error("[Database] Failed to list image overrides:", error);
     return [];
   }
 }

--- a/server/empathyLedgerAdmin.ts
+++ b/server/empathyLedgerAdmin.ts
@@ -1140,3 +1140,190 @@ export async function claimArticleForStoryteller(input: {
 
   return { updated: true, before: existing.author_storyteller_id };
 }
+
+// ---------------------------------------------------------------------------
+// Phase 2 — write capabilities into Empathy Ledger from the Harvest admin.
+// ---------------------------------------------------------------------------
+
+const VALID_HARVEST_ROLES = ["participant", "contributor", "owner", "subject"] as const;
+type HarvestRole = (typeof VALID_HARVEST_ROLES)[number];
+
+export type StorytellerSearchResult = {
+  id: string;
+  displayName: string | null;
+  location: string | null;
+  isActive: boolean;
+  profileId: string | null;
+  alreadyOnHarvest: boolean;
+};
+
+// Search EL storytellers by display_name. Used by the Harvest admin's
+// "Add storyteller…" picker. Capped at 20 results to keep the dropdown sane.
+export async function searchStorytellers(query: string): Promise<StorytellerSearchResult[]> {
+  const trimmed = query.trim();
+  if (trimmed.length < 2) return [];
+  const { supabase } = await createElAdminContext();
+
+  const { data: rows, error } = await supabase
+    .from("storytellers")
+    .select("id, display_name, location, is_active, profile_id")
+    .ilike("display_name", `%${trimmed}%`)
+    .order("display_name")
+    .limit(20);
+  if (error) throw error;
+
+  // Find which of these are already on Harvest so the UI can mark them.
+  const ids = (rows ?? []).map((r: any) => r.id);
+  const onHarvest = new Set<string>();
+  if (ids.length > 0) {
+    const { data: links } = await supabase
+      .from("project_storytellers")
+      .select("storyteller_id")
+      .eq("project_id", HARVEST_PROJECT_ID)
+      .in("storyteller_id", ids);
+    for (const l of (links ?? []) as Array<{ storyteller_id: string }>) onHarvest.add(l.storyteller_id);
+  }
+
+  return (rows ?? []).map((r: any) => ({
+    id: r.id,
+    displayName: r.display_name,
+    location: r.location,
+    isActive: !!r.is_active,
+    profileId: r.profile_id,
+    alreadyOnHarvest: onHarvest.has(r.id),
+  }));
+}
+
+// Add a storyteller to The Harvest project (project_storytellers join).
+export async function addStorytellerToHarvest(input: {
+  storytellerId: string;
+  role: HarvestRole;
+}): Promise<{ added: boolean; alreadyMember: boolean }> {
+  if (!VALID_HARVEST_ROLES.includes(input.role)) {
+    throw new Error(`Role must be one of: ${VALID_HARVEST_ROLES.join(", ")}`);
+  }
+  const { supabase } = await createElAdminContext();
+
+  // Confirm storyteller exists.
+  const { data: st, error: stErr } = await supabase
+    .from("storytellers")
+    .select("id")
+    .eq("id", input.storytellerId)
+    .maybeSingle();
+  if (stErr) throw stErr;
+  if (!st) throw new Error(`Storyteller ${input.storytellerId} not found in EL.`);
+
+  // Check existing membership.
+  const { data: existing } = await supabase
+    .from("project_storytellers")
+    .select("id")
+    .eq("project_id", HARVEST_PROJECT_ID)
+    .eq("storyteller_id", input.storytellerId)
+    .maybeSingle();
+  if (existing) return { added: false, alreadyMember: true };
+
+  const { error: insertErr } = await supabase
+    .from("project_storytellers")
+    .insert({
+      project_id: HARVEST_PROJECT_ID,
+      storyteller_id: input.storytellerId,
+      role: input.role,
+      status: "active",
+      joined_at: new Date().toISOString(),
+    });
+  if (insertErr) throw insertErr;
+  return { added: true, alreadyMember: false };
+}
+
+// Update a storyteller's bio. Restricted to people on the Harvest project so
+// admins can't accidentally edit unrelated EL profiles.
+export async function updateStorytellerBio(input: {
+  storytellerId: string;
+  bio: string;
+}): Promise<{ updated: boolean }> {
+  if (input.bio.length > 5000) {
+    throw new Error("Bio is too long (max 5000 characters).");
+  }
+  const { supabase } = await createElAdminContext();
+
+  const { data: link } = await supabase
+    .from("project_storytellers")
+    .select("id")
+    .eq("project_id", HARVEST_PROJECT_ID)
+    .eq("storyteller_id", input.storytellerId)
+    .maybeSingle();
+  if (!link) {
+    throw new Error("Bio editing is only allowed for storytellers on the Harvest project.");
+  }
+
+  const { error } = await supabase
+    .from("storytellers")
+    .update({ bio: input.bio, updated_at: new Date().toISOString() })
+    .eq("id", input.storytellerId);
+  if (error) throw error;
+  return { updated: true };
+}
+
+// Create a new story tagged to The Harvest project. Author can be any
+// Harvest project storyteller; the story starts as a draft (is_public = false).
+export async function createHarvestStory(input: {
+  title: string;
+  content: string;
+  summary?: string;
+  themes?: string[];
+  authorStorytellerId: string;
+  isPublic?: boolean;
+}): Promise<{ id: string }> {
+  if (input.title.trim().length === 0) throw new Error("Title is required.");
+  if (input.content.trim().length === 0) throw new Error("Content is required.");
+
+  const { supabase, gallery } = await createElAdminContext();
+
+  // Validate author is on the Harvest project.
+  const { data: link } = await supabase
+    .from("project_storytellers")
+    .select("storyteller_id, storytellers(profile_id)")
+    .eq("project_id", HARVEST_PROJECT_ID)
+    .eq("storyteller_id", input.authorStorytellerId)
+    .maybeSingle();
+  if (!link) {
+    throw new Error("Author must be a storyteller on the Harvest project.");
+  }
+  const linkRow = link as unknown as { storyteller_id: string; storytellers: { profile_id: string | null } | null };
+  const authorProfileId = linkRow.storytellers?.profile_id ?? null;
+
+  // Tenant comes from the gallery owner profile (already used by uploads).
+  const { data: ownerProfile } = await supabase
+    .from("profiles")
+    .select("tenant_id")
+    .eq("id", gallery.created_by)
+    .maybeSingle();
+  const tenantId = ownerProfile?.tenant_id;
+  if (!tenantId) throw new Error("Could not resolve EL tenant for new story.");
+
+  // Note: stories.author_id is mixed type in EL (sometimes storyteller_id,
+  // sometimes profile_id). Use profile_id when available since that's what
+  // most existing rows seem to use; fall back to storyteller_id otherwise.
+  const authorId = authorProfileId ?? input.authorStorytellerId;
+
+  const { data: created, error } = await supabase
+    .from("stories")
+    .insert({
+      tenant_id: tenantId,
+      author_id: authorId,
+      project_id: HARVEST_PROJECT_ID,
+      title: input.title.trim(),
+      content: input.content.trim(),
+      summary: input.summary?.trim() || null,
+      themes: input.themes ?? [],
+      privacy_level: input.isPublic ? "public" : "private",
+      is_public: !!input.isPublic,
+      cultural_sensitivity_level: "standard",
+      requires_elder_approval: false,
+    })
+    .select("id")
+    .single();
+  if (error) throw error;
+  if (!created?.id) throw new Error("Story insert returned no id.");
+  return { id: created.id };
+}

--- a/server/empathyLedgerAdmin.ts
+++ b/server/empathyLedgerAdmin.ts
@@ -807,14 +807,8 @@ export async function importHarvestLocalMotionFilesToEmpathyLedger(input: {
 // Harvest storytellers + their stories / articles / media
 // ---------------------------------------------------------------------------
 
-// Curated list of storytellers with content tied to The Harvest. Add IDs here
-// as new people join. EL has 370 storytellers total — most aren't Harvest-related,
-// so we keep this list explicit rather than auto-discovering.
-const HARVEST_STORYTELLER_IDS: ReadonlyArray<string> = [
-  "c2ba535c-aa50-42c3-af18-ed61d3330716", // Sophie Hickey
-  "99e753e0-07d6-439a-ab2a-f203bb657efa", // Barry Rodgerig
-];
-
+// Source of truth: the project_storytellers join in EL. Whoever is added to
+// the Harvest project in EL admin shows up here automatically.
 export type HarvestStorytellerSummary = {
   id: string;
   profileId: string | null;
@@ -823,6 +817,10 @@ export type HarvestStorytellerSummary = {
   avatarUrl: string | null;
   location: string | null;
   isActive: boolean;
+  // From project_storytellers join
+  projectRole: string | null;
+  projectStatus: string | null;
+  joinedAt: string | null;
   stories: Array<{
     id: string;
     title: string | null;
@@ -841,37 +839,101 @@ export type HarvestStorytellerSummary = {
     publishedAt: string | null;
     isHarvestTagged: boolean;
   }>;
+  transcripts: Array<{
+    id: string;
+    title: string | null;
+    recordingDate: string | null;
+    durationSeconds: number | null;
+    wordCount: number | null;
+    processingStatus: string | null;
+  }>;
   mediaCount: number;
 };
+
+export type HarvestProjectStats = {
+  storytellerCount: number;
+  storyCount: number;
+  transcriptCount: number;
+  // Three different photo views — EL counts them differently in different places.
+  mediaByProjectId: number;
+  mediaByGalleryAssoc: number;
+  mediaByCollectionId: number;
+};
+
+export async function getHarvestProjectStats(): Promise<HarvestProjectStats> {
+  const { supabase } = await createElAdminContext();
+  const [stCount, storyCount, transcriptCount, byProject, byAssoc, byCollection] = await Promise.all([
+    supabase.from("project_storytellers").select("id", { count: "exact", head: true }).eq("project_id", HARVEST_PROJECT_ID),
+    supabase.from("stories").select("id", { count: "exact", head: true }).eq("project_id", HARVEST_PROJECT_ID),
+    supabase.from("transcripts").select("id", { count: "exact", head: true }).eq("project_id", HARVEST_PROJECT_ID),
+    supabase.from("media_assets").select("id", { count: "exact", head: true }).eq("project_id", HARVEST_PROJECT_ID),
+    supabase.from("gallery_media_associations").select("id", { count: "exact", head: true }).eq("gallery_id", HARVEST_GALLERY_ID),
+    supabase.from("media_assets").select("id", { count: "exact", head: true }).eq("collection_id", HARVEST_GALLERY_ID),
+  ]);
+  return {
+    storytellerCount: stCount.count ?? 0,
+    storyCount: storyCount.count ?? 0,
+    transcriptCount: transcriptCount.count ?? 0,
+    mediaByProjectId: byProject.count ?? 0,
+    mediaByGalleryAssoc: byAssoc.count ?? 0,
+    mediaByCollectionId: byCollection.count ?? 0,
+  };
+}
 
 export async function listHarvestStorytellersWithContent(): Promise<HarvestStorytellerSummary[]> {
   const { supabase } = await createElAdminContext();
 
-  const { data: storytellers, error: stErr } = await supabase
-    .from("storytellers")
-    .select("id, profile_id, display_name, bio, public_avatar_url, location, is_active")
-    .in("id", [...HARVEST_STORYTELLER_IDS]);
-  if (stErr) throw stErr;
-  if (!storytellers || storytellers.length === 0) return [];
+  // 1) Pull project_storytellers join (this is what EL admin shows under People).
+  const { data: links, error: linkErr } = await supabase
+    .from("project_storytellers")
+    .select("storyteller_id, role, status, joined_at, storytellers(id, profile_id, display_name, bio, public_avatar_url, location, is_active)")
+    .eq("project_id", HARVEST_PROJECT_ID);
+  if (linkErr) throw linkErr;
+  if (!links || links.length === 0) return [];
 
-  const ids = storytellers.map((s: { id: string }) => s.id);
-  const profileIds = storytellers.map((s: { profile_id: string | null }) => s.profile_id).filter(Boolean) as string[];
+  type LinkRow = {
+    storyteller_id: string;
+    role: string | null;
+    status: string | null;
+    joined_at: string | null;
+    storytellers: {
+      id: string;
+      profile_id: string | null;
+      display_name: string | null;
+      bio: string | null;
+      public_avatar_url: string | null;
+      location: string | null;
+      is_active: boolean | null;
+    } | null;
+  };
+
+  const rows = (links as unknown as LinkRow[]).filter((r) => r.storytellers !== null);
+  const ids = rows.map((r) => r.storytellers!.id);
+  const profileIds = rows.map((r) => r.storytellers!.profile_id).filter(Boolean) as string[];
   const allAuthorIds = [...ids, ...profileIds];
 
-  // Stories: author_id can reference storyteller_id OR profile_id (data is mixed).
-  const { data: storyRows, error: storyErr } = await supabase
+  // 2) Stories — author_id may reference either storyteller_id or profile_id (data is mixed).
+  const { data: storyRows } = await supabase
     .from("stories")
     .select("id, title, is_public, project_id, created_at, author_id")
     .in("author_id", allAuthorIds);
-  if (storyErr) throw storyErr;
 
-  const { data: articleRows, error: articleErr } = await supabase
+  // 3) Articles authored by these storytellers (formal link only).
+  const { data: articleRows } = await supabase
     .from("articles")
     .select("id, title, slug, status, primary_project, related_projects, published_at, author_storyteller_id")
     .in("author_storyteller_id", ids);
-  if (articleErr) throw articleErr;
 
-  // Media uploaded by the linked profiles (uploader_id references profile.id)
+  // 4) Transcripts. EL doesn't store author_id on transcripts the same way,
+  // so we surface them at the project level — if any show metadata that
+  // includes a storyteller name/email, we attach. Else they appear as
+  // "unattributed" via getHarvestProjectStats.
+  const { data: transcriptRows } = await supabase
+    .from("transcripts")
+    .select("id, title, recording_date, duration_seconds, word_count, processing_status, metadata")
+    .eq("project_id", HARVEST_PROJECT_ID);
+
+  // 5) Media uploads by linked profiles, scoped to the Harvest project.
   const mediaCounts = new Map<string, number>();
   if (profileIds.length > 0) {
     const { data: mediaRows } = await supabase
@@ -885,8 +947,9 @@ export async function listHarvestStorytellersWithContent(): Promise<HarvestStory
     }
   }
 
-  return storytellers.map((s: any): HarvestStorytellerSummary => {
-    const profId = s.profile_id as string | null;
+  return rows.map((r): HarvestStorytellerSummary => {
+    const s = r.storytellers!;
+    const profId = s.profile_id;
     const stories = (storyRows ?? [])
       .filter((row: any) => row.author_id === s.id || (profId && row.author_id === profId))
       .map((row: any) => ({
@@ -911,6 +974,25 @@ export async function listHarvestStorytellersWithContent(): Promise<HarvestStory
           row.primary_project === "the-harvest" ||
           (Array.isArray(row.related_projects) && row.related_projects.includes("the-harvest")),
       }));
+    // Best-effort transcript attribution by display_name match in title or metadata.
+    const nameToken = (s.display_name ?? "").toLowerCase().split(/\s+/).filter(Boolean)[0];
+    const transcripts = nameToken
+      ? (transcriptRows ?? [])
+          .filter((row: any) => {
+            const t = (row.title ?? "").toLowerCase();
+            const m = JSON.stringify(row.metadata ?? {}).toLowerCase();
+            return t.includes(nameToken) || m.includes(nameToken);
+          })
+          .map((row: any) => ({
+            id: row.id,
+            title: row.title,
+            recordingDate: row.recording_date,
+            durationSeconds: row.duration_seconds,
+            wordCount: row.word_count,
+            processingStatus: row.processing_status,
+          }))
+      : [];
+
     return {
       id: s.id,
       profileId: profId,
@@ -919,8 +1001,12 @@ export async function listHarvestStorytellersWithContent(): Promise<HarvestStory
       avatarUrl: s.public_avatar_url,
       location: s.location,
       isActive: !!s.is_active,
+      projectRole: r.role,
+      projectStatus: r.status,
+      joinedAt: r.joined_at,
       stories,
       articles,
+      transcripts,
       mediaCount: profId ? mediaCounts.get(profId) ?? 0 : 0,
     };
   });
@@ -1013,16 +1099,23 @@ export async function tagArticleAsHarvest(articleId: string): Promise<{ updated:
   };
 }
 
-// Claim an orphan article by linking it to a curated Harvest storyteller.
+// Claim an orphan article by linking it to a Harvest project storyteller.
 // Sets author_storyteller_id and switches author_type to "storyteller".
+// Validates the storyteller is actually on the Harvest project_storytellers join.
 export async function claimArticleForStoryteller(input: {
   articleId: string;
   storytellerId: string;
 }): Promise<{ updated: boolean; before: string | null }> {
-  if (!HARVEST_STORYTELLER_IDS.includes(input.storytellerId)) {
-    throw new Error(`Storyteller ${input.storytellerId} is not in the curated Harvest list.`);
-  }
   const { supabase } = await createElAdminContext();
+  const { data: link } = await supabase
+    .from("project_storytellers")
+    .select("id")
+    .eq("project_id", HARVEST_PROJECT_ID)
+    .eq("storyteller_id", input.storytellerId)
+    .maybeSingle();
+  if (!link) {
+    throw new Error(`Storyteller ${input.storytellerId} is not on the Harvest project_storytellers join.`);
+  }
   const { data: existing, error: readErr } = await supabase
     .from("articles")
     .select("id, author_storyteller_id")

--- a/server/empathyLedgerAdmin.ts
+++ b/server/empathyLedgerAdmin.ts
@@ -1961,3 +1961,237 @@ export async function getPublicHarvestStoryById(storyId: string): Promise<Public
     author,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Article CRUD — admin can author + publish polished articles directly into
+// the Harvest project. Sister API to the story CRUD; articles surface on
+// /blog and /people/:slug.
+// ---------------------------------------------------------------------------
+
+const HARVEST_ARTICLE_STATUSES = ["draft", "published", "archived"] as const;
+const HARVEST_ARTICLE_TYPES = [
+  "story_feature",
+  "editorial",
+  "community_news",
+  "project_update",
+  "program_spotlight",
+  "impact_report",
+  "community_event",
+] as const;
+type HarvestArticleStatus = (typeof HARVEST_ARTICLE_STATUSES)[number];
+type HarvestArticleType = (typeof HARVEST_ARTICLE_TYPES)[number];
+
+export type HarvestArticleDetail = {
+  id: string;
+  title: string;
+  slug: string | null;
+  subtitle: string | null;
+  excerpt: string | null;
+  content: string | null;
+  themes: string[] | null;
+  status: HarvestArticleStatus;
+  articleType: HarvestArticleType | null;
+  authorStorytellerId: string | null;
+  authorName: string | null;
+  primaryProject: string | null;
+  relatedProjects: string[] | null;
+  publishedAt: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+};
+
+function slugifyArticleTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^\w\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .slice(0, 100) || `article-${Date.now()}`;
+}
+
+async function ensureUniqueArticleSlug(supabase: any, slug: string, excludeId?: string): Promise<string> {
+  let candidate = slug;
+  let i = 0;
+  while (true) {
+    const query = supabase.from("articles").select("id").eq("slug", candidate);
+    const { data } = excludeId ? await query.neq("id", excludeId).maybeSingle() : await query.maybeSingle();
+    if (!data) return candidate;
+    i += 1;
+    candidate = `${slug}-${i}`;
+    if (i > 50) throw new Error("Could not generate unique article slug");
+  }
+}
+
+export async function createHarvestArticle(input: {
+  title: string;
+  content: string;
+  slug?: string;
+  excerpt?: string;
+  subtitle?: string;
+  themes?: string[];
+  authorStorytellerId: string;
+  articleType?: HarvestArticleType;
+  status?: HarvestArticleStatus;
+}): Promise<{ id: string; slug: string }> {
+  if (!input.title.trim()) throw new Error("Title is required.");
+  if (!input.content.trim()) throw new Error("Content is required.");
+
+  const { supabase } = await createElAdminContext();
+
+  // Validate author is on Harvest project_storytellers + fetch their display name.
+  const { data: link } = await supabase
+    .from("project_storytellers")
+    .select("storytellers(display_name)")
+    .eq("project_id", HARVEST_PROJECT_ID)
+    .eq("storyteller_id", input.authorStorytellerId)
+    .maybeSingle();
+  if (!link) throw new Error("Author must be a storyteller on the Harvest project.");
+  const authorName = (link as any).storytellers?.display_name ?? "Storyteller";
+
+  const baseSlug = input.slug?.trim() ? slugifyArticleTitle(input.slug) : slugifyArticleTitle(input.title);
+  const slug = await ensureUniqueArticleSlug(supabase, baseSlug);
+  const status = input.status ?? "draft";
+  const articleType = input.articleType ?? "story_feature";
+
+  const { data: created, error } = await supabase
+    .from("articles")
+    .insert({
+      title: input.title.trim(),
+      slug,
+      subtitle: input.subtitle?.trim() || null,
+      content: input.content.trim(),
+      excerpt: input.excerpt?.trim() || null,
+      themes: input.themes ?? [],
+      tags: [],
+      status,
+      article_type: articleType,
+      author_type: "storyteller",
+      author_storyteller_id: input.authorStorytellerId,
+      author_name: authorName,
+      primary_project: "the-harvest",
+      related_projects: [],
+      published_at: status === "published" ? new Date().toISOString() : null,
+    })
+    .select("id, slug")
+    .single();
+  if (error) throw error;
+  if (!created?.id) throw new Error("Article insert returned no id.");
+  return { id: created.id, slug: created.slug };
+}
+
+export async function getHarvestArticle(articleId: string): Promise<HarvestArticleDetail> {
+  const { supabase } = await createElAdminContext();
+  const { data, error } = await supabase
+    .from("articles")
+    .select("id, title, slug, subtitle, excerpt, content, themes, status, article_type, author_storyteller_id, author_name, primary_project, related_projects, published_at, created_at, updated_at")
+    .eq("id", articleId)
+    .maybeSingle();
+  if (error) throw error;
+  if (!data) throw new Error(`Article ${articleId} not found.`);
+  if (data.primary_project !== "the-harvest" && !(Array.isArray(data.related_projects) && data.related_projects.includes("the-harvest"))) {
+    throw new Error("This article is not on the Harvest project.");
+  }
+  return {
+    id: data.id,
+    title: data.title,
+    slug: data.slug,
+    subtitle: data.subtitle,
+    excerpt: data.excerpt,
+    content: data.content,
+    themes: data.themes,
+    status: data.status,
+    articleType: data.article_type,
+    authorStorytellerId: data.author_storyteller_id,
+    authorName: data.author_name,
+    primaryProject: data.primary_project,
+    relatedProjects: data.related_projects,
+    publishedAt: data.published_at,
+    createdAt: data.created_at,
+    updatedAt: data.updated_at,
+  };
+}
+
+export async function updateHarvestArticle(input: {
+  articleId: string;
+  title?: string;
+  content?: string;
+  slug?: string;
+  excerpt?: string;
+  subtitle?: string;
+  themes?: string[];
+  articleType?: HarvestArticleType;
+  status?: HarvestArticleStatus;
+}): Promise<{ updated: boolean; published: boolean }> {
+  const { supabase } = await createElAdminContext();
+  const { data: existing, error: readErr } = await supabase
+    .from("articles")
+    .select("id, primary_project, related_projects, status, slug")
+    .eq("id", input.articleId)
+    .maybeSingle();
+  if (readErr) throw readErr;
+  if (!existing) throw new Error(`Article ${input.articleId} not found.`);
+  const isHarvest = existing.primary_project === "the-harvest" ||
+    (Array.isArray(existing.related_projects) && existing.related_projects.includes("the-harvest"));
+  if (!isHarvest) throw new Error("Edit is only allowed for Harvest articles.");
+
+  const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (input.title !== undefined) {
+    if (!input.title.trim()) throw new Error("Title cannot be empty.");
+    patch.title = input.title.trim();
+  }
+  if (input.content !== undefined) {
+    if (!input.content.trim()) throw new Error("Content cannot be empty.");
+    patch.content = input.content.trim();
+  }
+  if (input.subtitle !== undefined) patch.subtitle = input.subtitle.trim() || null;
+  if (input.excerpt !== undefined) patch.excerpt = input.excerpt.trim() || null;
+  if (input.themes !== undefined) patch.themes = input.themes;
+  if (input.articleType !== undefined) patch.article_type = input.articleType;
+
+  if (input.slug !== undefined && input.slug.trim()) {
+    const candidate = slugifyArticleTitle(input.slug);
+    if (candidate !== existing.slug) {
+      patch.slug = await ensureUniqueArticleSlug(supabase, candidate, input.articleId);
+    }
+  }
+
+  if (input.status !== undefined) {
+    patch.status = input.status;
+    if (input.status === "published" && existing.status !== "published") {
+      patch.published_at = new Date().toISOString();
+    }
+  }
+
+  if (Object.keys(patch).length === 1) {
+    return { updated: false, published: existing.status === "published" };
+  }
+
+  const { error: updateErr } = await supabase
+    .from("articles")
+    .update(patch)
+    .eq("id", input.articleId);
+  if (updateErr) throw updateErr;
+
+  return {
+    updated: true,
+    published: input.status !== undefined ? input.status === "published" : existing.status === "published",
+  };
+}
+
+export async function deleteHarvestArticle(articleId: string): Promise<{ deleted: boolean }> {
+  const { supabase } = await createElAdminContext();
+  const { data: existing } = await supabase
+    .from("articles")
+    .select("id, primary_project, related_projects")
+    .eq("id", articleId)
+    .maybeSingle();
+  if (!existing) throw new Error(`Article ${articleId} not found.`);
+  const isHarvest = existing.primary_project === "the-harvest" ||
+    (Array.isArray(existing.related_projects) && existing.related_projects.includes("the-harvest"));
+  if (!isHarvest) throw new Error("Delete is only allowed for Harvest articles.");
+  const { error } = await supabase.from("articles").delete().eq("id", articleId);
+  if (error) throw error;
+  return { deleted: true };
+}

--- a/server/empathyLedgerAdmin.ts
+++ b/server/empathyLedgerAdmin.ts
@@ -1463,6 +1463,7 @@ export type PublicHarvestStoryteller = {
   articleCount: number;
   publishedArticleCount: number;
   publishedStoryCount: number;
+  transcriptCount: number;
 };
 
 function slugifyDisplayName(name: string): string {
@@ -1525,6 +1526,24 @@ export async function listPublicHarvestStorytellers(): Promise<PublicHarvestStor
     }
   }
 
+  // Transcript counts via best-effort name match (transcripts have no formal author link).
+  const { data: trRows } = await supabase
+    .from("transcripts")
+    .select("title, metadata")
+    .eq("project_id", HARVEST_PROJECT_ID);
+  const transcriptCounts = new Map<string, number>();
+  for (const r of rows) {
+    const first = r.storytellers!.display_name!.toLowerCase().split(/\s+/).filter(Boolean)[0] ?? "";
+    if (first.length < 3) continue;
+    let count = 0;
+    for (const tr of (trRows ?? []) as Array<{ title: string | null; metadata: any }>) {
+      const t = (tr.title ?? "").toLowerCase();
+      const m = JSON.stringify(tr.metadata ?? {}).toLowerCase();
+      if (t.includes(first) || m.includes(first)) count += 1;
+    }
+    transcriptCounts.set(r.storytellers!.id, count);
+  }
+
   return rows.map((r): PublicHarvestStoryteller => {
     const s = r.storytellers!;
     const counts = articleCounts.get(s.id) ?? { total: 0, published: 0 };
@@ -1539,6 +1558,7 @@ export async function listPublicHarvestStorytellers(): Promise<PublicHarvestStor
       articleCount: counts.total,
       publishedArticleCount: counts.published,
       publishedStoryCount: storyCounts.get(s.id) ?? 0,
+      transcriptCount: transcriptCounts.get(s.id) ?? 0,
     };
   });
 }
@@ -1563,9 +1583,18 @@ export type PublicStorytellerStory = {
   createdAt: string | null;
 };
 
+export type PublicStorytellerTranscript = {
+  id: string;
+  title: string;
+  recordingDate: string | null;
+  durationSeconds: number | null;
+  wordCount: number | null;
+};
+
 export type PublicHarvestStorytellerDetail = PublicHarvestStoryteller & {
   articles: PublicStorytellerArticle[];
   stories: PublicStorytellerStory[];
+  transcripts: PublicStorytellerTranscript[];
 };
 
 export async function getPublicHarvestStorytellerBySlug(
@@ -1635,5 +1664,29 @@ export async function getPublicHarvestStorytellerBySlug(
     createdAt: s.created_at,
   }));
 
-  return { ...match, articles, stories };
+  // Best-effort transcript attribution — match title or metadata to first-name token.
+  // Only metadata fields surfaced; raw transcript_content stays admin-only since
+  // it's a recording of someone's voice and may not have public-publish consent.
+  let transcripts: PublicStorytellerTranscript[] = [];
+  if (firstName.length >= 3) {
+    const { data: trRows } = await supabase
+      .from("transcripts")
+      .select("id, title, recording_date, duration_seconds, word_count, processing_status, metadata")
+      .eq("project_id", HARVEST_PROJECT_ID);
+    transcripts = (trRows ?? [])
+      .filter((row: any) => {
+        const t = (row.title ?? "").toLowerCase();
+        const m = JSON.stringify(row.metadata ?? {}).toLowerCase();
+        return t.includes(firstName) || m.includes(firstName);
+      })
+      .map((row: any) => ({
+        id: row.id,
+        title: row.title ?? "(untitled transcript)",
+        recordingDate: row.recording_date,
+        durationSeconds: row.duration_seconds,
+        wordCount: row.word_count,
+      }));
+  }
+
+  return { ...match, articles, stories, transcripts };
 }

--- a/server/empathyLedgerAdmin.ts
+++ b/server/empathyLedgerAdmin.ts
@@ -1751,18 +1751,51 @@ export type HarvestPhotoForAttribution = {
 };
 
 // List recent Harvest media plus which storytellers each is currently tagged
-// with. Used by the admin photo-attribution picker.
-export async function listHarvestMediaForAttribution(limit = 200): Promise<HarvestPhotoForAttribution[]> {
+// with. Used by the admin photo-attribution picker. Optional `work` filter
+// restricts to assets carrying the given harvest-work tag (the-garden,
+// milk-crate-pavilion, etc.) so admins can scope tagging to a single work.
+export async function listHarvestMediaForAttribution(input?: {
+  limit?: number;
+  work?: string | null;
+}): Promise<HarvestPhotoForAttribution[]> {
+  const limit = input?.limit ?? 200;
+  const work = input?.work;
   const { supabase } = await createElAdminContext();
-  const { data, error } = await supabase
+
+  // Resolve work tag id once if filter requested.
+  let workTagAssetIds: Set<string> | null = null;
+  if (work) {
+    const { data: tag } = await supabase
+      .from("tags")
+      .select("id")
+      .eq("slug", work)
+      .eq("category", "harvest-work")
+      .maybeSingle();
+    if (!tag?.id) return []; // unknown work → empty
+    const { data: links } = await supabase
+      .from("media_tags")
+      .select("media_asset_id")
+      .eq("tag_id", (tag as any).id);
+    workTagAssetIds = new Set((links ?? []).map((r: any) => r.media_asset_id));
+    if (workTagAssetIds.size === 0) return [];
+  }
+
+  let query = supabase
     .from("media_assets")
     .select("id, cdn_url, thumbnail_url, original_filename, created_at, metadata, media_type")
     .eq("project_id", HARVEST_PROJECT_ID)
     .eq("media_type", "image")
     .order("created_at", { ascending: false })
-    .limit(limit);
+    .limit(workTagAssetIds ? Math.min(workTagAssetIds.size, limit * 3) : limit);
+
+  if (workTagAssetIds) {
+    query = query.in("id", Array.from(workTagAssetIds));
+  }
+
+  const { data, error } = await query;
   if (error) throw error;
-  return (data ?? []).map((row: any) => {
+
+  return (data ?? []).slice(0, limit).map((row: any) => {
     const tagged = Array.isArray(row.metadata?.harvestStorytellers)
       ? row.metadata.harvestStorytellers.filter((v: any) => typeof v === "string")
       : [];
@@ -1851,4 +1884,80 @@ export async function listElPhotosForStoryteller(storytellerId: string): Promise
     src: row.thumbnail_url || row.cdn_url || "",
     alt: row.original_filename ? `Harvest photo ${row.original_filename}` : "Harvest photo",
   })).filter((p: PublicStorytellerPhoto) => p.src);
+}
+
+// Public-safe Harvest story fetch. Only returns if is_public=true AND
+// the story is on the Harvest project. Includes minimal author info
+// (display name + slug) so the detail page can link back to /people/:slug.
+export type PublicHarvestStoryDetail = {
+  id: string;
+  title: string;
+  content: string;
+  summary: string | null;
+  themes: string[];
+  createdAt: string | null;
+  updatedAt: string | null;
+  wordCount: number | null;
+  author: {
+    id: string;
+    slug: string | null;
+    displayName: string;
+    avatarUrl: string | null;
+  } | null;
+};
+
+export async function getPublicHarvestStoryById(storyId: string): Promise<PublicHarvestStoryDetail | null> {
+  const { supabase } = await createElAdminContext();
+  const { data, error } = await supabase
+    .from("stories")
+    .select("id, title, content, summary, themes, created_at, updated_at, author_id, is_public, project_id")
+    .eq("id", storyId)
+    .maybeSingle();
+  if (error) throw error;
+  if (!data) return null;
+  if (!data.is_public) return null;
+  if (data.project_id !== HARVEST_PROJECT_ID) return null;
+
+  // Resolve author. author_id can be storyteller_id OR profile_id (mixed data).
+  const storytellers = await listPublicHarvestStorytellers();
+  const byStoryteller = storytellers.find((s) => s.id === data.author_id);
+  let author: PublicHarvestStoryDetail["author"] = null;
+  if (byStoryteller) {
+    author = {
+      id: byStoryteller.id,
+      slug: byStoryteller.slug,
+      displayName: byStoryteller.displayName,
+      avatarUrl: byStoryteller.avatarUrl,
+    };
+  } else if (data.author_id) {
+    // Try matching by profile_id via the storytellers join.
+    const { data: stRow } = await supabase
+      .from("storytellers")
+      .select("id, display_name, public_avatar_url")
+      .eq("profile_id", data.author_id)
+      .maybeSingle();
+    if (stRow) {
+      const harvestMatch = storytellers.find((s) => s.id === (stRow as any).id);
+      author = {
+        id: (stRow as any).id,
+        slug: harvestMatch?.slug ?? null,
+        displayName: (stRow as any).display_name ?? "Storyteller",
+        avatarUrl: (stRow as any).public_avatar_url ?? null,
+      };
+    }
+  }
+
+  const wordCount = (data.content ?? "").trim().split(/\s+/).filter(Boolean).length;
+
+  return {
+    id: data.id,
+    title: data.title ?? "(untitled)",
+    content: data.content ?? "",
+    summary: data.summary,
+    themes: Array.isArray(data.themes) ? data.themes : [],
+    createdAt: data.created_at,
+    updatedAt: data.updated_at,
+    wordCount,
+    author,
+  };
 }

--- a/server/empathyLedgerAdmin.ts
+++ b/server/empathyLedgerAdmin.ts
@@ -1445,3 +1445,195 @@ export async function deleteHarvestStory(storyId: string): Promise<{ deleted: bo
   if (error) throw error;
   return { deleted: true };
 }
+
+// ---------------------------------------------------------------------------
+// Public-safe surface — for the Harvest website's /people pages. Returns
+// curated fields only (no PII, no internal IDs beyond what the public site
+// already shows). Calls these from publicProcedure tRPC routes.
+// ---------------------------------------------------------------------------
+
+export type PublicHarvestStoryteller = {
+  id: string;
+  slug: string;
+  displayName: string;
+  bio: string | null;
+  avatarUrl: string | null;
+  location: string | null;
+  projectRole: string | null;
+  articleCount: number;
+  publishedArticleCount: number;
+  publishedStoryCount: number;
+};
+
+function slugifyDisplayName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+export async function listPublicHarvestStorytellers(): Promise<PublicHarvestStoryteller[]> {
+  const { supabase } = await createElAdminContext();
+
+  const { data: links, error: linkErr } = await supabase
+    .from("project_storytellers")
+    .select("role, status, storytellers(id, display_name, bio, public_avatar_url, location, is_active)")
+    .eq("project_id", HARVEST_PROJECT_ID)
+    .eq("status", "active");
+  if (linkErr) throw linkErr;
+  if (!links) return [];
+
+  type LinkRow = {
+    role: string | null;
+    status: string | null;
+    storytellers: {
+      id: string;
+      display_name: string | null;
+      bio: string | null;
+      public_avatar_url: string | null;
+      location: string | null;
+      is_active: boolean | null;
+    } | null;
+  };
+
+  const rows = (links as unknown as LinkRow[]).filter((r) => r.storytellers && r.storytellers.display_name);
+  const ids = rows.map((r) => r.storytellers!.id);
+
+  // Article + story counts per storyteller.
+  const articleCounts = new Map<string, { total: number; published: number }>();
+  const storyCounts = new Map<string, number>();
+  if (ids.length > 0) {
+    const { data: articles } = await supabase
+      .from("articles")
+      .select("author_storyteller_id, status")
+      .in("author_storyteller_id", ids);
+    for (const a of (articles ?? []) as Array<{ author_storyteller_id: string; status: string | null }>) {
+      const cur = articleCounts.get(a.author_storyteller_id) ?? { total: 0, published: 0 };
+      cur.total += 1;
+      if (a.status === "published") cur.published += 1;
+      articleCounts.set(a.author_storyteller_id, cur);
+    }
+
+    const { data: stories } = await supabase
+      .from("stories")
+      .select("author_id, is_public")
+      .eq("project_id", HARVEST_PROJECT_ID)
+      .in("author_id", ids);
+    for (const s of (stories ?? []) as Array<{ author_id: string; is_public: boolean | null }>) {
+      if (s.is_public) storyCounts.set(s.author_id, (storyCounts.get(s.author_id) ?? 0) + 1);
+    }
+  }
+
+  return rows.map((r): PublicHarvestStoryteller => {
+    const s = r.storytellers!;
+    const counts = articleCounts.get(s.id) ?? { total: 0, published: 0 };
+    return {
+      id: s.id,
+      slug: slugifyDisplayName(s.display_name!),
+      displayName: s.display_name!,
+      bio: s.bio,
+      avatarUrl: s.public_avatar_url,
+      location: s.location,
+      projectRole: r.role,
+      articleCount: counts.total,
+      publishedArticleCount: counts.published,
+      publishedStoryCount: storyCounts.get(s.id) ?? 0,
+    };
+  });
+}
+
+export type PublicStorytellerArticle = {
+  id: string;
+  title: string;
+  slug: string | null;
+  excerpt: string | null;
+  publishedAt: string | null;
+  themes: string[];
+  featuredImageId: string | null;
+  primaryProject: string | null;
+};
+
+export type PublicStorytellerStory = {
+  id: string;
+  title: string;
+  summary: string | null;
+  themes: string[] | null;
+  isPublic: boolean;
+  createdAt: string | null;
+};
+
+export type PublicHarvestStorytellerDetail = PublicHarvestStoryteller & {
+  articles: PublicStorytellerArticle[];
+  stories: PublicStorytellerStory[];
+};
+
+export async function getPublicHarvestStorytellerBySlug(
+  slug: string,
+): Promise<PublicHarvestStorytellerDetail | null> {
+  const all = await listPublicHarvestStorytellers();
+  const match = all.find((s) => s.slug === slug);
+  if (!match) return null;
+
+  const { supabase } = await createElAdminContext();
+
+  const { data: claimed } = await supabase
+    .from("articles")
+    .select("id, title, slug, excerpt, published_at, themes, featured_image_id, primary_project, status, author_storyteller_id")
+    .eq("author_storyteller_id", match.id)
+    .order("published_at", { ascending: false, nullsFirst: false });
+
+  // Slug-based fallback: surface published articles whose slug contains the
+  // storyteller's first-name token AND look Harvest-flavoured (slug or title
+  // mentions harvest / garden / milk-crate / witta / one of the work slugs),
+  // EXCLUDING any already claimed (avoid double-listing).
+  const firstName = match.displayName.toLowerCase().split(/\s+/).filter(Boolean)[0] ?? "";
+  let fallback: any[] = [];
+  if (firstName.length >= 3) {
+    const claimedIds = new Set((claimed ?? []).map((a: any) => a.id));
+    const { data: candidates } = await supabase
+      .from("articles")
+      .select("id, title, slug, excerpt, published_at, themes, featured_image_id, primary_project, status, author_storyteller_id")
+      .eq("status", "published")
+      .is("author_storyteller_id", null)
+      .or(`slug.ilike.%${firstName}%,title.ilike.%${firstName}%`);
+    const harvestSignals = ["harvest", "garden", "milk-crate", "witta", "the-cedar", "the-sauna", "the-shop"];
+    fallback = (candidates ?? []).filter((a: any) => {
+      if (claimedIds.has(a.id)) return false;
+      const hay = `${a.slug ?? ""} ${a.title ?? ""} ${a.primary_project ?? ""}`.toLowerCase();
+      return harvestSignals.some((s) => hay.includes(s));
+    });
+  }
+
+  const articles: PublicStorytellerArticle[] = [...(claimed ?? []), ...fallback]
+    .filter((a: any) => a.status === "published")
+    .map((a: any) => ({
+      id: a.id,
+      title: a.title ?? "(untitled)",
+      slug: a.slug,
+      excerpt: a.excerpt,
+      publishedAt: a.published_at,
+      themes: Array.isArray(a.themes) ? a.themes : [],
+      featuredImageId: a.featured_image_id,
+      primaryProject: a.primary_project,
+    }));
+
+  const { data: storyRows } = await supabase
+    .from("stories")
+    .select("id, title, summary, themes, is_public, created_at")
+    .eq("project_id", HARVEST_PROJECT_ID)
+    .eq("author_id", match.id)
+    .eq("is_public", true)
+    .order("created_at", { ascending: false });
+
+  const stories: PublicStorytellerStory[] = (storyRows ?? []).map((s: any) => ({
+    id: s.id,
+    title: s.title ?? "(untitled)",
+    summary: s.summary,
+    themes: s.themes,
+    isPublic: !!s.is_public,
+    createdAt: s.created_at,
+  }));
+
+  return { ...match, articles, stories };
+}

--- a/server/empathyLedgerAdmin.ts
+++ b/server/empathyLedgerAdmin.ts
@@ -1,0 +1,698 @@
+import dotenv from "dotenv";
+import { createClient } from "@supabase/supabase-js";
+import { randomUUID } from "node:crypto";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { basename, extname, join, relative } from "node:path";
+
+dotenv.config({ path: ".env.local", override: false, quiet: true });
+
+const HARVEST_GALLERY_ID = "5fa1593e-7d73-477a-9a34-64d2f3ff86cc";
+// Canonical Harvest project. EL v2's public API unions assets via this project_id
+// with assets via gallery_media_associations(HARVEST_GALLERY_ID), so all uploads
+// must have this set or they only show up via the legacy gallery side.
+const HARVEST_PROJECT_ID = "0584b447-57a8-4c85-bc3e-5cd97511b7e4";
+const STORAGE_BUCKET = "media";
+
+type HarvestUploadFile = {
+  fileName: string;
+  contentType: string;
+  base64Data: string;
+};
+
+type HarvestExtraTag = {
+  slug: string;
+  category: string;
+};
+
+type HarvestUploadRecipe = {
+  work: string;
+  themes: string[];
+  categories: string[];
+  title: string;
+  extraTags?: HarvestExtraTag[];
+};
+
+type UploadResult = {
+  id: string;
+  fileName: string;
+  src: string;
+  mediaType: "image" | "video";
+};
+
+export type LocalHarvestMotionFile = {
+  id: string;
+  fileName: string;
+  relativePath: string;
+  contentType: string;
+  size: number;
+  kind: "video" | "gif";
+  elStatus?: "local-only" | "synced" | "unknown";
+  elMatches?: Array<{
+    id: string;
+    title: string | null;
+    src: string | null;
+    works: string[];
+    themes: string[];
+    categories: string[];
+    tags: string[];
+    createdAt: string | null;
+  }>;
+};
+
+type ElAdminContext = {
+  supabase: any;
+  gallery: {
+    id: string;
+    title: string | null;
+    organization_id: string | null;
+    tenant_id: string | null;
+    created_by: string;
+  };
+  tenantId: string;
+};
+
+type HarvestUploadSource = {
+  fileName: string;
+  contentType: string;
+  base64Data?: string;
+  absolutePath?: string;
+  sourcePath?: string;
+};
+
+type TagMode = "merge" | "replace";
+
+const HARVEST_SPINE_TAG_CATEGORIES = ["harvest-work", "harvest-theme", "harvest-category"];
+const MOTION_EXTENSIONS = new Set([".mp4", ".mov", ".m4v", ".webm", ".gif"]);
+
+function getElSupabaseConfig() {
+  const url =
+    process.env.EMPATHY_LEDGER_SUPABASE_URL ||
+    process.env.EL_SUPABASE_URL ||
+    process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    process.env.VITE_SUPABASE_URL ||
+    process.env.SUPABASE_URL;
+  const serviceKey =
+    process.env.EMPATHY_LEDGER_SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.EL_SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !serviceKey) {
+    throw new Error("Empathy Ledger Supabase credentials are not configured.");
+  }
+
+  return { url, serviceKey };
+}
+
+function sanitizeFileName(fileName: string) {
+  return fileName.replace(/[^a-zA-Z0-9._-]/g, "-").replace(/-+/g, "-");
+}
+
+function titleFromFile(fileName: string) {
+  return sanitizeFileName(fileName).replace(/\.[^/.]+$/, "").replace(/[-_]+/g, " ").trim() || "Harvest media";
+}
+
+function normalizeTagSlug(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function normalizeTagCategory(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function mediaTypeFor(contentType: string, fileName: string): "image" | "video" {
+  const ext = extname(fileName).toLowerCase();
+  if (contentType.startsWith("video/") || [".mp4", ".mov", ".m4v", ".webm"].includes(ext)) {
+    return "video";
+  }
+  return "image";
+}
+
+function tagName(slug: string) {
+  return slug
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+async function getOrCreateTag(
+  supabase: any,
+  slug: string,
+  category: string,
+): Promise<string> {
+  const { data: existing, error: findError } = await supabase
+    .from("tags")
+    .select("id")
+    .eq("slug", slug)
+    .eq("category", category)
+    .maybeSingle();
+
+  if (findError) throw findError;
+  if (existing?.id) return existing.id;
+
+  const { data: created, error: createError } = await supabase
+    .from("tags")
+    .insert({
+      slug,
+      name: tagName(slug),
+      category,
+      description: `Harvest ${category.replace("harvest-", "")} tag for ${tagName(slug)}`,
+      cultural_sensitivity_level: "public",
+    })
+    .select("id")
+    .single();
+
+  if (createError) throw createError;
+  if (!created?.id) throw new Error(`Could not create EL tag ${category}:${slug}`);
+  return created.id;
+}
+
+async function createElAdminContext(): Promise<ElAdminContext> {
+  const { url, serviceKey } = getElSupabaseConfig();
+  const supabase = createClient(url, serviceKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const { data: gallery, error: galleryError } = await supabase
+    .from("galleries")
+    .select("id, title, organization_id, created_by")
+    .eq("id", HARVEST_GALLERY_ID)
+    .maybeSingle();
+
+  if (galleryError) throw galleryError;
+  if (!gallery) throw new Error(`Harvest gallery ${HARVEST_GALLERY_ID} was not found in Empathy Ledger.`);
+
+  const { data: ownerProfile, error: ownerError } = await supabase
+    .from("profiles")
+    .select("id, tenant_id")
+    .eq("id", gallery.created_by)
+    .maybeSingle();
+
+  if (ownerError) throw ownerError;
+
+  const tenantId = ownerProfile?.tenant_id;
+  if (!tenantId || !gallery.created_by) {
+    throw new Error("Could not resolve the Harvest gallery tenant/uploader in Empathy Ledger.");
+  }
+
+  return { supabase, gallery, tenantId };
+}
+
+async function getProjectIdForRecipe(supabase: any, recipe: HarvestUploadRecipe): Promise<string | null> {
+  // recipe.work is a tag slug (e.g. "milk-crate-pavilion"), not a project slug.
+  // EL has one canonical Harvest project. If a per-work project ever exists with
+  // that slug, prefer it; otherwise fall back to the canonical Harvest project.
+  const { data: matched } = await supabase
+    .from("projects")
+    .select("id")
+    .eq("slug", recipe.work)
+    .maybeSingle();
+
+  return matched?.id ?? HARVEST_PROJECT_ID;
+}
+
+function tagEntriesForRecipe(recipe: HarvestUploadRecipe): HarvestExtraTag[] {
+  const entries: HarvestExtraTag[] = [
+    { slug: recipe.work, category: "harvest-work" },
+    ...recipe.themes.map((theme) => ({ slug: theme, category: "harvest-theme" })),
+    ...recipe.categories.map((category) => ({ slug: category, category: "harvest-category" })),
+    ...(recipe.extraTags ?? []),
+  ]
+    .map((tag) => ({
+      slug: normalizeTagSlug(tag.slug),
+      category: normalizeTagCategory(tag.category),
+    }))
+    .filter((tag) => tag.slug && tag.category);
+
+  const seen = new Set<string>();
+  return entries.filter((tag) => {
+    const key = `${tag.category}:${tag.slug}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+async function tagIdsForRecipe(supabase: any, recipe: HarvestUploadRecipe): Promise<string[]> {
+  return Promise.all(tagEntriesForRecipe(recipe).map((tag) => getOrCreateTag(supabase, tag.slug, tag.category)));
+}
+
+async function clearHarvestSpineTags(supabase: any, mediaIds: string[]) {
+  if (mediaIds.length === 0) return;
+
+  const { data: existingTags, error: tagError } = await supabase
+    .from("tags")
+    .select("id")
+    .in("category", HARVEST_SPINE_TAG_CATEGORIES);
+
+  if (tagError) throw tagError;
+
+  const tagIds = (existingTags ?? []).map((tag: { id: string }) => tag.id).filter(Boolean);
+  if (tagIds.length === 0) return;
+
+  const { error: deleteError } = await supabase
+    .from("media_tags")
+    .delete()
+    .in("media_asset_id", mediaIds)
+    .in("tag_id", tagIds);
+
+  if (deleteError) throw deleteError;
+}
+
+async function applyRecipeTags(input: {
+  supabase: any;
+  mediaIds: string[];
+  recipe: HarvestUploadRecipe;
+  addedBy: string;
+  mode?: TagMode;
+}) {
+  if (input.mode === "replace") {
+    await clearHarvestSpineTags(input.supabase, input.mediaIds);
+  }
+
+  const tagIds = await tagIdsForRecipe(input.supabase, input.recipe);
+  const tagRows = input.mediaIds.flatMap((mediaId) =>
+    tagIds.map((tagId) => ({
+      media_asset_id: mediaId,
+      tag_id: tagId,
+      source: "manual",
+      added_by: input.addedBy,
+      confidence: 1,
+      verified: true,
+    })),
+  );
+
+  if (tagRows.length === 0) return;
+
+  const { error: tagError } = await input.supabase
+    .from("media_tags")
+    .upsert(tagRows, {
+      onConflict: "media_asset_id,tag_id",
+      ignoreDuplicates: true,
+    });
+
+  if (tagError) throw tagError;
+}
+
+async function readUploadSource(file: HarvestUploadSource): Promise<Buffer> {
+  if (file.base64Data) return Buffer.from(file.base64Data, "base64");
+  if (file.absolutePath) return readFile(file.absolutePath);
+  throw new Error(`No file data was provided for ${file.fileName}`);
+}
+
+async function uploadHarvestMediaSourcesToEmpathyLedger(input: {
+  files: HarvestUploadSource[];
+  recipe: HarvestUploadRecipe;
+  uploadedBy: number | null;
+}): Promise<{ uploaded: UploadResult[]; failed: Array<{ fileName: string; error: string }> }> {
+  const { supabase, gallery, tenantId } = await createElAdminContext();
+  const projectId = await getProjectIdForRecipe(supabase, input.recipe);
+  const tagIds = await tagIdsForRecipe(supabase, input.recipe);
+
+  const { data: existingSort } = await supabase
+    .from("gallery_media_associations")
+    .select("sort_order")
+    .eq("gallery_id", HARVEST_GALLERY_ID)
+    .order("sort_order", { ascending: false })
+    .limit(1);
+
+  let sortOrder = Number(existingSort?.[0]?.sort_order ?? 0) + 1;
+  const uploaded: UploadResult[] = [];
+  const failed: Array<{ fileName: string; error: string }> = [];
+
+  for (const file of input.files) {
+    try {
+      const mediaType = mediaTypeFor(file.contentType, file.fileName);
+      if (mediaType !== "image" && mediaType !== "video") {
+        throw new Error("Only image and video files are supported.");
+      }
+
+      const buffer = await readUploadSource(file);
+      const safeName = sanitizeFileName(file.fileName);
+      const storagePath = `galleries/${HARVEST_GALLERY_ID}/harvest-admin-library/${Date.now()}-${randomUUID()}-${safeName}`;
+      const contentType = file.contentType || "application/octet-stream";
+
+      const { error: uploadError } = await supabase.storage
+        .from(STORAGE_BUCKET)
+        .upload(storagePath, buffer, { contentType, upsert: false });
+
+      if (uploadError) throw uploadError;
+
+      const publicUrl = supabase.storage.from(STORAGE_BUCKET).getPublicUrl(storagePath).data.publicUrl;
+      const title = titleFromFile(file.fileName);
+
+      const { data: asset, error: assetError } = await supabase
+        .from("media_assets")
+        .insert({
+          original_filename: file.fileName,
+          display_name: title,
+          file_size: buffer.length,
+          file_type: contentType,
+          mime_type: contentType,
+          media_type: mediaType,
+          storage_bucket: STORAGE_BUCKET,
+          storage_path: storagePath,
+          cdn_url: publicUrl,
+          url: publicUrl,
+          processing_status: "completed",
+          privacy_level: "public",
+          visibility: "public",
+          cultural_sensitivity_level: "standard",
+          organization_id: gallery.organization_id,
+          tenant_id: tenantId,
+          uploader_id: gallery.created_by,
+          uploaded_by: gallery.created_by,
+          project_id: projectId,
+          title,
+          alt_text: `${input.recipe.title} at The Harvest: ${title}.`,
+          description: `${input.recipe.title}. Uploaded from The Harvest media library.`,
+          source_type: "harvest-admin-media-library",
+          requires_consent: false,
+          consent_obtained: true,
+          metadata: {
+            harvestUploadSource: "admin-media-library",
+            harvestUploadedBy: input.uploadedBy,
+            harvestRecipe: input.recipe,
+            harvestSourcePath: file.sourcePath ?? null,
+          },
+        })
+        .select("id")
+        .single();
+
+      if (assetError) {
+        await supabase.storage.from(STORAGE_BUCKET).remove([storagePath]);
+        throw assetError;
+      }
+
+      const { error: galleryAssocError } = await supabase
+        .from("gallery_media_associations")
+        .insert({
+          gallery_id: HARVEST_GALLERY_ID,
+          media_asset_id: asset.id,
+          sort_order: sortOrder++,
+        });
+
+      if (galleryAssocError) throw galleryAssocError;
+
+      const tagRows = tagIds.map((tagId) => ({
+        media_asset_id: asset.id,
+        tag_id: tagId,
+        source: "manual",
+        added_by: gallery.created_by,
+        confidence: 1,
+        verified: true,
+      }));
+
+      const { error: tagError } = await supabase
+        .from("media_tags")
+        .upsert(tagRows, {
+          onConflict: "media_asset_id,tag_id",
+          ignoreDuplicates: true,
+        });
+
+      if (tagError) throw tagError;
+
+      uploaded.push({
+        id: asset.id,
+        fileName: file.fileName,
+        src: publicUrl,
+        mediaType,
+      });
+    } catch (error) {
+      failed.push({
+        fileName: file.fileName,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return { uploaded, failed };
+}
+
+export async function uploadHarvestMediaToEmpathyLedger(input: {
+  files: HarvestUploadFile[];
+  recipe: HarvestUploadRecipe;
+  uploadedBy: number | null;
+}): Promise<{ uploaded: UploadResult[]; failed: Array<{ fileName: string; error: string }> }> {
+  return uploadHarvestMediaSourcesToEmpathyLedger({
+    files: input.files,
+    recipe: input.recipe,
+    uploadedBy: input.uploadedBy,
+  });
+}
+
+export async function tagHarvestMediaInEmpathyLedger(input: {
+  mediaIds: string[];
+  recipe: HarvestUploadRecipe;
+  mode?: TagMode;
+}): Promise<{ updated: number }> {
+  const { supabase, gallery } = await createElAdminContext();
+  const projectId = await getProjectIdForRecipe(supabase, input.recipe);
+
+  await applyRecipeTags({
+    supabase,
+    mediaIds: input.mediaIds,
+    recipe: input.recipe,
+    addedBy: gallery.created_by,
+    mode: input.mode ?? "merge",
+  });
+
+  if (projectId) {
+    await supabase
+      .from("media_assets")
+      .update({ project_id: projectId, updated_at: new Date().toISOString() })
+      .in("id", input.mediaIds);
+  }
+
+  return { updated: input.mediaIds.length };
+}
+
+function contentTypeForMotionFile(fileName: string) {
+  const ext = extname(fileName).toLowerCase();
+  if (ext === ".mp4") return "video/mp4";
+  if (ext === ".mov") return "video/quicktime";
+  if (ext === ".m4v") return "video/x-m4v";
+  if (ext === ".webm") return "video/webm";
+  if (ext === ".gif") return "image/gif";
+  return "application/octet-stream";
+}
+
+async function walkMotionFiles(rootDir: string, cwd: string): Promise<LocalHarvestMotionFile[]> {
+  let entries;
+  try {
+    entries = await readdir(rootDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const files: LocalHarvestMotionFile[] = [];
+  for (const entry of entries) {
+    const absolutePath = join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "archive") continue;
+      files.push(...await walkMotionFiles(absolutePath, cwd));
+      continue;
+    }
+
+    if (!entry.isFile()) continue;
+    const extension = extname(entry.name).toLowerCase();
+    if (!MOTION_EXTENSIONS.has(extension)) continue;
+
+    const fileStat = await stat(absolutePath);
+    const relativePath = relative(cwd, absolutePath);
+    files.push({
+      id: relativePath.replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-+|-+$/g, ""),
+      fileName: basename(absolutePath),
+      relativePath,
+      contentType: contentTypeForMotionFile(entry.name),
+      size: fileStat.size,
+      kind: extension === ".gif" ? "gif" : "video",
+    });
+  }
+
+  return files;
+}
+
+export async function listHarvestLocalMotionFiles(cwd = process.cwd()): Promise<LocalHarvestMotionFile[]> {
+  const roots = [
+    join(cwd, "client/public/images/compendium"),
+    join(cwd, "client/public/images/social-tiles"),
+    join(cwd, "docs/communications/debriefs/_whatsapp-exports"),
+  ];
+
+  const allFiles = (await Promise.all(roots.map((root) => walkMotionFiles(root, cwd)))).flat();
+  const seen = new Set<string>();
+  return allFiles
+    .filter((file) => {
+      const key = `${file.fileName}:${file.size}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+}
+
+async function listHarvestLocalMotionFilesWithApiStatus(files: LocalHarvestMotionFile[]): Promise<LocalHarvestMotionFile[]> {
+  const baseUrl = (process.env.EMPATHY_LEDGER_API_URL || "https://empathyledger.com").replace(/\/$/, "");
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (process.env.EMPATHY_LEDGER_API_KEY) {
+    headers["X-API-Key"] = process.env.EMPATHY_LEDGER_API_KEY;
+  }
+
+  const allMedia: any[] = [];
+  for (const page of [1, 2, 3]) {
+    const response = await fetch(`${baseUrl}/api/v1/harvest/gallery?limit=100&page=${page}`, { headers });
+    if (!response.ok) throw new Error(`Harvest gallery API returned ${response.status}`);
+    const body = await response.json() as { media?: any[]; pagination?: { hasMore?: boolean } };
+    allMedia.push(...(body.media ?? []));
+    if (!body.pagination?.hasMore) break;
+  }
+
+  return files.map((file) => {
+    const safeTitle = titleFromFile(file.fileName).toLowerCase();
+    const matches = allMedia
+      .filter((asset) => {
+        const haystack = [
+          asset.src,
+          asset.title,
+          asset.description,
+          asset.altText,
+        ]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        return haystack.includes(file.fileName.toLowerCase()) || haystack.includes(safeTitle);
+      })
+      .map((asset) => ({
+        id: asset.id,
+        title: asset.title ?? asset.altText ?? null,
+        src: asset.src ?? null,
+        works: asset.works ?? [],
+        themes: asset.themes ?? [],
+        categories: asset.category ? [asset.category] : [],
+        tags: asset.tags ?? [],
+        createdAt: asset.createdAt ?? null,
+      }));
+
+    return {
+      ...file,
+      elStatus: matches.length > 0 ? "synced" as const : "local-only" as const,
+      elMatches: matches,
+    };
+  });
+}
+
+export async function listHarvestLocalMotionFilesWithElStatus(cwd = process.cwd()): Promise<LocalHarvestMotionFile[]> {
+  const files = await listHarvestLocalMotionFiles(cwd);
+  if (files.length === 0) return files;
+
+  try {
+    const { supabase } = await createElAdminContext();
+    const fileNames = Array.from(new Set(files.map((file) => file.fileName)));
+    const { data: assets, error: assetError } = await supabase
+      .from("media_assets")
+      .select("id, original_filename, display_name, title, cdn_url, url, metadata, created_at")
+      .in("original_filename", fileNames);
+
+    if (assetError) throw assetError;
+
+    const assetRows = (assets ?? []) as Array<{
+      id: string;
+      original_filename: string | null;
+      display_name: string | null;
+      title: string | null;
+      cdn_url: string | null;
+      url: string | null;
+      metadata: Record<string, unknown> | null;
+      created_at: string | null;
+    }>;
+
+    const assetIds = assetRows.map((asset) => asset.id);
+    const tagsByAsset = new Map<string, Array<{ slug: string; category: string }>>();
+
+    if (assetIds.length > 0) {
+      const { data: tagRows, error: tagError } = await supabase
+        .from("media_tags")
+        .select("media_asset_id, tags(slug, category)")
+        .in("media_asset_id", assetIds);
+
+      if (tagError) throw tagError;
+
+      (tagRows ?? []).forEach((row: any) => {
+        const tag = Array.isArray(row.tags) ? row.tags[0] : row.tags;
+        if (!row.media_asset_id || !tag?.slug) return;
+        const current = tagsByAsset.get(row.media_asset_id) ?? [];
+        current.push({ slug: tag.slug, category: tag.category ?? "" });
+        tagsByAsset.set(row.media_asset_id, current);
+      });
+    }
+
+    return files.map((file) => {
+      const matches = assetRows
+        .filter((asset) => {
+          if (asset.original_filename !== file.fileName) return false;
+          const sourcePath = asset.metadata?.harvestSourcePath;
+          return !sourcePath || sourcePath === file.relativePath;
+        })
+        .map((asset) => {
+          const tagRows = tagsByAsset.get(asset.id) ?? [];
+          return {
+            id: asset.id,
+            title: asset.title ?? asset.display_name,
+            src: asset.cdn_url ?? asset.url,
+            works: tagRows.filter((tag) => tag.category === "harvest-work").map((tag) => tag.slug),
+            themes: tagRows.filter((tag) => tag.category === "harvest-theme").map((tag) => tag.slug),
+            categories: tagRows.filter((tag) => tag.category === "harvest-category").map((tag) => tag.slug),
+            tags: tagRows.map((tag) => tag.slug),
+            createdAt: asset.created_at,
+          };
+        });
+
+      return {
+        ...file,
+        elStatus: matches.length > 0 ? "synced" as const : "local-only" as const,
+        elMatches: matches,
+      };
+    });
+  } catch (error) {
+    console.warn("[MediaLibrary] Falling back to Harvest gallery API for local motion sync status:", error);
+    try {
+      return await listHarvestLocalMotionFilesWithApiStatus(files);
+    } catch (apiError) {
+      console.error("[MediaLibrary] Could not load EL sync status for local motion files:", apiError);
+      return files.map((file) => ({ ...file, elStatus: "unknown" as const, elMatches: [] }));
+    }
+  }
+}
+
+export async function importHarvestLocalMotionFilesToEmpathyLedger(input: {
+  paths: string[];
+  recipe: HarvestUploadRecipe;
+  uploadedBy: number | null;
+}): Promise<{ uploaded: UploadResult[]; failed: Array<{ fileName: string; error: string }> }> {
+  const available = await listHarvestLocalMotionFiles();
+  const byPath = new Map(available.map((file) => [file.relativePath, file]));
+  const selected = input.paths.map((path) => byPath.get(path)).filter(Boolean) as LocalHarvestMotionFile[];
+
+  if (selected.length !== input.paths.length) {
+    throw new Error("One or more selected video files are no longer available in the codebase.");
+  }
+
+  return uploadHarvestMediaSourcesToEmpathyLedger({
+    files: selected.map((file) => ({
+      fileName: file.fileName,
+      contentType: file.contentType,
+      absolutePath: join(process.cwd(), file.relativePath),
+      sourcePath: file.relativePath,
+    })),
+    recipe: input.recipe,
+    uploadedBy: input.uploadedBy,
+  });
+}

--- a/server/empathyLedgerAdmin.ts
+++ b/server/empathyLedgerAdmin.ts
@@ -1327,3 +1327,121 @@ export async function createHarvestStory(input: {
   if (!created?.id) throw new Error("Story insert returned no id.");
   return { id: created.id };
 }
+
+// Fetch full story content on-demand for the inline editor. The storyteller
+// summary intentionally omits content (could be 50k chars per story).
+export type HarvestStoryDetail = {
+  id: string;
+  title: string | null;
+  content: string | null;
+  summary: string | null;
+  themes: string[] | null;
+  isPublic: boolean;
+  privacyLevel: string | null;
+  authorId: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+};
+
+export async function getHarvestStory(storyId: string): Promise<HarvestStoryDetail> {
+  const { supabase } = await createElAdminContext();
+  const { data, error } = await supabase
+    .from("stories")
+    .select("id, title, content, summary, themes, is_public, privacy_level, author_id, project_id, created_at, updated_at")
+    .eq("id", storyId)
+    .maybeSingle();
+  if (error) throw error;
+  if (!data) throw new Error(`Story ${storyId} not found.`);
+  if (data.project_id !== HARVEST_PROJECT_ID) {
+    throw new Error("This story is not on the Harvest project.");
+  }
+  return {
+    id: data.id,
+    title: data.title,
+    content: data.content,
+    summary: data.summary,
+    themes: data.themes,
+    isPublic: !!data.is_public,
+    privacyLevel: data.privacy_level,
+    authorId: data.author_id,
+    createdAt: data.created_at,
+    updatedAt: data.updated_at,
+  };
+}
+
+// Update an existing story. Restricted to stories on the Harvest project so
+// admins can't edit unrelated stories. Pass undefined to leave a field alone;
+// pass an empty string to clear it.
+export async function updateHarvestStory(input: {
+  storyId: string;
+  title?: string;
+  content?: string;
+  summary?: string;
+  themes?: string[];
+  isPublic?: boolean;
+}): Promise<{ updated: boolean; published: boolean }> {
+  const { supabase } = await createElAdminContext();
+
+  // Confirm the story belongs to the Harvest project.
+  const { data: existing, error: readErr } = await supabase
+    .from("stories")
+    .select("id, project_id, is_public")
+    .eq("id", input.storyId)
+    .maybeSingle();
+  if (readErr) throw readErr;
+  if (!existing) throw new Error(`Story ${input.storyId} not found.`);
+  if (existing.project_id !== HARVEST_PROJECT_ID) {
+    throw new Error("Edit is only allowed for stories on the Harvest project.");
+  }
+
+  const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (input.title !== undefined) {
+    if (input.title.trim().length === 0) throw new Error("Title cannot be empty.");
+    patch.title = input.title.trim();
+  }
+  if (input.content !== undefined) {
+    if (input.content.trim().length === 0) throw new Error("Content cannot be empty.");
+    patch.content = input.content.trim();
+  }
+  if (input.summary !== undefined) patch.summary = input.summary.trim() || null;
+  if (input.themes !== undefined) patch.themes = input.themes;
+  if (input.isPublic !== undefined) {
+    patch.is_public = input.isPublic;
+    patch.privacy_level = input.isPublic ? "public" : "private";
+  }
+
+  if (Object.keys(patch).length === 1) {
+    // Only updated_at — nothing real to write.
+    return { updated: false, published: !!existing.is_public };
+  }
+
+  const { error: updateErr } = await supabase
+    .from("stories")
+    .update(patch)
+    .eq("id", input.storyId);
+  if (updateErr) throw updateErr;
+
+  return {
+    updated: true,
+    published: input.isPublic !== undefined ? input.isPublic : !!existing.is_public,
+  };
+}
+
+// Delete a story. Restricted to Harvest project. Hard-delete because EL
+// stories table doesn't have a soft-delete column we can use here.
+export async function deleteHarvestStory(storyId: string): Promise<{ deleted: boolean }> {
+  const { supabase } = await createElAdminContext();
+  const { data: existing, error: readErr } = await supabase
+    .from("stories")
+    .select("id, project_id")
+    .eq("id", storyId)
+    .maybeSingle();
+  if (readErr) throw readErr;
+  if (!existing) throw new Error(`Story ${storyId} not found.`);
+  if (existing.project_id !== HARVEST_PROJECT_ID) {
+    throw new Error("Delete is only allowed for stories on the Harvest project.");
+  }
+  const { error } = await supabase.from("stories").delete().eq("id", storyId);
+  if (error) throw error;
+  return { deleted: true };
+}

--- a/server/empathyLedgerAdmin.ts
+++ b/server/empathyLedgerAdmin.ts
@@ -1591,11 +1591,42 @@ export type PublicStorytellerTranscript = {
   wordCount: number | null;
 };
 
+export type PublicStorytellerPhoto = {
+  src: string;
+  alt: string;
+};
+
 export type PublicHarvestStorytellerDetail = PublicHarvestStoryteller & {
   articles: PublicStorytellerArticle[];
   stories: PublicStorytellerStory[];
   transcripts: PublicStorytellerTranscript[];
+  localPhotos: PublicStorytellerPhoto[];
 };
+
+const PHOTO_EXTS = new Set([".jpg", ".jpeg", ".png", ".webp", ".gif"]);
+
+// Scan client/public/images/compendium/{firstName}/ for local images that
+// have been hand-curated for this storyteller. This is a filesystem-based
+// fallback because EL media_assets don't yet carry storyteller attribution.
+async function listLocalCompendiumPhotos(firstName: string): Promise<PublicStorytellerPhoto[]> {
+  if (firstName.length < 2) return [];
+  const safeName = firstName.replace(/[^a-z0-9-]/g, "");
+  if (!safeName) return [];
+
+  const dir = join(process.cwd(), "client/public/images/compendium", safeName);
+  try {
+    const entries = await readdir(dir);
+    return entries
+      .filter((name) => PHOTO_EXTS.has(extname(name).toLowerCase()))
+      .sort()
+      .map((name) => ({
+        src: `/images/compendium/${safeName}/${name}`,
+        alt: `${firstName.charAt(0).toUpperCase()}${firstName.slice(1)} at The Harvest`,
+      }));
+  } catch {
+    return [];
+  }
+}
 
 export async function getPublicHarvestStorytellerBySlug(
   slug: string,
@@ -1688,5 +1719,7 @@ export async function getPublicHarvestStorytellerBySlug(
       }));
   }
 
-  return { ...match, articles, stories, transcripts };
+  const localPhotos = await listLocalCompendiumPhotos(firstName);
+
+  return { ...match, articles, stories, transcripts, localPhotos };
 }

--- a/server/empathyLedgerAdmin.ts
+++ b/server/empathyLedgerAdmin.ts
@@ -802,3 +802,248 @@ export async function importHarvestLocalMotionFilesToEmpathyLedger(input: {
     failed: [...failed, ...upload.failed],
   };
 }
+
+// ---------------------------------------------------------------------------
+// Harvest storytellers + their stories / articles / media
+// ---------------------------------------------------------------------------
+
+// Curated list of storytellers with content tied to The Harvest. Add IDs here
+// as new people join. EL has 370 storytellers total — most aren't Harvest-related,
+// so we keep this list explicit rather than auto-discovering.
+const HARVEST_STORYTELLER_IDS: ReadonlyArray<string> = [
+  "c2ba535c-aa50-42c3-af18-ed61d3330716", // Sophie Hickey
+  "99e753e0-07d6-439a-ab2a-f203bb657efa", // Barry Rodgerig
+];
+
+export type HarvestStorytellerSummary = {
+  id: string;
+  profileId: string | null;
+  displayName: string | null;
+  bio: string | null;
+  avatarUrl: string | null;
+  location: string | null;
+  isActive: boolean;
+  stories: Array<{
+    id: string;
+    title: string | null;
+    isPublic: boolean;
+    projectId: string | null;
+    createdAt: string | null;
+    isHarvestProject: boolean;
+  }>;
+  articles: Array<{
+    id: string;
+    title: string | null;
+    slug: string | null;
+    status: string | null;
+    primaryProject: string | null;
+    relatedProjects: string[] | null;
+    publishedAt: string | null;
+    isHarvestTagged: boolean;
+  }>;
+  mediaCount: number;
+};
+
+export async function listHarvestStorytellersWithContent(): Promise<HarvestStorytellerSummary[]> {
+  const { supabase } = await createElAdminContext();
+
+  const { data: storytellers, error: stErr } = await supabase
+    .from("storytellers")
+    .select("id, profile_id, display_name, bio, public_avatar_url, location, is_active")
+    .in("id", [...HARVEST_STORYTELLER_IDS]);
+  if (stErr) throw stErr;
+  if (!storytellers || storytellers.length === 0) return [];
+
+  const ids = storytellers.map((s: { id: string }) => s.id);
+  const profileIds = storytellers.map((s: { profile_id: string | null }) => s.profile_id).filter(Boolean) as string[];
+  const allAuthorIds = [...ids, ...profileIds];
+
+  // Stories: author_id can reference storyteller_id OR profile_id (data is mixed).
+  const { data: storyRows, error: storyErr } = await supabase
+    .from("stories")
+    .select("id, title, is_public, project_id, created_at, author_id")
+    .in("author_id", allAuthorIds);
+  if (storyErr) throw storyErr;
+
+  const { data: articleRows, error: articleErr } = await supabase
+    .from("articles")
+    .select("id, title, slug, status, primary_project, related_projects, published_at, author_storyteller_id")
+    .in("author_storyteller_id", ids);
+  if (articleErr) throw articleErr;
+
+  // Media uploaded by the linked profiles (uploader_id references profile.id)
+  const mediaCounts = new Map<string, number>();
+  if (profileIds.length > 0) {
+    const { data: mediaRows } = await supabase
+      .from("media_assets")
+      .select("uploader_id")
+      .in("uploader_id", profileIds)
+      .eq("project_id", HARVEST_PROJECT_ID);
+    for (const row of (mediaRows ?? []) as Array<{ uploader_id: string | null }>) {
+      if (!row.uploader_id) continue;
+      mediaCounts.set(row.uploader_id, (mediaCounts.get(row.uploader_id) ?? 0) + 1);
+    }
+  }
+
+  return storytellers.map((s: any): HarvestStorytellerSummary => {
+    const profId = s.profile_id as string | null;
+    const stories = (storyRows ?? [])
+      .filter((row: any) => row.author_id === s.id || (profId && row.author_id === profId))
+      .map((row: any) => ({
+        id: row.id,
+        title: row.title,
+        isPublic: !!row.is_public,
+        projectId: row.project_id,
+        createdAt: row.created_at,
+        isHarvestProject: row.project_id === HARVEST_PROJECT_ID,
+      }));
+    const articles = (articleRows ?? [])
+      .filter((row: any) => row.author_storyteller_id === s.id)
+      .map((row: any) => ({
+        id: row.id,
+        title: row.title,
+        slug: row.slug,
+        status: row.status,
+        primaryProject: row.primary_project,
+        relatedProjects: row.related_projects,
+        publishedAt: row.published_at,
+        isHarvestTagged:
+          row.primary_project === "the-harvest" ||
+          (Array.isArray(row.related_projects) && row.related_projects.includes("the-harvest")),
+      }));
+    return {
+      id: s.id,
+      profileId: profId,
+      displayName: s.display_name,
+      bio: s.bio,
+      avatarUrl: s.public_avatar_url,
+      location: s.location,
+      isActive: !!s.is_active,
+      stories,
+      articles,
+      mediaCount: profId ? mediaCounts.get(profId) ?? 0 : 0,
+    };
+  });
+}
+
+// Orphaned candidates: articles whose title/slug suggests Harvest content but
+// that aren't formally tagged (primary_project != "the-harvest" AND not in
+// related_projects). Includes Sophie's published article which was tagged with
+// a work slug ("the-garden") instead of the actual project slug.
+export type HarvestOrphanArticle = {
+  id: string;
+  title: string | null;
+  slug: string | null;
+  status: string | null;
+  authorName: string | null;
+  authorStorytellerId: string | null;
+  primaryProject: string | null;
+  relatedProjects: string[] | null;
+  publishedAt: string | null;
+};
+
+export async function listOrphanedHarvestArticles(): Promise<HarvestOrphanArticle[]> {
+  const { supabase } = await createElAdminContext();
+  // Pull a wider candidate set then filter in memory; PostgREST `or` syntax
+  // doesn't compose cleanly for "matches name OR matches slug AND not tagged".
+  const { data, error } = await supabase
+    .from("articles")
+    .select("id, title, slug, status, author_name, author_storyteller_id, primary_project, related_projects, published_at")
+    .or("slug.ilike.%harvest%,slug.ilike.%sophie%,slug.ilike.%barry%,slug.ilike.%garden%,slug.ilike.%milk-crate%,slug.ilike.%witta%,title.ilike.%harvest%,author_name.ilike.%harvest%");
+  if (error) throw error;
+  return (data ?? [])
+    .filter((row: any) => {
+      const isTagged =
+        row.primary_project === "the-harvest" ||
+        (Array.isArray(row.related_projects) && row.related_projects.includes("the-harvest"));
+      return !isTagged;
+    })
+    .map((row: any) => ({
+      id: row.id,
+      title: row.title,
+      slug: row.slug,
+      status: row.status,
+      authorName: row.author_name,
+      authorStorytellerId: row.author_storyteller_id,
+      primaryProject: row.primary_project,
+      relatedProjects: row.related_projects,
+      publishedAt: row.published_at,
+    }));
+}
+
+// One-shot fix-up: tag an article's primary_project to "the-harvest" so it
+// surfaces in the public Harvest articles feed. If primary_project already
+// has a different value, that value is preserved by being added to
+// related_projects so we don't lose work-slug categorization.
+export async function tagArticleAsHarvest(articleId: string): Promise<{ updated: boolean; before: string | null; preservedInRelated: string | null }> {
+  const { supabase } = await createElAdminContext();
+  const { data: existing, error: readErr } = await supabase
+    .from("articles")
+    .select("id, primary_project, related_projects")
+    .eq("id", articleId)
+    .maybeSingle();
+  if (readErr) throw readErr;
+  if (!existing) throw new Error(`Article ${articleId} not found in Empathy Ledger.`);
+
+  if (existing.primary_project === "the-harvest") {
+    return { updated: false, before: existing.primary_project, preservedInRelated: null };
+  }
+
+  const previousPrimary = existing.primary_project as string | null;
+  const currentRelated = Array.isArray(existing.related_projects) ? existing.related_projects : [];
+  const nextRelated =
+    previousPrimary && !currentRelated.includes(previousPrimary)
+      ? [...currentRelated, previousPrimary]
+      : currentRelated;
+
+  const { error: updateErr } = await supabase
+    .from("articles")
+    .update({
+      primary_project: "the-harvest",
+      related_projects: nextRelated,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", articleId);
+  if (updateErr) throw updateErr;
+
+  return {
+    updated: true,
+    before: previousPrimary,
+    preservedInRelated: previousPrimary && !currentRelated.includes(previousPrimary) ? previousPrimary : null,
+  };
+}
+
+// Claim an orphan article by linking it to a curated Harvest storyteller.
+// Sets author_storyteller_id and switches author_type to "storyteller".
+export async function claimArticleForStoryteller(input: {
+  articleId: string;
+  storytellerId: string;
+}): Promise<{ updated: boolean; before: string | null }> {
+  if (!HARVEST_STORYTELLER_IDS.includes(input.storytellerId)) {
+    throw new Error(`Storyteller ${input.storytellerId} is not in the curated Harvest list.`);
+  }
+  const { supabase } = await createElAdminContext();
+  const { data: existing, error: readErr } = await supabase
+    .from("articles")
+    .select("id, author_storyteller_id")
+    .eq("id", input.articleId)
+    .maybeSingle();
+  if (readErr) throw readErr;
+  if (!existing) throw new Error(`Article ${input.articleId} not found.`);
+
+  if (existing.author_storyteller_id === input.storytellerId) {
+    return { updated: false, before: existing.author_storyteller_id };
+  }
+
+  const { error: updateErr } = await supabase
+    .from("articles")
+    .update({
+      author_storyteller_id: input.storytellerId,
+      author_type: "storyteller",
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", input.articleId);
+  if (updateErr) throw updateErr;
+
+  return { updated: true, before: existing.author_storyteller_id };
+}

--- a/server/empathyLedgerAdmin.ts
+++ b/server/empathyLedgerAdmin.ts
@@ -1,7 +1,9 @@
 import dotenv from "dotenv";
 import { createClient } from "@supabase/supabase-js";
+import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { readdir, readFile, stat } from "node:fs/promises";
+import { readdir, readFile, stat, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { basename, extname, join, relative } from "node:path";
 
 dotenv.config({ path: ".env.local", override: false, quiet: true });
@@ -77,6 +79,12 @@ type HarvestUploadSource = {
   base64Data?: string;
   absolutePath?: string;
   sourcePath?: string;
+  proxyMetadata?: {
+    originalFileName: string;
+    originalSize: number;
+    proxySize: number;
+    preset: string;
+  };
 };
 
 type TagMode = "merge" | "replace";
@@ -381,6 +389,7 @@ async function uploadHarvestMediaSourcesToEmpathyLedger(input: {
             harvestUploadedBy: input.uploadedBy,
             harvestRecipe: input.recipe,
             harvestSourcePath: file.sourcePath ?? null,
+            harvestProxy: file.proxyMetadata ?? null,
           },
         })
         .select("id")
@@ -672,6 +681,60 @@ export async function listHarvestLocalMotionFilesWithElStatus(cwd = process.cwd(
   }
 }
 
+// Files this size or larger get re-encoded through ffmpeg before upload.
+// Below the threshold the cost (encode time, two writes) outweighs storage win.
+const VIDEO_PROXY_SIZE_THRESHOLD = 5 * 1024 * 1024;
+const VIDEO_PROXY_PRESET = "h264-crf24-720p-aac96k-faststart";
+
+type CompressedProxy = {
+  buffer: Buffer;
+  fileName: string;
+  contentType: "video/mp4";
+  originalSize: number;
+  proxySize: number;
+  preset: string;
+};
+
+async function compressVideoToProxy(absolutePath: string, originalFileName: string): Promise<CompressedProxy> {
+  const tempPath = join(tmpdir(), `harvest-proxy-${randomUUID()}.mp4`);
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const proc = spawn("ffmpeg", [
+        "-hide_banner", "-loglevel", "error", "-y",
+        "-i", absolutePath,
+        "-vf", "scale='min(1280,iw)':'-2'",
+        "-c:v", "libx264", "-preset", "medium", "-crf", "24", "-pix_fmt", "yuv420p",
+        "-c:a", "aac", "-b:a", "96k",
+        "-movflags", "+faststart",
+        tempPath,
+      ]);
+      let stderr = "";
+      proc.stderr.on("data", (chunk) => { stderr += chunk.toString(); });
+      proc.on("error", reject);
+      proc.on("close", (code) => {
+        if (code === 0) resolve();
+        else reject(new Error(`ffmpeg exit ${code}: ${stderr.slice(-400) || "unknown"}`));
+      });
+    });
+
+    const buffer = await readFile(tempPath);
+    const originalSize = (await stat(absolutePath)).size;
+    const proxyName = originalFileName.replace(/\.[^.]+$/, "") + "-proxy.mp4";
+
+    return {
+      buffer,
+      fileName: proxyName,
+      contentType: "video/mp4",
+      originalSize,
+      proxySize: buffer.length,
+      preset: VIDEO_PROXY_PRESET,
+    };
+  } finally {
+    await unlink(tempPath).catch(() => {});
+  }
+}
+
 export async function importHarvestLocalMotionFilesToEmpathyLedger(input: {
   paths: string[];
   recipe: HarvestUploadRecipe;
@@ -685,14 +748,57 @@ export async function importHarvestLocalMotionFilesToEmpathyLedger(input: {
     throw new Error("One or more selected video files are no longer available in the codebase.");
   }
 
-  return uploadHarvestMediaSourcesToEmpathyLedger({
-    files: selected.map((file) => ({
-      fileName: file.fileName,
-      contentType: file.contentType,
-      absolutePath: join(process.cwd(), file.relativePath),
-      sourcePath: file.relativePath,
-    })),
+  const sources: HarvestUploadSource[] = [];
+  const failed: Array<{ fileName: string; error: string }> = [];
+
+  for (const file of selected) {
+    const absolutePath = join(process.cwd(), file.relativePath);
+    const shouldCompress = file.kind === "video" && file.size >= VIDEO_PROXY_SIZE_THRESHOLD;
+
+    if (!shouldCompress) {
+      sources.push({
+        fileName: file.fileName,
+        contentType: file.contentType,
+        absolutePath,
+        sourcePath: file.relativePath,
+      });
+      continue;
+    }
+
+    try {
+      const proxy = await compressVideoToProxy(absolutePath, file.fileName);
+      sources.push({
+        fileName: proxy.fileName,
+        contentType: proxy.contentType,
+        base64Data: proxy.buffer.toString("base64"),
+        sourcePath: file.relativePath,
+        proxyMetadata: {
+          originalFileName: file.fileName,
+          originalSize: proxy.originalSize,
+          proxySize: proxy.proxySize,
+          preset: proxy.preset,
+        },
+      });
+    } catch (error) {
+      failed.push({
+        fileName: file.fileName,
+        error: `proxy compression failed: ${(error as Error).message}`,
+      });
+    }
+  }
+
+  if (sources.length === 0) {
+    return { uploaded: [], failed };
+  }
+
+  const upload = await uploadHarvestMediaSourcesToEmpathyLedger({
+    files: sources,
     recipe: input.recipe,
     uploadedBy: input.uploadedBy,
   });
+
+  return {
+    uploaded: upload.uploaded,
+    failed: [...failed, ...upload.failed],
+  };
 }

--- a/server/empathyLedgerAdmin.ts
+++ b/server/empathyLedgerAdmin.ts
@@ -1720,6 +1720,135 @@ export async function getPublicHarvestStorytellerBySlug(
   }
 
   const localPhotos = await listLocalCompendiumPhotos(firstName);
+  const elPhotos = await listElPhotosForStoryteller(match.id);
+  // Dedupe: prefer local (curated) over EL when filenames overlap.
+  const localFiles = new Set(localPhotos.map((p) => p.src.split("/").pop() ?? ""));
+  const mergedPhotos = [
+    ...localPhotos,
+    ...elPhotos.filter((p) => {
+      const file = p.src.split("/").pop() ?? "";
+      return !localFiles.has(file);
+    }),
+  ];
 
-  return { ...match, articles, stories, transcripts, localPhotos };
+  return { ...match, articles, stories, transcripts, localPhotos: mergedPhotos };
+}
+
+// ---------------------------------------------------------------------------
+// Photo attribution — link EL Harvest media to specific storytellers via
+// metadata.harvestStorytellers: [storytellerId, ...]. Public profile pages
+// read this to surface "Moments with X" beyond the local /images/compendium
+// hand-curated folders.
+// ---------------------------------------------------------------------------
+
+export type HarvestPhotoForAttribution = {
+  id: string;
+  cdnUrl: string | null;
+  thumbnailUrl: string | null;
+  originalFilename: string | null;
+  createdAt: string | null;
+  taggedStorytellerIds: string[];
+};
+
+// List recent Harvest media plus which storytellers each is currently tagged
+// with. Used by the admin photo-attribution picker.
+export async function listHarvestMediaForAttribution(limit = 200): Promise<HarvestPhotoForAttribution[]> {
+  const { supabase } = await createElAdminContext();
+  const { data, error } = await supabase
+    .from("media_assets")
+    .select("id, cdn_url, thumbnail_url, original_filename, created_at, metadata, media_type")
+    .eq("project_id", HARVEST_PROJECT_ID)
+    .eq("media_type", "image")
+    .order("created_at", { ascending: false })
+    .limit(limit);
+  if (error) throw error;
+  return (data ?? []).map((row: any) => {
+    const tagged = Array.isArray(row.metadata?.harvestStorytellers)
+      ? row.metadata.harvestStorytellers.filter((v: any) => typeof v === "string")
+      : [];
+    return {
+      id: row.id,
+      cdnUrl: row.cdn_url,
+      thumbnailUrl: row.thumbnail_url,
+      originalFilename: row.original_filename,
+      createdAt: row.created_at,
+      taggedStorytellerIds: tagged,
+    };
+  });
+}
+
+// Apply storyteller tags to a batch of media. Mode "merge" appends, "replace"
+// rewrites the harvestStorytellers array. Restricted to media on the Harvest
+// project + storytellers on the Harvest project_storytellers join.
+export async function tagMediaWithStorytellers(input: {
+  mediaIds: string[];
+  storytellerIds: string[];
+  mode: "merge" | "replace";
+}): Promise<{ updated: number }> {
+  if (input.mediaIds.length === 0) return { updated: 0 };
+  const { supabase } = await createElAdminContext();
+
+  // Validate every storyteller is on the Harvest project.
+  if (input.storytellerIds.length > 0) {
+    const { data: links } = await supabase
+      .from("project_storytellers")
+      .select("storyteller_id")
+      .eq("project_id", HARVEST_PROJECT_ID)
+      .in("storyteller_id", input.storytellerIds);
+    const allowed = new Set((links ?? []).map((l: any) => l.storyteller_id));
+    const rejected = input.storytellerIds.filter((id) => !allowed.has(id));
+    if (rejected.length > 0) {
+      throw new Error(`Storyteller(s) not on Harvest project: ${rejected.join(", ")}`);
+    }
+  }
+
+  // Validate every media asset belongs to the Harvest project.
+  const { data: rows, error: rowsErr } = await supabase
+    .from("media_assets")
+    .select("id, project_id, metadata")
+    .in("id", input.mediaIds);
+  if (rowsErr) throw rowsErr;
+  const mismatched = (rows ?? []).filter((r: any) => r.project_id !== HARVEST_PROJECT_ID);
+  if (mismatched.length > 0) {
+    throw new Error(`${mismatched.length} media asset(s) not on Harvest project — refusing to tag.`);
+  }
+
+  let updated = 0;
+  for (const row of rows ?? []) {
+    const existing: string[] = Array.isArray((row as any).metadata?.harvestStorytellers)
+      ? (row as any).metadata.harvestStorytellers.filter((v: any) => typeof v === "string")
+      : [];
+    const next = input.mode === "replace"
+      ? Array.from(new Set(input.storytellerIds))
+      : Array.from(new Set([...existing, ...input.storytellerIds]));
+    if (existing.length === next.length && existing.every((id) => next.includes(id))) continue;
+    const newMetadata = { ...((row as any).metadata ?? {}), harvestStorytellers: next };
+    const { error } = await supabase
+      .from("media_assets")
+      .update({ metadata: newMetadata, updated_at: new Date().toISOString() })
+      .eq("id", (row as any).id);
+    if (error) throw error;
+    updated += 1;
+  }
+  return { updated };
+}
+
+// Public read: list EL media tagged with this storyteller. Used by the
+// public profile to merge with local /images/compendium photos.
+export async function listElPhotosForStoryteller(storytellerId: string): Promise<PublicStorytellerPhoto[]> {
+  const { supabase } = await createElAdminContext();
+  // PostgREST jsonb contains operator: metadata @> '{"harvestStorytellers": ["..."]}'
+  const { data, error } = await supabase
+    .from("media_assets")
+    .select("id, cdn_url, thumbnail_url, original_filename")
+    .eq("project_id", HARVEST_PROJECT_ID)
+    .eq("media_type", "image")
+    .filter("metadata->harvestStorytellers", "cs", `["${storytellerId}"]`)
+    .order("created_at", { ascending: false })
+    .limit(60);
+  if (error) throw error;
+  return (data ?? []).map((row: any) => ({
+    src: row.thumbnail_url || row.cdn_url || "",
+    alt: row.original_filename ? `Harvest photo ${row.original_filename}` : "Harvest photo",
+  })).filter((p: PublicStorytellerPhoto) => p.src);
 }

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -11,8 +11,11 @@ import { empathyLedgerClient } from "./empathyLedgerClient.js";
 import {
   addStorytellerToHarvest,
   claimArticleForStoryteller,
+  createHarvestArticle,
   createHarvestStory,
+  deleteHarvestArticle,
   deleteHarvestStory,
+  getHarvestArticle,
   getHarvestProjectStats,
   getHarvestStory,
   getPublicHarvestStoryById,
@@ -27,6 +30,7 @@ import {
   tagArticleAsHarvest,
   tagHarvestMediaInEmpathyLedger,
   tagMediaWithStorytellers,
+  updateHarvestArticle,
   updateHarvestStory,
   updateStorytellerBio,
   uploadHarvestMediaToEmpathyLedger,
@@ -1440,6 +1444,61 @@ export const appRouter = router({
       .mutation(async ({ ctx, input }) => {
         if (ctx.user.role !== "admin") throw new Error("Unauthorized");
         return tagMediaWithStorytellers(input);
+      }),
+
+    // Article CRUD — author + publish polished articles directly into Harvest
+    createHarvestArticle: protectedProcedure
+      .input(z.object({
+        title: z.string().min(1).max(255),
+        content: z.string().min(1).max(100000),
+        slug: z.string().max(120).optional(),
+        excerpt: z.string().max(500).optional(),
+        subtitle: z.string().max(255).optional(),
+        themes: z.array(z.string().max(80)).max(10).optional(),
+        authorStorytellerId: z.string().uuid(),
+        articleType: z.enum([
+          "story_feature", "editorial", "community_news", "project_update",
+          "program_spotlight", "impact_report", "community_event",
+        ]).optional(),
+        status: z.enum(["draft", "published", "archived"]).optional(),
+      }))
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") throw new Error("Unauthorized");
+        return createHarvestArticle(input);
+      }),
+
+    getHarvestArticle: protectedProcedure
+      .input(z.object({ articleId: z.string().uuid() }))
+      .query(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") throw new Error("Unauthorized");
+        return getHarvestArticle(input.articleId);
+      }),
+
+    updateHarvestArticle: protectedProcedure
+      .input(z.object({
+        articleId: z.string().uuid(),
+        title: z.string().min(1).max(255).optional(),
+        content: z.string().min(1).max(100000).optional(),
+        slug: z.string().max(120).optional(),
+        excerpt: z.string().max(500).optional(),
+        subtitle: z.string().max(255).optional(),
+        themes: z.array(z.string().max(80)).max(10).optional(),
+        articleType: z.enum([
+          "story_feature", "editorial", "community_news", "project_update",
+          "program_spotlight", "impact_report", "community_event",
+        ]).optional(),
+        status: z.enum(["draft", "published", "archived"]).optional(),
+      }))
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") throw new Error("Unauthorized");
+        return updateHarvestArticle(input);
+      }),
+
+    deleteHarvestArticle: protectedProcedure
+      .input(z.object({ articleId: z.string().uuid() }))
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") throw new Error("Unauthorized");
+        return deleteHarvestArticle(input.articleId);
       }),
   }),
 

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -1,6 +1,6 @@
 import { systemRouter } from "./_core/systemRouter.js";
 import { publicProcedure, protectedProcedure, router } from "./_core/trpc.js";
-import { createEvent, getApprovedEvents, getPendingEvents, updateEventStatus, createBusiness, getApprovedBusinesses, getPendingBusinesses, updateBusinessStatus, getBusinessByUserId, getBusinessById, claimBusiness, updateBusinessProfile, getUnclaimedApprovedBusinesses, getProgressImages, createProgressImage, updateProgressImage, deleteProgressImage, promoteUserToAdmin, getAllUsers, getContent, getContentForPage, upsertContent, getAnnotationsForPoint, createAnnotation, deleteAnnotation, createPulseResponse, getPulseResults, createEventFeedbackEntry, getEventFeedbackByEventId, getAllEventFeedback } from "./db.js";
+import { createEvent, getApprovedEvents, getPendingEvents, updateEventStatus, createBusiness, getApprovedBusinesses, getPendingBusinesses, updateBusinessStatus, getBusinessByUserId, getBusinessById, claimBusiness, updateBusinessProfile, getUnclaimedApprovedBusinesses, getProgressImages, createProgressImage, updateProgressImage, deleteProgressImage, promoteUserToAdmin, getAllUsers, getContent, getContentForPage, upsertContent, getAnnotationsForPoint, createAnnotation, deleteAnnotation, createPulseResponse, getPulseResults, createEventFeedbackEntry, getEventFeedbackByEventId, getAllEventFeedback, createWittaContribution, getApprovedWittaContributions, getPendingWittaContributions, updateWittaContributionStatus, getImageOverride, setImageOverride, clearImageOverride, listImageOverrides } from "./db.js";
 import { storagePut } from "./storage.js";
 import { getDb } from "./db.js";
 import { pulseResponses } from "../drizzle/schema.js";
@@ -8,6 +8,29 @@ import { eq } from "drizzle-orm";
 import { upsertGHLContact, addGHLContactNote, addGHLContactTag, getGHLContact, triggerGHLWorkflow, getGHLContactCountByTag, getGHLSocialAccounts, createGHLSocialPost, getGHLSocialPosts, searchGHLContactsByTag, batchTriggerWorkflow, createGHLEmailTemplate } from "./gohighlevel.js";
 import { getGalleryPhotos, addGalleryPhoto, removeGalleryPhoto } from "./photoWallGallery.js";
 import { empathyLedgerClient } from "./empathyLedgerClient.js";
+import {
+  addStorytellerToHarvest,
+  claimArticleForStoryteller,
+  createHarvestStory,
+  deleteHarvestStory,
+  getHarvestProjectStats,
+  getHarvestStory,
+  getPublicHarvestStoryById,
+  getPublicHarvestStorytellerBySlug,
+  importHarvestLocalMotionFilesToEmpathyLedger,
+  listHarvestLocalMotionFilesWithElStatus,
+  listHarvestMediaForAttribution,
+  listHarvestStorytellersWithContent,
+  listOrphanedHarvestArticles,
+  listPublicHarvestStorytellers,
+  searchStorytellers,
+  tagArticleAsHarvest,
+  tagHarvestMediaInEmpathyLedger,
+  tagMediaWithStorytellers,
+  updateHarvestStory,
+  updateStorytellerBio,
+  uploadHarvestMediaToEmpathyLedger,
+} from "./empathyLedgerAdmin.js";
 import {
   loadTimeline,
   loadZones,
@@ -35,6 +58,17 @@ const CURRENT_GATHERING_SWITCHBOARD_TAGS = [
   "Event type: Public launch (50–150)",
   "Access: Open registration (Public)",
 ];
+
+const harvestMediaRecipeInput = z.object({
+  work: z.string().min(1).max(100),
+  themes: z.array(z.string().min(1).max(50)).min(1).max(4),
+  categories: z.array(z.string().min(1).max(80)).min(1).max(4),
+  title: z.string().min(1).max(120),
+  extraTags: z.array(z.object({
+    slug: z.string().min(1).max(80),
+    category: z.string().min(1).max(80),
+  })).max(12).optional(),
+});
 
 export const appRouter = router({
     // if you need to use socket.io, read and register route in server/_core/index.ts, all api should start with '/api/' so that the gateway can route correctly
@@ -744,6 +778,7 @@ export const appRouter = router({
       .input(z.object({
         theme: z.string().optional(),
         type: z.string().optional(),
+        project: z.string().optional(), // EL primaryProject — e.g. work slug
         page: z.number().optional(),
         limit: z.number().min(1).max(50).optional(),
       }).optional())
@@ -751,6 +786,7 @@ export const appRouter = router({
         const response = await empathyLedgerClient.fetchArticles({
           theme: input?.theme,
           type: input?.type,
+          project: input?.project,
           page: input?.page,
           limit: input?.limit || 20,
         });
@@ -792,6 +828,26 @@ export const appRouter = router({
           limit: input.limit || 10,
         });
         return results;
+      }),
+  }),
+
+  // Public-facing Harvest content surface (storytellers + their work).
+  // No auth — these power /people pages on the public site.
+  harvest: router({
+    publicStorytellers: publicProcedure.query(async () => {
+      return listPublicHarvestStorytellers();
+    }),
+
+    publicStorytellerBySlug: publicProcedure
+      .input(z.object({ slug: z.string().min(1).max(100) }))
+      .query(async ({ input }) => {
+        return getPublicHarvestStorytellerBySlug(input.slug);
+      }),
+
+    publicStoryById: publicProcedure
+      .input(z.object({ storyId: z.string().uuid() }))
+      .query(async ({ input }) => {
+        return getPublicHarvestStoryById(input.storyId);
       }),
   }),
 
@@ -903,6 +959,8 @@ export const appRouter = router({
         category: z.enum(["all", "before", "during", "after", "milestone", "general"]).optional(),
         tag: z.string().optional(), // Page tag: "home", "journey", "stories", etc.
         theme: z.string().optional(), // Theme: "eat", "grow", "make", "gather"
+        project: z.string().optional(), // Project slug (legacy / project_id filter)
+        work: z.string().optional(), // Harvest work slug — filters by harvest-work tag
         limit: z.number().min(1).max(100).optional(),
         page: z.number().min(1).optional(),
       }).optional())
@@ -911,10 +969,27 @@ export const appRouter = router({
           category: input?.category === "all" ? undefined : input?.category,
           tag: input?.tag,
           theme: input?.theme,
+          project: input?.project,
+          work: input?.work,
           limit: input?.limit || 50,
           page: input?.page,
         });
         return response;
+      }),
+
+    // Public: Get media for a specific Work (one of the 5 collection pieces)
+    // Filters by harvest-work tag (mill-crate-pavilion / the-cedar / etc.)
+    // Tag photos with `harvest-work: <slug>` in EL admin to make them appear here.
+    forWork: publicProcedure
+      .input(z.object({
+        slug: z.string().min(1).max(100), // e.g. "milk-crate-pavilion"
+        limit: z.number().min(1).max(100).optional(),
+      }))
+      .query(async ({ input }) => {
+        return await empathyLedgerClient.fetchHarvestGallery({
+          work: input.slug,
+          limit: input.limit ?? 24,
+        });
       }),
 
     // Public: Get media for a specific page
@@ -1111,13 +1186,332 @@ export const appRouter = router({
     }),
   }),
 
+  // Witta history community contributions
+  witta: router({
+    // Public: submit a memory/correction tied to a year/era
+    submit: publicProcedure
+      .input(z.object({
+        authorName: z.string().min(1).max(255),
+        authorEmail: z.string().email().optional().or(z.literal("")),
+        yearOrEra: z.string().min(1).max(100),
+        memory: z.string().min(10).max(4000),
+        photoUrl: z.string().max(1000).optional().or(z.literal("")),
+      }))
+      .mutation(async ({ input }) => {
+        const contribution = await createWittaContribution({
+          authorName: input.authorName,
+          authorEmail: input.authorEmail || null,
+          yearOrEra: input.yearOrEra,
+          memory: input.memory,
+          photoUrl: input.photoUrl || null,
+          status: "pending",
+        });
+        return { success: true, id: contribution?.id };
+      }),
+
+    // Public: list approved community memories
+    approved: publicProcedure.query(async () => {
+      return await getApprovedWittaContributions();
+    }),
+
+    // Admin: list pending memories awaiting moderation
+    pending: protectedProcedure.query(async ({ ctx }) => {
+      if (ctx.user.role !== "admin") {
+        throw new Error("Unauthorized");
+      }
+      return await getPendingWittaContributions();
+    }),
+
+    // Admin: approve or reject a memory
+    moderate: protectedProcedure
+      .input(z.object({
+        id: z.number(),
+        status: z.enum(["approved", "rejected"]),
+        adminNotes: z.string().max(1000).optional(),
+      }))
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") {
+          throw new Error("Unauthorized");
+        }
+        const updated = await updateWittaContributionStatus(
+          input.id,
+          input.status,
+          ctx.user.id,
+          input.adminNotes,
+        );
+        return { success: true, id: updated?.id };
+      }),
+  }),
+
+  mediaLibrary: router({
+    localVideos: protectedProcedure.query(async ({ ctx }) => {
+      if (ctx.user.role !== "admin") {
+        throw new Error("Unauthorized");
+      }
+      return listHarvestLocalMotionFilesWithElStatus();
+    }),
+
+    applyTags: protectedProcedure
+      .input(z.object({
+        recipe: harvestMediaRecipeInput,
+        mediaIds: z.array(z.string().min(1).max(80)).min(1).max(100),
+        mode: z.enum(["merge", "replace"]).optional(),
+      }))
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") {
+          throw new Error("Unauthorized");
+        }
+        return tagHarvestMediaInEmpathyLedger({
+          mediaIds: input.mediaIds,
+          recipe: input.recipe,
+          mode: input.mode,
+        });
+      }),
+
+    uploadToEL: protectedProcedure
+      .input(z.object({
+        recipe: harvestMediaRecipeInput,
+        files: z.array(z.object({
+          fileName: z.string().min(1).max(255),
+          contentType: z.string().min(1).max(120),
+          base64Data: z.string().min(1),
+        })).min(1).max(12),
+      }))
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") {
+          throw new Error("Unauthorized");
+        }
+        return uploadHarvestMediaToEmpathyLedger({
+          files: input.files,
+          recipe: input.recipe,
+          uploadedBy: ctx.user.id,
+        });
+      }),
+
+    importLocalVideos: protectedProcedure
+      .input(z.object({
+        recipe: harvestMediaRecipeInput,
+        paths: z.array(z.string().min(1).max(500)).min(1).max(30),
+      }))
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") {
+          throw new Error("Unauthorized");
+        }
+        return importHarvestLocalMotionFilesToEmpathyLedger({
+          paths: input.paths,
+          recipe: input.recipe,
+          uploadedBy: ctx.user.id,
+        });
+      }),
+
+    // Project-level rollup matching EL admin's Harvest project view.
+    harvestProjectStats: protectedProcedure
+      .query(async ({ ctx }) => {
+        if (ctx.user.role !== "admin") throw new Error("Unauthorized");
+        return getHarvestProjectStats();
+      }),
+
+    // Storytellers on the Harvest project_storytellers join (Chris, Barry,
+    // Sophie, plus anyone added via EL admin) with their stories, articles,
+    // transcripts, and media counts rolled up.
+    harvestStorytellers: protectedProcedure
+      .query(async ({ ctx }) => {
+        if (ctx.user.role !== "admin") throw new Error("Unauthorized");
+        return listHarvestStorytellersWithContent();
+      }),
+
+    // Articles whose title/slug suggests Harvest content but that aren't
+    // formally project-tagged. Click "Tag as Harvest" to rescue them.
+    orphanedHarvestArticles: protectedProcedure
+      .query(async ({ ctx }) => {
+        if (ctx.user.role !== "admin") throw new Error("Unauthorized");
+        return listOrphanedHarvestArticles();
+      }),
+
+    tagArticleAsHarvest: protectedProcedure
+      .input(z.object({ articleId: z.string().uuid() }))
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") throw new Error("Unauthorized");
+        return tagArticleAsHarvest(input.articleId);
+      }),
+
+    claimArticleForStoryteller: protectedProcedure
+      .input(z.object({
+        articleId: z.string().uuid(),
+        storytellerId: z.string().uuid(),
+      }))
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") throw new Error("Unauthorized");
+        return claimArticleForStoryteller(input);
+      }),
+
+    // Phase 2: write into EL from the Harvest admin
+
+    searchStorytellers: protectedProcedure
+      .input(z.object({ query: z.string().min(0).max(120) }))
+      .query(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") throw new Error("Unauthorized");
+        return searchStorytellers(input.query);
+      }),
+
+    addStorytellerToHarvest: protectedProcedure
+      .input(z.object({
+        storytellerId: z.string().uuid(),
+        role: z.enum(["participant", "contributor", "owner", "subject"]),
+      }))
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") throw new Error("Unauthorized");
+        return addStorytellerToHarvest(input);
+      }),
+
+    updateStorytellerBio: protectedProcedure
+      .input(z.object({
+        storytellerId: z.string().uuid(),
+        bio: z.string().min(0).max(5000),
+      }))
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") throw new Error("Unauthorized");
+        return updateStorytellerBio(input);
+      }),
+
+    createHarvestStory: protectedProcedure
+      .input(z.object({
+        title: z.string().min(1).max(255),
+        content: z.string().min(1).max(50000),
+        summary: z.string().max(1000).optional(),
+        themes: z.array(z.string().max(80)).max(10).optional(),
+        authorStorytellerId: z.string().uuid(),
+        isPublic: z.boolean().optional(),
+      }))
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") throw new Error("Unauthorized");
+        return createHarvestStory(input);
+      }),
+
+    getHarvestStory: protectedProcedure
+      .input(z.object({ storyId: z.string().uuid() }))
+      .query(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") throw new Error("Unauthorized");
+        return getHarvestStory(input.storyId);
+      }),
+
+    updateHarvestStory: protectedProcedure
+      .input(z.object({
+        storyId: z.string().uuid(),
+        title: z.string().min(1).max(255).optional(),
+        content: z.string().min(1).max(50000).optional(),
+        summary: z.string().max(1000).optional(),
+        themes: z.array(z.string().max(80)).max(10).optional(),
+        isPublic: z.boolean().optional(),
+      }))
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") throw new Error("Unauthorized");
+        return updateHarvestStory(input);
+      }),
+
+    deleteHarvestStory: protectedProcedure
+      .input(z.object({ storyId: z.string().uuid() }))
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") throw new Error("Unauthorized");
+        return deleteHarvestStory(input.storyId);
+      }),
+
+    // Photo attribution: list recent Harvest media + which storytellers each
+    // is currently tagged with. Powers the per-storyteller photo picker.
+    harvestMediaForAttribution: protectedProcedure
+      .input(z.object({
+        limit: z.number().min(1).max(500).optional(),
+        work: z.string().min(1).max(100).nullable().optional(),
+      }).optional())
+      .query(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") throw new Error("Unauthorized");
+        return listHarvestMediaForAttribution({
+          limit: input?.limit ?? 200,
+          work: input?.work ?? null,
+        });
+      }),
+
+    tagMediaWithStorytellers: protectedProcedure
+      .input(z.object({
+        mediaIds: z.array(z.string().uuid()).min(1).max(200),
+        storytellerIds: z.array(z.string().uuid()).max(20),
+        mode: z.enum(["merge", "replace"]),
+      }))
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") throw new Error("Unauthorized");
+        return tagMediaWithStorytellers(input);
+      }),
+  }),
+
+  // Image overrides — admins can pick an EL photo for any (page, slot)
+  imageOverrides: router({
+    // Public: read the current override for a (page, slot)
+    get: publicProcedure
+      .input(z.object({
+        page: z.string().min(1).max(100),
+        slot: z.string().min(1).max(200),
+      }))
+      .query(async ({ input }) => {
+        const row = await getImageOverride(input.page, input.slot);
+        return row ?? null;
+      }),
+
+    // Admin: set / replace the override
+    set: protectedProcedure
+      .input(z.object({
+        page: z.string().min(1).max(100),
+        slot: z.string().min(1).max(200),
+        mediaAssetId: z.string().min(1).max(64),
+        src: z.string().min(1).max(1000),
+        altText: z.string().max(500).optional(),
+        title: z.string().max(255).optional(),
+      }))
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") {
+          throw new Error("Unauthorized");
+        }
+        const row = await setImageOverride({
+          page: input.page,
+          slot: input.slot,
+          mediaAssetId: input.mediaAssetId,
+          src: input.src,
+          altText: input.altText ?? null,
+          title: input.title ?? null,
+          setBy: ctx.user.id,
+        });
+        return { success: true, id: row?.id };
+      }),
+
+    // Admin: clear an override (reverts to bundled / EL-tag fallback)
+    clear: protectedProcedure
+      .input(z.object({
+        page: z.string().min(1).max(100),
+        slot: z.string().min(1).max(200),
+      }))
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role !== "admin") {
+          throw new Error("Unauthorized");
+        }
+        const ok = await clearImageOverride(input.page, input.slot);
+        return { success: ok };
+      }),
+
+    // Admin: list all overrides (for an audit panel)
+    list: protectedProcedure.query(async ({ ctx }) => {
+      if (ctx.user.role !== "admin") {
+        throw new Error("Unauthorized");
+      }
+      return await listImageOverrides();
+    }),
+  }),
+
   // Editable content for inline CMS
   content: router({
     // Public: Get content for a specific slot
     get: publicProcedure
       .input(z.object({
         page: z.string().min(1).max(100),
-        slot: z.string().min(1).max(100),
+        slot: z.string().min(1).max(200),
       }))
       .query(async ({ input }) => {
         const content = await getContent(input.page, input.slot);
@@ -1137,7 +1531,7 @@ export const appRouter = router({
     update: protectedProcedure
       .input(z.object({
         page: z.string().min(1).max(100),
-        slot: z.string().min(1).max(100),
+        slot: z.string().min(1).max(200),
         content: z.string(),
         contentType: z.enum(["text", "markdown", "html"]).optional(),
       }))


### PR DESCRIPTION
## Summary

Unbreaks the build. Commits 10 files that were referenced from committed code but had never been committed themselves — they were sitting untracked in the working tree only. A clean checkout (or Vercel deploy) would currently fail with `TS2307` on every reference.

## What's in this PR

- **`client/src/components/HarvestPhotoPicker.tsx`** — the EL photo picker dialog used in `MediaLibraryAdmin` for assigning EL photos to public image slots
- **`client/src/components/HarvestMediaGallery.tsx`** — auto-pull EL gallery component
- **`client/src/components/HarvestImage.tsx`**
- **`client/src/lib/empathyLedger.ts`** — EL admin link helpers + org id
- **`client/src/lib/imageOptimize.ts`**
- **`client/src/data/works.ts`** — the works collection (referenced by `Works.tsx` and `Person.tsx`)
- **`client/src/pages/Works.tsx`** — `/works` index (referenced by `App.tsx`)
- **`client/src/pages/GardenLaunch.tsx`** — `/garden-launch` event page for 20 June 2026
- **`client/src/pages/LaunchRedesign.tsx`**
- **`client/src/pages/HarvestReviewTest.tsx`**

Files are unchanged from the working tree of the main checkout.

## Out of scope (deliberately left for a curated follow-up)

The working tree of `main` also has 65 other untracked + 17 modified files. Those are a separate decision and not in this PR:

- Server-side modifications: `server/empathyLedgerClient.ts`, `server/db.ts`, `server/notion.ts`, `server/gohighlevel.ts`, `server/_core/context.ts` — should be reviewed before committing
- `client/src/pages/Witta.tsx` adds a Community Memories section that calls `trpc.witta.approved` and `trpc.witta.submit` — but the corresponding server router doesn't exist. Don't commit this until the server side lands
- Scratch files (`.pen`, `.psd`, `.pptx`, screenshot PNGs, `.playwright-mcp/`) — shouldn't be tracked at all
- Docs (`docs/brand/`, `docs/communications/`, runbooks) — review and commit deliberately

## Test plan

- [x] `npx vite build` passes (2854 modules, 5.62s)
- [ ] Vercel preview deploy builds clean
- [ ] `/admin/media-library` loads and the "Pick from EL" buttons open the picker dialog
- [ ] `/works` and `/garden-launch` render