### PR TITLE
fix(seo): point canonical URL + structured data + contact email at actual prod domain

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -14,14 +14,14 @@
     <meta name="robots" content="index, follow" />
 
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://theharvest.community/" />
+    <link rel="canonical" href="https://www.theharvestwitta.com.au/" />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://theharvest.community/" />
+    <meta property="og:url" content="https://www.theharvestwitta.com.au/" />
     <meta property="og:title" content="The Harvest Witta - garden, events and art space" />
     <meta property="og:description" content="A community space forming in Witta, Sunshine Coast Hinterland. Jinibara Country." />
-    <meta property="og:image" content="https://theharvest.community/images/og-image.jpg" />
+    <meta property="og:image" content="https://www.theharvestwitta.com.au/images/og-image.jpg" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:locale" content="en_AU" />
@@ -29,10 +29,10 @@
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:url" content="https://theharvest.community/" />
+    <meta property="twitter:url" content="https://www.theharvestwitta.com.au/" />
     <meta property="twitter:title" content="The Harvest Witta - garden, events and art space" />
     <meta property="twitter:description" content="A community space forming in Witta, Sunshine Coast Hinterland. Jinibara Country." />
-    <meta property="twitter:image" content="https://theharvest.community/images/og-image.jpg" />
+    <meta property="twitter:image" content="https://www.theharvestwitta.com.au/images/og-image.jpg" />
 
     <!-- Geo Tags -->
     <meta name="geo.region" content="AU-QLD" />
@@ -70,15 +70,15 @@
     {
       "@context": "https://schema.org",
       "@type": "LocalBusiness",
-      "@id": "https://theharvest.community/#organization",
+      "@id": "https://www.theharvestwitta.com.au/#organization",
       "name": "The Harvest",
       "alternateName": "The Harvest Witta",
       "description": "A regenerative community hub featuring a seasonal kitchen, garden centre, workshops, and gathering space in the Sunshine Coast hinterland.",
-      "url": "https://theharvest.community",
-      "logo": "https://theharvest.community/images/logo.png",
-      "image": "https://theharvest.community/images/harvest-hero.jpg",
+      "url": "https://www.theharvestwitta.com.au",
+      "logo": "https://www.theharvestwitta.com.au/images/logo.png",
+      "image": "https://www.theharvestwitta.com.au/images/harvest-hero.jpg",
       "telephone": "",
-      "email": "hello@theharvest.community",
+      "email": "hello@theharvestwitta.com.au",
       "address": {
         "@type": "PostalAddress",
         "streetAddress": "",
@@ -157,7 +157,7 @@
           "@type": "ListItem",
           "position": 1,
           "name": "Home",
-          "item": "https://theharvest.community/"
+          "item": "https://www.theharvestwitta.com.au/"
         }
       ]
     }


### PR DESCRIPTION
## Summary

`client/index.html` had 11 references to `https://theharvest.community` — a domain not in this project's Vercel domain list. Search engines were being told the canonical URL was a domain Ben doesn't appear to control, which leaks SEO juice and can confuse indexing of the actual prod site (`https://www.theharvestwitta.com.au`).

All 11 references replaced:
- `<link rel="canonical">`
- `og:url`, `og:image`
- `twitter:url`, `twitter:image`
- Schema.org `LocalBusiness`: `@id`, `url`, `logo`, `image`, `email`
- Schema.org `BreadcrumbList`: home item URL

Plus the contact email in the structured data: `hello@theharvest.community` → `hello@theharvestwitta.com.au` (matches what's actually used in `Contact.tsx` and the `PublicLayout` footer).

## Test plan

- [x] Zero `theharvest.community` references remain in `client/index.html` (verified)
- [ ] After deploy: `curl https://www.theharvestwitta.com.au/ | grep canonical` returns the new URL
- [ ] After deploy: validate the structured data with [Google's Rich Results Test](https://search.google.com/test/rich-results) on the new URL

## Out of scope (noted, deferred)

The `LocalBusiness` structured data still describes the site as "a regenerative community hub featuring a seasonal kitchen, garden centre, workshops, and gathering space" with services `Community Kitchen` / `Garden Centre` / `Workshops` / `Venue Hire`. That's the old brand/scope language (kitchen is now a sublicenced future operation per `CLAUDE.md`). A future PR could realign the schema with the "garden, events and art space" brand, but it's lower-priority than the canonical fix.