### PR TITLE
docs(launch-kit): website launch + Garden Launch social and newsletter

### DIFF
--- a/docs/launch-kit/website-launch-2026-05/newsletter.html
+++ b/docs/launch-kit/website-launch-2026-05/newsletter.html
@@ -1,0 +1,210 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>The Harvest, Witta — The site is live, and the garden is going in</title>
+<!--
+  Newsletter for the website launch + Garden Launch Day.
+  Drafted 2026-05-09. Send window: 12 to 16 May 2026.
+  Paste into GHL Email Builder as custom HTML.
+  Voice: matter of fact, no em-dashes, specific details.
+-->
+</head>
+<body style="margin:0;padding:0;background:#1c1917;font-family:Georgia,'Times New Roman',serif;color:#e7e5e4;">
+
+<!-- Preheader -->
+<div style="display:none;max-height:0;overflow:hidden;font-size:1px;line-height:1px;color:#1c1917;">
+  The site is live. The garden is going in. Long table lunch on Saturday 20 June, 10am, 9 Gumland Drive, Witta.
+</div>
+
+<table width="100%" cellpadding="0" cellspacing="0" style="background:#1c1917;">
+<tr><td align="center" style="padding:40px 20px;">
+
+<table width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;">
+
+  <!-- Header -->
+  <tr>
+    <td style="padding:30px 40px 20px;text-align:center;">
+      <p style="margin:0;font-size:14px;letter-spacing:3px;color:#a8a29e;text-transform:uppercase;">The Harvest</p>
+      <p style="margin:4px 0 0;font-size:11px;letter-spacing:2px;color:#78716c;text-transform:uppercase;">Witta &middot; Jinibara Country</p>
+    </td>
+  </tr>
+
+  <!-- Hero -->
+  <tr>
+    <td style="padding:20px 0 0;">
+      <img src="https://theharvestwitta.com.au/images/site-plan/layers/photos/00-base-photo.png"
+           alt="Aerial view of The Harvest site in Witta, Sunshine Coast Hinterland"
+           width="600"
+           style="width:100%;height:auto;display:block;" />
+    </td>
+  </tr>
+
+  <!-- Headline -->
+  <tr>
+    <td style="padding:48px 40px 16px;text-align:center;">
+      <h1 style="margin:0;font-size:32px;line-height:1.25;color:#fbbf24;font-weight:normal;font-family:Georgia,serif;">
+        The site is live.<br>The garden is going in.
+      </h1>
+    </td>
+  </tr>
+
+  <!-- Lede -->
+  <tr>
+    <td style="padding:0 40px 24px;text-align:center;">
+      <p style="margin:0;font-size:16px;line-height:1.7;color:#d6d3d1;">
+        After three years of conversations, sketches, a lease, and a community of people who kept showing up,
+        <a href="https://theharvestwitta.com.au" style="color:#fbbf24;text-decoration:underline;">theharvestwitta.com.au</a>
+        is where The Harvest now lives.
+      </p>
+    </td>
+  </tr>
+
+  <!-- Divider -->
+  <tr><td style="padding:8px 40px;"><div style="height:1px;background:#44403c;"></div></td></tr>
+
+  <!-- Section: What's on the site -->
+  <tr>
+    <td style="padding:32px 40px 8px;">
+      <p style="margin:0;font-size:11px;letter-spacing:2.5px;color:#fbbf24;text-transform:uppercase;">What is on the site</p>
+      <h2 style="margin:8px 0 16px;font-size:22px;line-height:1.3;color:#f5f5f4;font-weight:normal;">
+        Five things to look at first
+      </h2>
+    </td>
+  </tr>
+
+  <tr>
+    <td style="padding:0 40px 8px;">
+      <p style="margin:0 0 14px;font-size:15px;line-height:1.7;color:#d6d3d1;">
+        <strong style="color:#fbbf24;">The home page.</strong>
+        Garden, Make, Feed. Three zones. The aerial video. A first read of who and what.
+        <a href="https://theharvestwitta.com.au" style="color:#fbbf24;">See it</a>.
+      </p>
+      <p style="margin:0 0 14px;font-size:15px;line-height:1.7;color:#d6d3d1;">
+        <strong style="color:#fbbf24;">People of The Harvest.</strong>
+        The first storyteller profiles are up. Real people, in their own words. We are publishing more every week.
+        <a href="https://theharvestwitta.com.au/people" style="color:#fbbf24;">Meet them</a>.
+      </p>
+      <p style="margin:0 0 14px;font-size:15px;line-height:1.7;color:#d6d3d1;">
+        <strong style="color:#fbbf24;">The Collection.</strong>
+        Five works. The Garden, the Milk Crate Pavilion, the Cedar, the Sauna, the Shop. Each one carries a thread back to the history of this place.
+        <a href="https://theharvestwitta.com.au/works" style="color:#fbbf24;">Walk the works</a>.
+      </p>
+      <p style="margin:0 0 14px;font-size:15px;line-height:1.7;color:#d6d3d1;">
+        <strong style="color:#fbbf24;">Witta.</strong>
+        The history of this hinterland, told by the people who live here. Jinibara Country first, then cedar getters, dairy farmers, the cooperative movement.
+        <a href="https://theharvestwitta.com.au/witta" style="color:#fbbf24;">Read it</a>.
+      </p>
+      <p style="margin:0 0 14px;font-size:15px;line-height:1.7;color:#d6d3d1;">
+        <strong style="color:#fbbf24;">Gather.</strong>
+        What is on, when, and how to come. The Garden Launch is the one to put in your diary first.
+        <a href="https://theharvestwitta.com.au/gather" style="color:#fbbf24;">See what is on</a>.
+      </p>
+    </td>
+  </tr>
+
+  <!-- Divider -->
+  <tr><td style="padding:24px 40px 8px;"><div style="height:1px;background:#44403c;"></div></td></tr>
+
+  <!-- Section: Garden Launch -->
+  <tr>
+    <td style="padding:32px 40px 8px;">
+      <p style="margin:0;font-size:11px;letter-spacing:2.5px;color:#fbbf24;text-transform:uppercase;">Save the date</p>
+      <h2 style="margin:8px 0 16px;font-size:26px;line-height:1.25;color:#f5f5f4;font-weight:normal;">
+        Garden Launch + Community Day<br>
+        <span style="color:#fbbf24;">Saturday 20 June 2026</span>
+      </h2>
+    </td>
+  </tr>
+
+  <tr>
+    <td style="padding:0 40px 16px;">
+      <p style="margin:0 0 12px;font-size:15px;line-height:1.7;color:#d6d3d1;">
+        10am to 3pm. 9 Gumland Drive, Witta QLD 4552. Jinibara Country. Sunshine Coast Hinterland. Free.
+      </p>
+      <p style="margin:0 0 12px;font-size:15px;line-height:1.7;color:#d6d3d1;">
+        We will walk the new garden beds together. The Milk Crate Pavilion built by 80 of you in March opens to the public for the first time. There is a long table lunch, wood fired and hinterland grown. The kids plan their own corner with chalk and markers. The open mic asks one question: what is missing in Witta? We listen and write it down.
+      </p>
+      <p style="margin:0 0 4px;font-size:15px;line-height:1.7;color:#d6d3d1;">
+        BYO seat or bring an empty one for a neighbour.
+      </p>
+    </td>
+  </tr>
+
+  <!-- CTA -->
+  <tr>
+    <td style="padding:24px 40px 8px;text-align:center;">
+      <a href="https://theharvestwitta.com.au/garden-launch"
+         style="display:inline-block;background:#fbbf24;color:#1c1917;font-family:Georgia,serif;font-size:14px;letter-spacing:2px;text-transform:uppercase;text-decoration:none;padding:16px 32px;font-weight:bold;">
+        RSVP for the long table
+      </a>
+    </td>
+  </tr>
+
+  <!-- Divider -->
+  <tr><td style="padding:32px 40px 8px;"><div style="height:1px;background:#44403c;"></div></td></tr>
+
+  <!-- Section: Quiet asks -->
+  <tr>
+    <td style="padding:32px 40px 8px;">
+      <p style="margin:0;font-size:11px;letter-spacing:2.5px;color:#fbbf24;text-transform:uppercase;">Quiet asks</p>
+      <h2 style="margin:8px 0 16px;font-size:22px;line-height:1.3;color:#f5f5f4;font-weight:normal;">
+        Three things you can do this week
+      </h2>
+    </td>
+  </tr>
+
+  <tr>
+    <td style="padding:0 40px 24px;">
+      <p style="margin:0 0 12px;font-size:15px;line-height:1.7;color:#d6d3d1;">
+        <strong style="color:#fbbf24;">1.</strong> Share <a href="https://theharvestwitta.com.au" style="color:#fbbf24;">theharvestwitta.com.au</a> with one person who would care about this. Local growers, makers, neighbours, family.
+      </p>
+      <p style="margin:0 0 12px;font-size:15px;line-height:1.7;color:#d6d3d1;">
+        <strong style="color:#fbbf24;">2.</strong> If you have stories about Witta, the dairy days, the timber years, the cooperative, send them. They go on the Witta page with your name and your words.
+      </p>
+      <p style="margin:0 0 12px;font-size:15px;line-height:1.7;color:#d6d3d1;">
+        <strong style="color:#fbbf24;">3.</strong> If you make something locally and want to be in the next round of the Shop, write back. We are listening.
+      </p>
+    </td>
+  </tr>
+
+  <!-- Sign-off -->
+  <tr>
+    <td style="padding:24px 40px 16px;text-align:center;">
+      <p style="margin:0 0 8px;font-size:15px;line-height:1.6;color:#d6d3d1;font-style:italic;">
+        Come by. Say hello. Bring something to share.
+      </p>
+      <p style="margin:0;font-size:14px;line-height:1.6;color:#a8a29e;">
+        Ben and Nicholas<br>
+        The Harvest, Witta
+      </p>
+    </td>
+  </tr>
+
+  <!-- Footer -->
+  <tr>
+    <td style="padding:32px 40px 24px;text-align:center;border-top:1px solid #44403c;">
+      <p style="margin:0 0 8px;font-size:12px;line-height:1.6;color:#78716c;">
+        9 Gumland Drive, Witta QLD 4552 &middot; Jinibara Country
+      </p>
+      <p style="margin:0 0 8px;font-size:12px;line-height:1.6;color:#78716c;">
+        <a href="mailto:hello@theharvestwitta.com.au" style="color:#a8a29e;">hello@theharvestwitta.com.au</a>
+      </p>
+      <p style="margin:16px 0 0;font-size:11px;line-height:1.6;color:#57534e;">
+        We acknowledge the Jinibara people as the traditional custodians of the land on which The Harvest is being built, and pay respect to their elders past, present, and emerging.
+      </p>
+      <p style="margin:16px 0 0;font-size:11px;line-height:1.6;color:#57534e;">
+        You are receiving this because you signed up at theharvestwitta.com.au or said yes at a gathering.
+        <a href="{{unsubscribe_url}}" style="color:#78716c;">Unsubscribe</a>.
+      </p>
+    </td>
+  </tr>
+
+</table>
+
+</td></tr>
+</table>
+
+</body>
+</html>

