### PR TITLE
Add community connection cadence doc for the June sprint comms

### DIFF
--- a/docs/strategy/community-connection-cadence.md
+++ b/docs/strategy/community-connection-cadence.md
@@ -1,0 +1,96 @@
+# How We Connect: The Harvest Community Connection Cadence
+
+> Created 2026-06-02 for the run to the 20 June members' day. This is the intent layer:
+> how we reach people, in what order, and why each touch is shaped the way it is. It sits
+> above three companion docs and does not repeat them.
+> - The dated schedule and the email copy live in `content-calendar-june-2026.md`.
+> - The send mechanics, the three lists, and the workflow-vs-broadcast rule live in
+>   `email-operating-system.md`.
+> - The strategy and the why live in `community-engagement-launch-plan.md`.
+>
+> Voice: plain, warm, honest. No marketing-speak. Australian spelling.
+
+## The idea in one line
+
+Members hear first, the public hears the story after, and nobody is grabbed. We invite
+people into something unfinished and ask for their hands.
+
+## Five principles, the how
+
+1. **Concentric circles, innermost first.** The people building the place hear the date
+   before anyone. Makers and doers in Wk4, members on 9 June, the public never as an
+   invite. Knowing first is what membership is for. Protect that, or the list means nothing.
+
+2. **Plain and honest is the strategy, not the garnish.** "Nothing polished, nothing
+   performative." Honest signage on the shop shelf about who made a thing and what they got
+   paid. "We read every one." The voice is the connection. The moment it reads like
+   marketing, the trust leaks.
+
+3. **Invite people into the unfinished.** We do not hand people a finished room and ask them
+   to admire it. The kids build the kids area, the artists shape the art space, the makers
+   shape the shop. "Nothing here is finished. That is why the member list matters." The ask
+   is always for a pair of hands, not just attention.
+
+4. **An event yes is not a subscribe.** A booking, an RSVP, a reply, none of these silently
+   add anyone to a list. We invite, we do not capture. People choose to follow in the
+   after-story, by choice, not by being tagged on the way past.
+
+5. **Real over manufactured.** Sourced facts, cleared photos, real names, real learnings.
+   Witta is about 1,296 people. Everyone knows everyone. A figure that is wrong or a photo
+   used without a yes costs trust you cannot rebuild here. When the true thing is not ready,
+   we leave the blank rather than fill it.
+
+## Who hears what, and when
+
+The full dated run with copy is in `content-calendar-june-2026.md`. The shape of it:
+
+| Circle | List or channel | What they get | When |
+| --- | --- | --- | --- |
+| Makers and doers | shop EOIs + doers segment | The date first, and the invite to help open the place. Both RSVP links. | Wk4, 2 to 8 Jun |
+| Members | `harvest-member` | The date, members first. The afternoon-plus-pizza RSVP. | Tue 9 Jun |
+| Members | `harvest-member` | The practical details: when, where, what to bring. | Fri 19 Jun |
+| The public | `harvest-newsletter` + social | The place taking shape, the shop, the question. "Late June, members hear first." Never 20 June as a public invite. | All Wk4 to Wk6 |
+| Members | `harvest-member` | Thank-you, cleared photos, one true thing learned. | Wed 24 Jun |
+| Members | `harvest-member` | What the first day taught us, and the next shape. | Early Jul |
+
+The public anticipation is built honestly. The garden is getting ready for something, members
+hear first, the list is free to join. We never leak the date to make the teaser louder.
+
+## The voice gate, before any send
+
+Run these against new copy, every time. Full reasoning in the harvest-voice memory.
+
+- No em-dashes.
+- None of: vibrant, tapestry, testament, underscore, pivotal, crucial, seamless, delve.
+- "Work days", never "working bees".
+- No invented counts, dates, attendance, or build claims. If it is not verified, do not
+  assert it. Use "taking shape" not "finished".
+- Place names: Witta on Jinibara Country. Colonial names in brackets where needed.
+
+## The send discipline, before any broadcast
+
+Full checklist in `email-operating-system.md`. The three that matter most:
+
+- A broadcast is a one-off Campaign, never a Workflow, and it **never adds a tag**. Adding a
+  tag is what fires a welcome, so a broadcast that tags people can spam a whole list.
+- One named smart list per send. Read the contact count before you press send. Members-only
+  content goes to the Harvest Members list only.
+- First-name fallback set to "there". About 19 members are stored with an email where a name
+  should be. Without the fallback, the greeting renders as their email address.
+
+## What is still on a human before each send
+
+These are the real gates. None can be filled from the repo without it being a fabrication or
+a guess.
+
+- **From address.** Sends currently go from `hi@act.place`, the shared default. The
+  Harvest-domain fix stays parked unless it can be done without risking the 9 June date.
+  Decide before the first members-first broadcast.
+- **The makers segment.** The Wk4 invite needs a real smart list built in GHL: shop EOIs plus
+  the doers. Until it exists, the invite has no audience.
+- **`[MAKER NAME]`** for the Wk3 social post. A real person who has been on site shaping the
+  art space or the kids area. Left blank on purpose.
+- **Real photos** for every social post and the thank-you note, attached at send time, each
+  person-led photo cleared first.
+- **The thank-you and the July note** cannot be finalised until the day has happened. They
+  carry one true detail, one true learning, one true next step, or they do not send.

--- a/docs/strategy/content-calendar-june-2026.md
+++ b/docs/strategy/content-calendar-june-2026.md
@@ -2,6 +2,8 @@
 
 > Created 2026-05-27. Reconciled 2026-06-02 to the current
 > [June sprint operating plan](june-sprint-operating-plan-2026-06-02.md).
+> This is the dated schedule and the copy. The intent behind it, how and in what order we
+> connect with the community, lives in [community-connection-cadence.md](community-connection-cadence.md).
 > The run covers 2026-06-02 to 2026-07-01. Saturday 20 June 2026 is a private
 > members' day in two parts: maker session 10am to 2pm, then afternoon plus pizza
 > from 2pm. Makers and doers hear first in Wk4. Members hear through Harvest Note 02


### PR DESCRIPTION
## What

Adds `docs/strategy/community-connection-cadence.md` — the intent layer for the June sprint communications: how and in what order we connect with the community (members first, the public hears the story after, nobody is grabbed), sitting above the dated schedule (`content-calendar-june-2026.md`) and the send mechanics (`email-operating-system.md`). Cross-linked from the content calendar so it is not orphaned.

## Why

The six June campaigns are already paste-ready and voice-clean (verified this session: zero drift between the GHL email templates and the canonical content calendar, voice gates pass, the "around 1,300 people" figure is sourced to the 2021 Census). What was missing was a single page holding the connection *intent* and rhythm. This fills that gap and surfaces the real send-time human gates (From address, makers segment, maker name, real photos).

## Scope

- New: `docs/strategy/community-connection-cadence.md`
- Edit: `docs/strategy/content-calendar-june-2026.md` (3-line cross-link in the header)

Docs only. No code, no live-system changes. Voice gates (no em-dashes, no AI-vocab) pass on the new doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)