### PR TITLE
docs(db): record manual migration for image_overrides + witta_contributions

### DIFF
--- a/drizzle/manual/0002_image_overrides_and_witta_contributions.sql
+++ b/drizzle/manual/0002_image_overrides_and_witta_contributions.sql
@@ -1,0 +1,51 @@
+-- Manual migration applied via Supabase SQL Editor on prod
+-- Source: matches the Drizzle schema additions from PR #2
+-- Date applied: 2026-05-09 (record this in your DB ops notes)
+--
+-- Why manual: drizzle-kit generate trips over the historical
+-- users → app_users rename (already handled by 0001_create_app_users.sql)
+-- and prompts interactively. Running this SQL by hand bypasses the prompts.
+--
+-- Idempotent: safe to re-run. Uses IF NOT EXISTS / EXCEPTION handling.
+
+DO $$ BEGIN
+  CREATE TYPE "witta_contribution_status" AS ENUM ('pending', 'approved', 'rejected');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "witta_contributions" (
+  "id" serial PRIMARY KEY,
+  "author_name" varchar(255) NOT NULL,
+  "author_email" varchar(320),
+  "year_or_era" varchar(100) NOT NULL,
+  "memory" text NOT NULL,
+  "photo_url" varchar(1000),
+  "status" "witta_contribution_status" DEFAULT 'pending' NOT NULL,
+  "admin_notes" text,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "approved_at" timestamp with time zone,
+  "approved_by" integer
+);
+
+CREATE TABLE IF NOT EXISTS "image_overrides" (
+  "id" serial PRIMARY KEY,
+  "page" varchar(100) NOT NULL,
+  "slot" varchar(200) NOT NULL,
+  "media_asset_id" varchar(64) NOT NULL,
+  "src" varchar(1000) NOT NULL,
+  "alt_text" varchar(500),
+  "title" varchar(255),
+  "set_by" integer,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+-- Widen editable_content.slot from varchar(100) to varchar(200)
+-- (so longer slot identifiers like "milk-crate-pavilion-hero" fit)
+ALTER TABLE "editable_content" ALTER COLUMN "slot" TYPE varchar(200);
+
+-- Verify after running:
+--   SELECT table_name, column_name, data_type
+--   FROM information_schema.columns
+--   WHERE table_name IN ('image_overrides', 'witta_contributions')
+--   ORDER BY table_name, ordinal_position;

--- a/drizzle/manual/README.md
+++ b/drizzle/manual/README.md
@@ -1,0 +1,26 @@
+# Manual migrations
+
+Drizzle-kit's auto-generator (via `npm run db:push`) is interactive. It trips over historical schema renames (e.g. the `users` → `app_users` rename that was applied via `drizzle/0001_create_app_users.sql`) and asks "is this a new table or a rename?" The wrong answer can rename an existing production table.
+
+When that interactive flow is risky, write the migration SQL by hand and apply it directly via the Supabase SQL Editor (or psql).
+
+## How to apply
+
+1. Open the Supabase SQL Editor for the Harvest project
+2. Paste the contents of the relevant `NNNN_*.sql` file in this directory
+3. Run it
+4. Verify tables / columns exist as expected
+5. Note in your ops log when and where you applied it
+
+## What's here
+
+| File | Applied | Notes |
+|---|---|---|
+| `0002_image_overrides_and_witta_contributions.sql` | 2026-05-09 (verify) | Adds `image_overrides` and `witta_contributions` tables; widens `editable_content.slot` from varchar(100) to varchar(200) |
+
+## When to use this vs `npm run db:push`
+
+- **Use this** when the schema diff would trigger interactive rename prompts
+- **Use `db:push`** when adding small, unambiguous changes and you're comfortable answering the prompts
+
+If you're not sure which case you're in, run `drizzle-kit generate` first (which generates without applying) and inspect the proposed SQL.


### PR DESCRIPTION
## Summary

Records the manual SQL migration that gets applied via the Supabase SQL Editor (instead of `npm run db:push`) for the `image_overrides` and `witta_contributions` tables that landed in PR #2.

## Why manual

`drizzle-kit generate` (which `db:push` runs) is interactive and trips on the historical `users` → `app_users` rename (already applied via the manual `0001_create_app_users.sql`). It would prompt "is this a rename or a new table?" and the wrong answer is destructive.

Pasting this SQL into the Supabase SQL Editor by hand skips all the prompts.

## What this PR adds

- `drizzle/manual/0002_image_overrides_and_witta_contributions.sql` — the actual SQL
- `drizzle/manual/README.md` — when to write manual migrations vs use `db:push`

The SQL is idempotent (uses `IF NOT EXISTS` and `EXCEPTION WHEN duplicate_object`) so re-running is safe.

## How to apply on prod

1. Open Supabase SQL Editor for the Harvest project
2. Paste contents of `drizzle/manual/0002_image_overrides_and_witta_contributions.sql`
3. Run it
4. Verify with the verification query at the bottom of the file
5. Update the README's "Applied" date

## Test plan

- [x] SQL is idempotent (re-running is no-op)
- [ ] After running on prod: visit `/admin/media-library`, click "Pick from EL" → save → confirm row in `image_overrides`
- [ ] After running on prod: visit `/witta`, submit a memory → confirm row in `witta_contributions` with `status="pending"`