### PR TITLE
perf(html): preconnect to Empathy Ledger Supabase storage CDN

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -55,6 +55,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
+    <!-- Empathy Ledger Supabase storage — image CDN -->
+    <link rel="preconnect" href="https://yvnuayzslukamizrlhwb.supabase.co" crossorigin />
+    <link rel="dns-prefetch" href="https://yvnuayzslukamizrlhwb.supabase.co" />
 
     <!-- Fonts -->
     <link


### PR DESCRIPTION
## Summary

Tiny perf win. Adds `<link rel="preconnect">` + `dns-prefetch` for the EL Supabase storage bucket. Browser does the TCP + TLS handshake in parallel with the rest of the page so the first EL image request lands on a warm connection.

Saves roughly 100-300ms on first image load on every page that pulls EL photos:
- `BauhausHome` (People of The Harvest grid)
- `/people` and `/people/:slug`
- `/works/:slug`
- `/blog` and `/blog/:slug`
- `/stories/:id`
- `/witta` gallery (once the photos start coming from EL too)

## Diff

3 lines added to `client/index.html`, slotted next to the existing Google Fonts preconnects.

## Test plan

- [x] `vite build` passes (no behaviour change, just extra `<link>` tags)
- [ ] After deploy, in DevTools Network tab on cold cache: EL Supabase image URLs should report ~0ms DNS / Connect time (already warm)