### PR TITLE
feat(seo): build-time sitemap with works + EL dynamic routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch server/_core/index.ts",
-    "build": "vite build && esbuild server/_core/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build && tsx scripts/build-sitemap.ts && esbuild server/_core/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build:sitemap": "tsx scripts/build-sitemap.ts",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc --noEmit",
     "format": "prettier --write .",

--- a/scripts/build-sitemap.ts
+++ b/scripts/build-sitemap.ts
@@ -1,0 +1,161 @@
+/**
+ * Generate sitemap.xml for production build.
+ *
+ * Runs AFTER vite build. Writes to dist/public/sitemap.xml, overwriting
+ * the static fallback that was copied from client/public/sitemap.xml.
+ *
+ * Sources:
+ *  - static public routes (hard-coded — matches client/public/sitemap.xml as the floor)
+ *  - /works/:slug from client/src/data/works.ts (static)
+ *  - /blog/:slug from Empathy Ledger (best-effort, falls back silently on failure)
+ *  - /stories/:slug from Empathy Ledger (best-effort)
+ *  - /people/:slug from Empathy Ledger (best-effort)
+ *
+ * If EL is unreachable or returns nothing, the dynamic sections are skipped
+ * and the sitemap still has the full static-route set. Build never fails
+ * because of a sitemap-generation hiccup.
+ */
+
+import { writeFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const SITE = "https://www.theharvestwitta.com.au";
+const TODAY = new Date().toISOString().slice(0, 10);
+const OUTPUT = resolve(process.cwd(), "dist/public/sitemap.xml");
+
+type Entry = {
+  loc: string;
+  priority: string;
+  changefreq: "weekly" | "monthly" | "yearly";
+  lastmod?: string;
+};
+
+const STATIC_ROUTES: Entry[] = [
+  { loc: "/", priority: "1.0", changefreq: "weekly" },
+  { loc: "/membership", priority: "0.9", changefreq: "weekly" },
+  { loc: "/what-is-the-harvest", priority: "0.8", changefreq: "monthly" },
+  { loc: "/story", priority: "0.8", changefreq: "monthly" },
+  { loc: "/witta", priority: "0.7", changefreq: "monthly" },
+  { loc: "/works", priority: "0.7", changefreq: "weekly" },
+  { loc: "/people", priority: "0.7", changefreq: "weekly" },
+  { loc: "/blog", priority: "0.6", changefreq: "weekly" },
+  { loc: "/contact", priority: "0.6", changefreq: "yearly" },
+  { loc: "/compendium", priority: "0.5", changefreq: "monthly" },
+  { loc: "/pulse", priority: "0.5", changefreq: "monthly" },
+  { loc: "/community", priority: "0.5", changefreq: "monthly" },
+  { loc: "/photo-wall", priority: "0.5", changefreq: "monthly" },
+  { loc: "/gather", priority: "0.5", changefreq: "monthly" },
+];
+
+function entryXml(e: Entry): string {
+  return `  <url>
+    <loc>${SITE}${e.loc}</loc>
+    <lastmod>${e.lastmod ?? TODAY}</lastmod>
+    <changefreq>${e.changefreq}</changefreq>
+    <priority>${e.priority}</priority>
+  </url>`;
+}
+
+async function workEntries(): Promise<Entry[]> {
+  try {
+    const { works } = await import("../client/src/data/works.js");
+    return works.map((w: { slug: string }) => ({
+      loc: `/works/${w.slug}`,
+      priority: "0.6",
+      changefreq: "monthly" as const,
+    }));
+  } catch (error) {
+    console.warn("[sitemap] could not load works.ts:", (error as Error).message);
+    return [];
+  }
+}
+
+async function elEntries(): Promise<Entry[]> {
+  const apiKey = process.env.EMPATHY_LEDGER_API_KEY;
+  const baseUrl = process.env.EMPATHY_LEDGER_API_URL || "https://empathyledger.com";
+
+  if (!apiKey) {
+    console.warn("[sitemap] EMPATHY_LEDGER_API_KEY not set, skipping EL routes");
+    return [];
+  }
+
+  const entries: Entry[] = [];
+
+  type ElItem = { slug?: string };
+
+  async function fetchJson<T>(path: string): Promise<T | null> {
+    try {
+      const res = await fetch(`${baseUrl}${path}`, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+      if (!res.ok) {
+        console.warn(`[sitemap] EL ${path} returned ${res.status}`);
+        return null;
+      }
+      return (await res.json()) as T;
+    } catch (error) {
+      console.warn(`[sitemap] EL ${path} fetch failed:`, (error as Error).message);
+      return null;
+    }
+  }
+
+  // Blog articles
+  const articlesRes = await fetchJson<{ articles?: ElItem[] }>(
+    "/api/v1/content-hub/articles?syndicated_to=harvest&limit=200",
+  );
+  for (const a of articlesRes?.articles ?? []) {
+    if (a.slug) {
+      entries.push({ loc: `/blog/${a.slug}`, priority: "0.5", changefreq: "monthly" });
+    }
+  }
+
+  // Stories
+  const storiesRes = await fetchJson<{ stories?: ElItem[] }>(
+    "/api/v1/content-hub/stories?syndicated_to=harvest&limit=200",
+  );
+  for (const s of storiesRes?.stories ?? []) {
+    if (s.slug) {
+      entries.push({ loc: `/stories/${s.slug}`, priority: "0.5", changefreq: "monthly" });
+    }
+  }
+
+  // People (storytellers)
+  const peopleRes = await fetchJson<{ storytellers?: ElItem[] }>(
+    "/api/v1/content-hub/storytellers?syndicated_to=harvest&limit=200",
+  );
+  for (const p of peopleRes?.storytellers ?? []) {
+    if (p.slug) {
+      entries.push({ loc: `/people/${p.slug}`, priority: "0.5", changefreq: "monthly" });
+    }
+  }
+
+  return entries;
+}
+
+async function main() {
+  if (!existsSync(resolve(process.cwd(), "dist/public"))) {
+    console.error("[sitemap] dist/public does not exist - run vite build first");
+    process.exit(0);
+  }
+
+  const [works, el] = await Promise.all([workEntries(), elEntries()]);
+  const all = [...STATIC_ROUTES, ...works, ...el];
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${all.map(entryXml).join("\n")}
+</urlset>
+`;
+
+  writeFileSync(OUTPUT, xml, "utf8");
+  console.log(
+    `[sitemap] wrote ${all.length} URLs to ${OUTPUT} ` +
+      `(${STATIC_ROUTES.length} static, ${works.length} works, ${el.length} EL)`,
+  );
+}
+
+main().catch((error) => {
+  console.error("[sitemap] generation failed:", error);
+  // Don't fail the build - the static client/public/sitemap.xml fallback is already in dist/public/
+  process.exit(0);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "pnpm exec vite build",
+  "buildCommand": "pnpm exec vite build && pnpm exec tsx scripts/build-sitemap.ts",
   "outputDirectory": "dist/public",
   "rewrites": [
     { "source": "/api/trpc/:path*", "destination": "/api/trpc/[trpc]" },


### PR DESCRIPTION
## Summary

Follow-up to PR #17 (static sitemap). Adds a build-time generator that emits dynamic URLs for `/works/:slug`, `/blog/:slug`, `/stories/:slug` and `/people/:slug` so the whole content surface is indexed, not just the 14 hard-coded routes.

### Architecture

- `scripts/build-sitemap.ts` runs **after** `vite build`, overwriting `dist/public/sitemap.xml` with the fully-populated version
- Static section is hard-coded in the script (same set as `client/public/sitemap.xml`) — that's the floor, never drops
- `/works/:slug` imported from `client/src/data/works.ts` at build time (4 entries today)
- `/blog/:slug`, `/stories/:slug`, `/people/:slug` fetched from Empathy Ledger via `/api/v1/content-hub/{articles,stories,storytellers}?syndicated_to=harvest&limit=200` — best-effort with graceful fallback
- If EL is unreachable, `EMPATHY_LEDGER_API_KEY` missing, or anything else throws, the script logs a warning and **exits 0** so the build never fails. The static `client/public/sitemap.xml` is already in `dist/public/` as the fallback.

### Wiring

- `package.json` `build`: `vite build && tsx scripts/build-sitemap.ts && esbuild ...`
- `vercel.json` `buildCommand`: `pnpm exec vite build && pnpm exec tsx scripts/build-sitemap.ts`
- New npm script `build:sitemap` for ad-hoc regeneration

### Verified locally

```
[sitemap] EMPATHY_LEDGER_API_KEY not set, skipping EL routes
[sitemap] wrote 18 URLs to .../dist/public/sitemap.xml (14 static, 4 works, 0 EL)
```

Vercel build has `EMPATHY_LEDGER_API_KEY` set, so EL routes will be included on deploy. Expect 50+ URLs after this lands.

## Test plan

- [x] Local `npm run build` writes a parseable sitemap (verified)
- [ ] After deploy: `curl https://www.theharvestwitta.com.au/sitemap.xml | grep -c '<url>'` shows more than 18 (depending on EL article count)
- [ ] After deploy: `curl https://www.theharvestwitta.com.au/sitemap.xml | grep '/works/' | wc -l` shows 4
- [ ] After deploy: validate at https://www.xml-sitemaps.com/validate-xml-sitemap.html

## Notes

- `client/public/sitemap.xml` is still committed and serves as the floor / dev-mode fallback. The build-generated version supersedes it in production.
- `lastmod` is set to today's UTC date on every build, not per-entry. Could enhance later to pull article updated-at from EL.