### PR TITLE
feat(el): wire the three new EL public endpoints (slug, /storytellers/:slug, /media?storyteller=)

### DIFF
--- a/server/empathyLedgerAdmin.ts
+++ b/server/empathyLedgerAdmin.ts
@@ -1531,19 +1531,23 @@ export async function listPublicHarvestStorytellers(): Promise<PublicHarvestStor
   }));
   const ids = rows.map((r) => r.storytellers!.id);
 
-  // Transcript counts come straight from the storyteller API response.
+  // Transcript counts and EL-provided slugs come straight from the storyteller API.
   const transcriptCountByTeller = new Map<string, number>();
+  const apiSlugByTeller = new Map<string, string>();
   for (const t of tellersRes.storytellers) {
     if (typeof t.transcriptCount === "number") transcriptCountByTeller.set(t.id, t.transcriptCount);
+    if (t.slug) apiSlugByTeller.set(t.id, t.slug);
   }
   void ids;
 
   return rows.map((r): PublicHarvestStoryteller => {
     const s = r.storytellers!;
     const counts = articleCounts.get(s.id) ?? { total: 0, published: 0 };
+    // Prefer EL's canonical slug if present, otherwise derive locally (back-compat).
+    const slug = apiSlugByTeller.get(s.id) ?? slugifyDisplayName(s.display_name!);
     return {
       id: s.id,
-      slug: slugifyDisplayName(s.display_name!),
+      slug,
       displayName: s.display_name!,
       bio: s.bio,
       avatarUrl: s.public_avatar_url,
@@ -1625,25 +1629,22 @@ async function listLocalCompendiumPhotos(firstName: string): Promise<PublicStory
 export async function getPublicHarvestStorytellerBySlug(
   slug: string,
 ): Promise<PublicHarvestStorytellerDetail | null> {
-  // Refactored 2026-05-13: was hitting EL's Supabase via service-role keys
-  // (broken in prod). Now uses EL public content-hub API.
+  // Uses EL public content-hub API. As of 2026-05-13 EL added:
+  //   - slug field on storyteller responses
+  //   - public /storytellers/:slug (O(1) lookup instead of list-and-find)
+  //   - ?storyteller=<uuid|slug> filter on /media (restores EL photo gallery)
   //
-  // Coverage today vs old Supabase-direct path:
-  //   articles        - same (filters by storyteller.id from articles API)
-  //   articles fallback (slug name-match) - DROPPED (EL doesn't expose unattributed
-  //                                          articles via public API; the fallback
-  //                                          was a hack for unclaimed legacy posts)
-  //   stories         - EMPTY until EL exposes `?project=the-harvest` filter on stories
-  //   transcripts     - EMPTY (no public transcripts endpoint)
-  //   localPhotos     - local compendium folder (filesystem) still works
-  //   EL photos       - DROPPED until EL exposes `?storyteller=<id>` filter on /media
-  //                     (current /media endpoint returns same 394 items regardless)
-  const all = await listPublicHarvestStorytellers();
-  const match = all.find((s) => s.slug === slug);
-  if (!match) return null;
+  // Coverage today:
+  //   articles    - filtered client-side from harvest articles list by storyteller.id
+  //   stories     - EMPTY until EL exposes /stories/:slug (currently 404)
+  //   transcripts - EMPTY (no public transcripts endpoint)
+  //   localPhotos - local /images/compendium/<firstName>/ folder + EL-tagged media
+  //                  merged with local taking precedence on filename collision.
+  const single = await empathyLedgerClient.fetchStoryteller(slug);
+  if (!single) return null;
 
-  const firstName = match.displayName.toLowerCase().split(/\s+/).filter(Boolean)[0] ?? "";
-
+  // Build the PublicHarvestStoryteller shell. Article counts come from the
+  // articles list; transcriptCount from the storyteller payload.
   type ArticleWithStoryteller = {
     id: string;
     title: string | null;
@@ -1655,31 +1656,64 @@ export async function getPublicHarvestStorytellerBySlug(
     primaryProject?: string | null;
     storyteller?: { id?: string } | null;
   };
-
   const articlesRes = await empathyLedgerClient.fetchArticles({
     project: "the-harvest",
     limit: 200,
   });
-  const articles: PublicStorytellerArticle[] = (
-    articlesRes.articles as unknown as ArticleWithStoryteller[]
-  )
-    .filter((a) => a.storyteller?.id === match.id)
-    .map((a) => ({
-      id: a.id,
-      title: a.title ?? "(untitled)",
-      slug: a.slug,
-      excerpt: a.excerpt,
-      publishedAt: a.publishedAt,
-      themes: Array.isArray(a.themes) ? a.themes : [],
-      featuredImageId: null, // public API returns URL not id; not used downstream
-      primaryProject: a.primaryProject ?? null,
-    }));
+  const ownArticles = (articlesRes.articles as unknown as ArticleWithStoryteller[]).filter(
+    (a) => a.storyteller?.id === single.id,
+  );
+
+  const base: PublicHarvestStoryteller = {
+    id: single.id,
+    slug: single.slug ?? slugifyDisplayName(single.displayName),
+    displayName: single.displayName,
+    bio: single.bio,
+    avatarUrl: single.avatarUrl,
+    location: single.location ?? null,
+    projectRole: null,
+    articleCount: ownArticles.length,
+    publishedArticleCount: ownArticles.length,
+    publishedStoryCount: 0,
+    transcriptCount: typeof single.transcriptCount === "number" ? single.transcriptCount : 0,
+  };
+
+  const articles: PublicStorytellerArticle[] = ownArticles.map((a) => ({
+    id: a.id,
+    title: a.title ?? "(untitled)",
+    slug: a.slug,
+    excerpt: a.excerpt,
+    publishedAt: a.publishedAt,
+    themes: Array.isArray(a.themes) ? a.themes : [],
+    featuredImageId: null,
+    primaryProject: a.primaryProject ?? null,
+  }));
 
   const stories: PublicStorytellerStory[] = [];
   const transcripts: PublicStorytellerTranscript[] = [];
-  const localPhotos = await listLocalCompendiumPhotos(firstName);
 
-  return { ...match, articles, stories, transcripts, localPhotos };
+  // Photos: merge local-curated compendium folder + EL-tagged media.
+  const firstName = single.displayName.toLowerCase().split(/\s+/).filter(Boolean)[0] ?? "";
+  const localPhotos = await listLocalCompendiumPhotos(firstName);
+  const elMedia = await empathyLedgerClient.fetchMediaForStoryteller(single.id, {
+    project: "the-harvest",
+    limit: 60,
+  });
+  const elPhotos: PublicStorytellerPhoto[] = elMedia.map((m) => ({
+    src: m.src,
+    alt: m.altText ?? m.title ?? `${single.displayName} at The Harvest`,
+  }));
+  // Dedupe by filename: local-curated wins over EL when both reference the same file.
+  const localFiles = new Set(localPhotos.map((p) => p.src.split("/").pop() ?? ""));
+  const mergedPhotos: PublicStorytellerPhoto[] = [
+    ...localPhotos,
+    ...elPhotos.filter((p) => {
+      const file = p.src.split("/").pop() ?? "";
+      return !localFiles.has(file);
+    }),
+  ];
+
+  return { ...base, articles, stories, transcripts, localPhotos: mergedPhotos };
 }
 
 // ---------------------------------------------------------------------------

--- a/server/empathyLedgerClient.ts
+++ b/server/empathyLedgerClient.ts
@@ -64,6 +64,7 @@ export interface ELStory {
 
 export interface ELStoryteller {
   id: string;
+  slug?: string | null;
   displayName: string;
   bio: string | null;
   avatarUrl: string | null;
@@ -99,6 +100,8 @@ export interface ELMediaAsset {
   themes: string[]; // Themes: "eat", "grow", "make", "gather", etc.
   special?: string[]; // Special tags: "hero", "featured"
   works?: string[]; // Harvest work slugs: "milk-crate-pavilion", "the-cedar", etc.
+  // Storytellers this media is attributed to. EL adds this from media_assets.metadata.harvestStorytellers.
+  taggedStorytellers?: Array<{ id: string; slug?: string | null; displayName: string; avatarUrl: string | null }>;
   projectId: string | null;
   sortOrder: number;
   isPublished: boolean;
@@ -259,6 +262,40 @@ class EmpathyLedgerClient {
     } catch (error) {
       console.error("[EmpathyLedger] Failed to fetch storytellers:", error);
       return { storytellers: [], pagination: { page: 1, limit: 20, total: 0, hasMore: false } };
+    }
+  }
+
+  /**
+   * Fetch a single storyteller by slug or UUID.
+   * Returns null on 404 / network failure.
+   */
+  async fetchStoryteller(identifier: string): Promise<ELStoryteller | null> {
+    try {
+      return await this.fetch<ELStoryteller>(`/api/v1/content-hub/storytellers/${encodeURIComponent(identifier)}`);
+    } catch (error) {
+      console.error(`[EmpathyLedger] Failed to fetch storyteller ${identifier}:`, error);
+      return null;
+    }
+  }
+
+  /**
+   * Fetch media attributed to a single storyteller.
+   * Backed by the public /media?storyteller=<uuid|slug> filter.
+   */
+  async fetchMediaForStoryteller(identifier: string, options: { project?: string; limit?: number } = {}): Promise<ELMediaAsset[]> {
+    const params = new URLSearchParams();
+    params.append("storyteller", identifier);
+    if (options.project) params.append("project", options.project);
+    params.append("limit", String(options.limit ?? 60));
+
+    try {
+      const res = await this.fetch<{ media?: ELMediaAsset[]; items?: ELMediaAsset[] }>(
+        `/api/v1/content-hub/media?${params.toString()}`,
+      );
+      return res.media ?? res.items ?? [];
+    } catch (error) {
+      console.error(`[EmpathyLedger] Failed to fetch media for storyteller ${identifier}:`, error);
+      return [];
     }
   }
 


### PR DESCRIPTION
## Summary

EL shipped 4 of the 5 asks from PR #20's runbook. This wires the three that affect the Harvest side.

### What's wired

**1. Storyteller `slug` from EL.** `listPublicHarvestStorytellers` now reads `t.slug` from the API response and falls back to the local `slugifyDisplayName` only if EL doesn't provide one. Stops Harvest+EL from drifting on slug semantics.

**2. Single-storyteller endpoint.** `getPublicHarvestStorytellerBySlug` now hits `GET /api/v1/content-hub/storytellers/:slug` directly via the new `empathyLedgerClient.fetchStoryteller(identifier)` method. O(1) lookup, no more list-and-find. Returns `null` on 404 so the page renders not-found.

**3. Media-by-storyteller filter.** Restores EL photo galleries on profile pages. New `empathyLedgerClient.fetchMediaForStoryteller(id, { project })` method calls `GET /api/v1/content-hub/media?project=the-harvest&storyteller=<id>`. Photos merged with the local `/images/compendium/<firstName>/` folder, local wins on filename collision.

### Smoke-tested locally

```
Barry Rodgerig (only harvest-tagged storyteller in EL today):
  slug: barry-rodgerig (from EL API)
  transcriptCount: 2 (from EL API)
  local photos: 12
  EL photos: 0 (Barry isn't tagged on any EL media — Sophie has 14)
```

Direct curl earlier confirmed `/media?storyteller=<sophie-uuid>` returns 14 photos, so the wiring works. As soon as a Harvest-tagged storyteller has EL media attribution, those photos surface on `/people/:slug`.

### Still gated on EL (Prompt 4 from the runbook)

- `GET /api/v1/content-hub/stories/:slug` still 404 → `getPublicHarvestStoryById` still returns null, `/stories/:slug` page renders not-found
- `/stories?project=the-harvest` returns 0 → no harvest stories tagged in EL yet (data, not code)

### Test plan

- [x] `npx tsc --noEmit` clean
- [x] Local smoke test via `scripts/test-storytellers.mjs`
- [ ] After deploy: `https://www.theharvestwitta.com.au/people/barry-rodgerig` still renders, photos show local compendium only
- [ ] When Sophie is added as a Harvest storyteller in EL: her profile page shows the 14 EL-attributed photos