### PR TITLE
fix(seo): realign Schema.org LocalBusiness with current brand

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -73,15 +73,13 @@
       "@id": "https://www.theharvestwitta.com.au/#organization",
       "name": "The Harvest",
       "alternateName": "The Harvest Witta",
-      "description": "A regenerative community hub featuring a seasonal kitchen, garden centre, workshops, and gathering space in the Sunshine Coast hinterland.",
+      "description": "A garden, events and art space forming in Witta, on Jinibara Country in the Sunshine Coast hinterland. A community-built place for gathering, growing and making.",
       "url": "https://www.theharvestwitta.com.au",
       "logo": "https://www.theharvestwitta.com.au/images/logo.png",
       "image": "https://www.theharvestwitta.com.au/images/harvest-hero.jpg",
-      "telephone": "",
       "email": "hello@theharvestwitta.com.au",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "",
         "addressLocality": "Witta",
         "addressRegion": "QLD",
         "postalCode": "4552",
@@ -92,38 +90,20 @@
         "latitude": "-26.7234",
         "longitude": "152.8123"
       },
-      "openingHoursSpecification": [
-        {
-          "@type": "OpeningHoursSpecification",
-          "dayOfWeek": ["Saturday", "Sunday"],
-          "opens": "08:00",
-          "closes": "14:00"
-        }
-      ],
-      "priceRange": "$$",
-      "servesCuisine": "Australian",
       "sameAs": [
         "https://www.facebook.com/theharvestwitta",
         "https://www.instagram.com/theharvestwitta"
       ],
       "hasOfferCatalog": {
         "@type": "OfferCatalog",
-        "name": "Services",
+        "name": "What's forming at The Harvest",
         "itemListElement": [
           {
             "@type": "Offer",
             "itemOffered": {
               "@type": "Service",
-              "name": "Community Kitchen",
-              "description": "Seasonal breakfast and brunch using local produce"
-            }
-          },
-          {
-            "@type": "Offer",
-            "itemOffered": {
-              "@type": "Service",
-              "name": "Garden Centre",
-              "description": "Native and productive plants for the Sunshine Coast region"
+              "name": "Community Events",
+              "description": "Community days, gatherings and shared meals on the garden site"
             }
           },
           {
@@ -131,7 +111,7 @@
             "itemOffered": {
               "@type": "Service",
               "name": "Workshops",
-              "description": "Pottery, preserving, gardening and more"
+              "description": "Practical workshops in the garden, art and food spaces"
             }
           },
           {
@@ -139,7 +119,15 @@
             "itemOffered": {
               "@type": "Service",
               "name": "Venue Hire",
-              "description": "Indoor-outdoor space for events and celebrations"
+              "description": "Indoor and outdoor space for events and celebrations"
+            }
+          },
+          {
+            "@type": "Offer",
+            "itemOffered": {
+              "@type": "Service",
+              "name": "Art Space",
+              "description": "Residencies, exhibitions and creative practice shaped by local artists"
             }
           }
         ]


### PR DESCRIPTION
## Summary

Follow-up to PR #15 (which I flagged as deferred). The `LocalBusiness` JSON-LD block in `client/index.html` still described The Harvest as a kitchen-led commercial venue with Sat/Sun opening hours. That's neither current brand (kitchen is a future sublicenced operation per `CLAUDE.md`) nor current reality (site is "not open for casual drop-ins yet" per `Membership.tsx`).

### What changed

| Field | Before | After |
| --- | --- | --- |
| `description` | "A regenerative community hub featuring a seasonal kitchen, garden centre, workshops, and gathering space..." | "A garden, events and art space forming in Witta, on Jinibara Country in the Sunshine Coast hinterland. A community-built place for gathering, growing and making." |
| `telephone` | `""` (empty) | Removed |
| `streetAddress` | `""` (empty) | Removed |
| `openingHoursSpecification` | Sat/Sun 8am-2pm | Removed (site not open for casual drop-ins) |
| `priceRange` | `"$$"` | Removed |
| `servesCuisine` | `"Australian"` | Removed |
| `hasOfferCatalog.name` | `"Services"` | `"What's forming at The Harvest"` |
| Service: Community Kitchen | present | dropped (future sublicenced) |
| Service: Garden Centre | present | dropped (not a current offering) |
| Service: Workshops | kept, reworded |  |
| Service: Venue Hire | kept, reworded |  |
| Service: Community Events | — | added (top-line brand pillar) |
| Service: Art Space | — | added (top-line brand pillar) |

### Why drop opening hours and price range

Search engines surface these in knowledge panels. Listing Sat/Sun 8am-2pm sends visitors to a closed site. Better to omit until the place actually has consistent open hours. Same for price range.

## Test plan

- [x] Both JSON-LD blocks validated as parseable (`node -e "JSON.parse(...)"` ✓)
- [ ] After deploy: paste prod URL into [Google's Rich Results Test](https://search.google.com/test/rich-results) — should show LocalBusiness recognised with the new description/services
- [ ] After deploy: paste prod URL into [Schema.org validator](https://validator.schema.org/) — should be error-free

## Out of scope

The `description` could still be tightened. Open to copy edits if you have a preferred phrasing.