### PR TITLE
chore(gitignore): ignore scratch files cluttering git status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,19 @@ docs/vision-prep/audio-transcripts/*.mp3
 docs/vision-prep/audio-transcripts/*.m4a
 docs/vision-prep/audio-transcripts/*.wav
 docs/vision-prep/audio-transcripts/*.ogg
+
+# Playwright MCP traces and Supabase local CLI cache
+.playwright-mcp/
+supabase/.temp/
+
+# Pencil and Morpholio design scratch
+*.pen
+*.morpholiotrace
+
+# Root-level scratch (screenshots, design source files, decks, AI image dumps)
+/*.psd
+/*.pptx
+/harvest-*.png
+/harvest-*-snapshot.md
+/images/
+


### PR DESCRIPTION
## Summary

Adds 16 lines to `.gitignore` to hide the 30+ untracked scratch files that have been showing up in `git status` for a while. None of them belong in git.

## Why

After PR #2 lands, you will pull main and still see ~30 noisy lines in `git status`. This kills the signal in `git status` and makes it easier to accidentally `git add .` something that shouldn't ship.

## Patterns added

- `.playwright-mcp/` — Playwright MCP local trace cache
- `supabase/.temp/` — Supabase CLI local cache
- `*.pen` — Pencil design files (encrypted, edited via the Pencil MCP)
- `*.morpholiotrace` — Morpholio iPad design files
- `/*.psd` — root-level Photoshop scratch (anchored, so future committed PSDs in subdirs are fine)
- `/*.pptx` — root-level deck scratch (same anchoring rationale)
- `/harvest-*.png` — root-level screenshot dumps (~25 files like `harvest-launch-redesign-desktop-v3.png`)
- `/harvest-*-snapshot.md` — ad-hoc snapshot markdown
- `/images/` — root-level AI image dumps (3.3M of `generated-*.png`)

Patterns are anchored to root (`/...`) where it matters so they don't accidentally hide intentionally-committed assets in subdirectories.

## Test plan

- [x] Run `git status` after pulling this branch — the 30+ noisy lines are gone
- [ ] Confirm no accidentally-tracked file becomes ignored (none expected — these patterns target untracked-only paths)