### PR TITLE
fix(types): resolve pre-existing TSC errors (tsc --noEmit clean)

### DIFF
--- a/client/src/components/EditableImage.tsx
+++ b/client/src/components/EditableImage.tsx
@@ -50,7 +50,7 @@ interface EditableImageProps {
   /** The page this image belongs to (e.g., "visit", "home") */
   page: string;
   /** The slot type (matches Empathy Ledger special tags) */
-  slot: "hero" | "featured" | "card-1" | "card-2" | "card-3" | "card-4" | "card-5" | "card-6";
+  slot: string;
   /** Alt text for the image */
   alt: string;
   /** CSS classes for the container */

--- a/client/src/components/ProgressGallery.tsx
+++ b/client/src/components/ProgressGallery.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { motion, AnimatePresence } from "framer-motion";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -146,18 +145,15 @@ export function ProgressGallery({
   const [lightboxIndex, setLightboxIndex] = useState(0);
 
   // Fetch from local database API
-  const { data: localImages } = useQuery({
-    queryKey: ["gallery", "list"],
-    queryFn: () => trpc.gallery.list.query(),
+  const { data: localImages } = trpc.gallery.list.useQuery(undefined, {
     enabled: source === "local",
   });
 
   // Fetch from Empathy Ledger
-  const { data: elResponse } = useQuery({
-    queryKey: ["gallery", "fromEL", pageTag, theme],
-    queryFn: () => trpc.gallery.fromEL.query({ tag: pageTag, theme }),
-    enabled: source === "empathy-ledger",
-  });
+  const { data: elResponse } = trpc.gallery.fromEL.useQuery(
+    { tag: pageTag, theme },
+    { enabled: source === "empathy-ledger" },
+  );
 
   // Transform local DB images to match our interface
   const transformedLocalImages: ProgressImage[] | undefined = localImages?.map((img: {

--- a/client/src/components/PublicLayout.tsx
+++ b/client/src/components/PublicLayout.tsx
@@ -278,7 +278,7 @@ export default function PublicLayout({ children }: PublicLayoutProps) {
                                         location === item.href ? "text-amber-700" : "text-stone-900"
                                       )}>
                                         {item.label}
-                                        {"badge" in item && item.badge && (
+                                        {"badge" in item && typeof item.badge === "string" && item.badge && (
                                           <span className="px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide bg-amber-100 text-amber-700 rounded">
                                             {item.badge}
                                           </span>

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -87,26 +87,58 @@ export async function submitBusiness(input: Record<string, unknown>) {
   return data;
 }
 
-export async function listPendingEvents() {
-  const response = await callFunction<{ events: unknown[] }>("admin-events");
+export interface HarvestPendingEvent {
+  id: number;
+  title: string;
+  date: string;
+  time: string;
+  location: string;
+  category: string;
+  description: string;
+  contactEmail: string;
+  submittedBy?: string | null;
+  status: "pending" | "approved" | "rejected";
+  createdAt: string;
+}
+
+export interface HarvestPendingBusiness {
+  id: number;
+  name: string;
+  category: string;
+  description: string;
+  address?: string | null;
+  phone?: string | null;
+  email?: string | null;
+  website?: string | null;
+  facebook?: string | null;
+  instagram?: string | null;
+  imageUrl?: string | null;
+  submittedBy?: string | null;
+  submitterEmail: string;
+  status: "pending" | "approved" | "rejected";
+  createdAt: string;
+}
+
+export async function listPendingEvents(): Promise<HarvestPendingEvent[]> {
+  const response = await callFunction<{ events: HarvestPendingEvent[] }>("admin-events");
   return response.events;
 }
 
-export async function updateEventStatus(eventId: number, status: "approved" | "rejected") {
-  const response = await callFunction<{ event: unknown }>("admin-events", {
+export async function updateEventStatus(eventId: number, status: "approved" | "rejected"): Promise<HarvestPendingEvent> {
+  const response = await callFunction<{ event: HarvestPendingEvent }>("admin-events", {
     eventId,
     status,
   });
   return response.event;
 }
 
-export async function listPendingBusinesses() {
-  const response = await callFunction<{ businesses: unknown[] }>("admin-businesses");
+export async function listPendingBusinesses(): Promise<HarvestPendingBusiness[]> {
+  const response = await callFunction<{ businesses: HarvestPendingBusiness[] }>("admin-businesses");
   return response.businesses;
 }
 
-export async function updateBusinessStatus(businessId: number, status: "approved" | "rejected") {
-  const response = await callFunction<{ business: unknown }>("admin-businesses", {
+export async function updateBusinessStatus(businessId: number, status: "approved" | "rejected"): Promise<HarvestPendingBusiness> {
+  const response = await callFunction<{ business: HarvestPendingBusiness }>("admin-businesses", {
     businessId,
     status,
   });

--- a/client/src/pages/HarvestHome.tsx
+++ b/client/src/pages/HarvestHome.tsx
@@ -2,7 +2,6 @@ import { Link } from "wouter";
 import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { Newspaper, ArrowRight } from "lucide-react";
-import { useQuery } from "@tanstack/react-query";
 import { trpc } from "@/lib/trpc";
 import BlogCard, { type ELArticle } from "@/components/BlogCard";
 
@@ -40,10 +39,7 @@ const pillars = [
 ];
 
 export default function HarvestHome() {
-  const { data: recentPosts = [] } = useQuery({
-    queryKey: ["blog", "recent"],
-    queryFn: () => trpc.blog.recent.query({ limit: 3 }),
-  });
+  const { data: recentPosts = [] } = trpc.blog.recent.useQuery({ limit: 3 });
 
   return (
     <div className="min-h-screen bg-stone-50">

--- a/client/src/pages/MyBusiness.tsx
+++ b/client/src/pages/MyBusiness.tsx
@@ -248,9 +248,9 @@ export default function MyBusiness() {
                                     size="sm" 
                                     className="bg-[#c17c54] hover:bg-[#a06543] shrink-0"
                                     onClick={() => handleClaim(business.id)}
-                                    disabled={claimBusiness.isPending}
+                                    disabled={claimBusinessMutation.isPending}
                                   >
-                                    {claimBusiness.isPending ? (
+                                    {claimBusinessMutation.isPending ? (
                                       <Loader2 className="h-4 w-4 animate-spin" />
                                     ) : (
                                       "Claim"

--- a/client/src/pages/PhotoWall.tsx
+++ b/client/src/pages/PhotoWall.tsx
@@ -47,7 +47,7 @@ export default function PhotoWall() {
   const isMobile = useMediaQuery("(max-width: 768px)");
   const { isAdmin, toggle: toggleAdmin } = useAdmin();
   const tapCount = useRef(0);
-  const tapTimer = useRef<ReturnType<typeof setTimeout>>();
+  const tapTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const handleLogoTap = () => {
     tapCount.current++;

--- a/server/db.ts
+++ b/server/db.ts
@@ -578,7 +578,7 @@ export async function upsertContent(
       await db.update(editableContent)
         .set({ content, contentType, editedBy, updatedAt: new Date() })
         .where(eq(editableContent.id, existing[0].id));
-      return { ...existing[0], content, contentType, editedBy, updatedAt: new Date() };
+      return { ...existing[0], content, contentType, editedBy: editedBy ?? null, updatedAt: new Date() };
     } else {
       // Insert
       await db.insert(editableContent).values({

--- a/server/empathyLedgerAdmin.ts
+++ b/server/empathyLedgerAdmin.ts
@@ -67,7 +67,6 @@ type ElAdminContext = {
     id: string;
     title: string | null;
     organization_id: string | null;
-    tenant_id: string | null;
     created_by: string;
   };
   tenantId: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "tsBuildInfoFile": "./node_modules/typescript/tsbuildinfo",
     "noEmit": true,
     "module": "ESNext",
+    "target": "ES2022",
     "strict": true,
     "lib": ["esnext", "dom", "dom.iterable"],
     "jsx": "preserve",


### PR DESCRIPTION
## Summary

Surfaced during the `chore/launch-prep-2026-05-13` sync — these errors were already on `origin/main`, just not noticed. Branched off main so this can merge independently.

- **AdminDashboard ~50 errors** → typed `HarvestPendingEvent` + `HarvestPendingBusiness` in `client/src/lib/api.ts`
- **trpc `.query` calls** (HarvestHome + ProgressGallery x2) → use `trpc.X.useQuery()` directly. The previous `useQuery({ queryFn: () => trpc.X.query() })` would throw at runtime since the React proxy doesn't expose `.query()`
- **MyBusiness** → `claimBusinessMutation.isPending` instead of `claimBusiness.isPending` (was reading off the imported function, loader never showed)
- **EditableImage slot** → widened to `string`. The narrow card-N union didn't match `/explore`'s use of `story-image` / `garden-image`
- **PublicLayout badge render** → `typeof item.badge === "string"` guard so `unknown` isn't passed to JSX
- **PhotoWall useRef** → explicit `undefined` initial under React 19's tightened types
- **server/db.ts** → `editedBy ?? null` coercion in `upsertContent` return
- **server/empathyLedgerAdmin** → dropped unused `tenant_id` from gallery context type (it's read from profiles, never selected on gallery)
- **tsconfig** → `"target": "ES2022"` so Set/Map iteration works (matches what Vite/esbuild emit anyway)

## Test plan

- [x] `npx tsc --noEmit` exits clean (verified locally, exit 0)
- [ ] `npm run dev` and sanity-check:
  - [ ] `/admin` events + businesses tabs still render
  - [ ] `/harvest-home` recent blog posts load
  - [ ] `/explore` images render (slot widening)
  - [ ] Footer nav renders without missing badges
  - [ ] `/photo-wall` admin tap-toggle still works

## Notes

Behavior-affecting fixes (MyBusiness loader state, ProgressGallery + HarvestHome trpc calls) are isolated and obvious — the prior code was already broken in those paths. Everything else is type-only.