--- a/docs/launch-kit/website-launch-2026-05/social-posts.md
+++ b/docs/launch-kit/website-launch-2026-05/social-posts.md
@@ -1,0 +1,107 @@
+# Social Posts — Website Launch + Garden Launch Day
+
+Drafted 2026-05-09. The site is live at theharvestwitta.com.au. Garden Launch + Community Day is Saturday 20 June 2026, 10am to 3pm.
+
+Voice rules: matter of fact, no em-dashes, no flourish, specific details over abstract. Witta first, Maleny in brackets where useful. Jinibara Country always acknowledged.
+
+Five posts. Stagger them across the next two weeks. Each one points back to the site or to a specific page.
+
+---
+
+## Post 1 — The site is live
+
+**Platform:** Facebook, Instagram, Witta and Maleny community groups
+**Image:** Aerial drone shot from the hero video, or the rammed-earth wall close up
+**When:** Tuesday, 9am
+
+> The Harvest has a home on the internet now.
+>
+> Three years of conversations, sketches, a lease, a community of people who kept showing up. theharvestwitta.com.au is where it lives.
+>
+> You'll find the people building it, the works in motion (the garden, the pavilion, the cedar room, the shop, the sauna), the writing that explains why we're doing this, and a way to come visit.
+>
+> 9 Gumland Drive, Witta. Jinibara Country. Sunshine Coast Hinterland.
+>
+> theharvestwitta.com.au
+>
+> #TheHarvestWitta #Witta #Maleny #JinibaraCountry #SunshineCoastHinterland
+
+---
+
+## Post 2 — Save the date: Garden Launch
+
+**Platform:** Facebook, Instagram, local groups
+**Image:** Garden bed photo, or a sketch from the brand kit
+**When:** Wednesday, 11am, two weeks before event
+
+> Saturday 20 June. 10am to 3pm. 9 Gumland Drive, Witta.
+>
+> The garden is going in. The Milk Crate Pavilion built by 80 of you in March is opening to the public. There is a long table lunch, wood fired, hinterland grown, free.
+>
+> The kids plan their own corner with chalk and markers. The open mic asks one question: what is missing in Witta? We listen and write it down.
+>
+> RSVP for a seat at the long table. theharvestwitta.com.au/garden-launch
+>
+> #GardenLaunch #TheHarvestWitta #Witta #JinibaraCountry
+
+---
+
+## Post 3 — People of The Harvest
+
+**Platform:** Instagram, Facebook
+**Image:** Portrait of one of the storytellers (pulled from the Empathy Ledger gallery)
+**When:** Thursday, 12pm
+
+> The Harvest is the people, not the place.
+>
+> Ben and Nicholas started it. Susie and Joey are the paired community stewards. The architects, the gardeners, the kids who built the milk crate wall, Barry from the nursery next door who has been restoring native plants here for 27 years.
+>
+> We've started publishing their voices on the site. Read who is on the land and what brought them.
+>
+> theharvestwitta.com.au/people
+>
+> #PeopleOfTheHarvest #Witta #Maleny #SunshineCoastHinterland
+
+---
+
+## Post 4 — The Collection
+
+**Platform:** Facebook, Instagram
+**Image:** A graphite-pencil sketch of one of the works (pavilion, cedar, garden, sauna, shop)
+**When:** Saturday, 10am
+
+> The Harvest is a slow, living collection.
+>
+> Five works for now. The Garden. The Milk Crate Pavilion. The Cedar (the timber room, not yet built). The Sauna. The Shop. Some are growing. Some are forthcoming. Each one carries a thread back to the history of this place: Jinibara Country first, then the cedar getters, the dairy farmers, the cooperative movement.
+>
+> See the collection: theharvestwitta.com.au/works
+>
+> #TheCollection #TheHarvestWitta #JinibaraCountry #HinterlandHistory
+
+---
+
+## Post 5 — Newsletter sign up
+
+**Platform:** Facebook, Instagram, local groups
+**Image:** The shed door at golden hour, or a long-table photo
+**When:** Sunday, 8am
+
+> If you want to know when the long table is set, when the sauna fires up the first time, when the cedar gets milled, when there is a workshop or an open garden day, sign up.
+>
+> One email a month. No marketing, no upsell. Just what is happening on the land.
+>
+> Sign up at the bottom of theharvestwitta.com.au.
+>
+> Or come visit. 9 Gumland Drive, Witta. Saturdays we are usually around.
+>
+> #TheHarvestWitta #Witta #SunshineCoastHinterland
+
+---
+
+## Notes for the person scheduling these
+
+- Always tag location as Witta first, Sunshine Coast Hinterland, Queensland
+- Acknowledge Jinibara Country in at least one post per week, ideally with the work being shown
+- Photos should come from the Empathy Ledger gallery (the admin picker pulls from there). Use the matter of fact, natural light, real people, real hands shots. No stock imagery. No staged smiles
+- Hashtags are restrained on purpose. Five or six per post, location plus topic. Don't pile on
+- If a post links to a specific page, double check the page actually exists in production before scheduling


### PR DESCRIPTION
## Summary

Adds the launch content kit for the website launch and the Garden Launch + Community Day on 20 June 2026:

- 5 social posts staggered across two weeks
- 1 GHL-ready HTML newsletter (matches the dark-theme template from `01-launch-newsletter.html`)

Voice rules applied:
- Matter of fact, no flourish
- **No em-dashes** anywhere
- Witta first, Maleny in brackets where useful
- Jinibara Country acknowledged
- Specific details over abstract description (per the Brand Guide writing section)

## Files

- `docs/launch-kit/website-launch-2026-05/social-posts.md`
- `docs/launch-kit/website-launch-2026-05/newsletter.html`

## Test plan

- [ ] Newsletter HTML renders correctly when pasted into GHL Email Builder
- [ ] Open newsletter in a browser to spot-check styles
- [ ] Read the social posts and tweak any phrasing before scheduling
- [ ] Replace placeholder photo references with EL-picked images via the admin picker