### PR TITLE
Align Works page: honesty fixes + coherence

### DIFF
--- a/client/src/data/works.ts
+++ b/client/src/data/works.ts
@@ -68,6 +68,27 @@ export function sortLifecycleTags(tags: LifecycleTag[]): LifecycleTag[] {
   });
 }
 
+export type WorkStatusLabel = "Built" | "Growing" | "Forthcoming";
+
+/**
+ * Resolve a work's many lifecycle tags down to the single human status the
+ * /works hero promises ("some built, some growing, some forthcoming"). The full
+ * tag taxonomy stays for admins and comms; visitors see one honest word.
+ */
+export function resolveWorkStatus(
+  tags: LifecycleTag[],
+): { label: WorkStatusLabel; badgeClass: string } {
+  const growing: LifecycleTag[] = ["growing", "building", "making", "extending"];
+  const built: LifecycleTag[] = ["built", "made", "harvested", "open", "maintained"];
+  if (tags.some((t) => growing.includes(t))) {
+    return { label: "Growing", badgeClass: "bg-emerald-700 text-emerald-50" };
+  }
+  if (tags.some((t) => built.includes(t))) {
+    return { label: "Built", badgeClass: "bg-stone-800 text-amber-300" };
+  }
+  return { label: "Forthcoming", badgeClass: "bg-amber-100 text-stone-800 border border-amber-300" };
+}
+
 /** @deprecated Use lifecycleTags array instead. Kept only for legacy callers. */
 export type WorkStatus = "built" | "growing" | "forthcoming";
 
@@ -127,6 +148,9 @@ export type Work = {
   storyLinks?: { label: string; href: string }[];
   /** Optional related works for cross-linking */
   related?: string[];
+  /** Display weight. "note" renders a short template (label, intro, hands, any
+   *  calls to action); "feature" (the default) renders the full long-form page. */
+  weight?: "feature" | "note";
 };
 
 export const works: Work[] = [
@@ -188,18 +212,18 @@ export const works: Work[] = [
     subtitle: "A gathering structure made from the dairy industry’s everyday object.",
     lifecycleTags: ["building"],
     materials: "Reclaimed milk crates · scaffold · salvaged timber · community hands",
-    year: "Built March 2026",
+    year: "Building through 2026",
     heroImage: "/images/optimized/gathering-recap-crowd-1200.webp",
-    heroAlt: "People gathered at The Harvest during the milk crate pavilion build",
+    heroAlt: "People gathered at The Harvest",
     heroCredit: "Radical Scoops fellowship · Regional Arts Australia",
     blurb:
-      "Eighty people built it together in a single weekend. Milk crates from the dairy industry, scaffold poles, found timber. The first piece of architecture on the site is also the most communal.",
+      "The community is building it together. Milk crates from the dairy industry, scaffold poles, found timber. The first piece of architecture on the site, and the most communal.",
     whatItIs:
       "A modular open-air pavilion at the heart of The Harvest. Roughly 14m × 9m, sized to fit comfortably under the pecan trees. Plays the role of gallery, theatre, market hall, dining room and weather shelter, sometimes in the same afternoon. Designed to come apart, rearrange, and grow.",
     why:
-      "We needed a shared roof before we needed walls. A pavilion lets the community show up before the buildings finish. Markets, exhibitions, films, dinners, conversations. It says clearly: this place is for gathering, and gathering is the first work.",
+      "A pavilion lets the community gather before anything else is finished. Markets, exhibitions, films, dinners, conversations. It says clearly: this place is for gathering, and gathering is the first work.",
     how:
-      "Built across one weekend in March 2026 with more than eighty community members under the Radical Scoops fellowship. Milk crates were sourced from the dairy industry that once powered Witta. Scaffold was hired and rebuilt as structure. Timber was offcuts, salvage, and gifts. No single builder. Everyone took a corner.",
+      "Being built by community members under the Radical Scoops fellowship. Milk crates were sourced from the dairy industry that once powered Witta. Scaffold was hired and rebuilt as structure. Timber is offcuts, salvage, and gifts. No single builder. Everyone takes a corner.",
     wittaThreads: [
       {
         year: "1904",
@@ -221,7 +245,7 @@ export const works: Work[] = [
       },
     ],
     hands: [
-      { name: "Eighty community members", role: "Builders, weekend of 7 March 2026" },
+      { name: "Community members", role: "Builders" },
       { name: "Regional Arts Australia", role: "Radical Scoops fellowship funder" },
       { name: "Ben Knight & Nicholas Marchesi", role: "Co-founders, project leads" },
     ],
@@ -254,7 +278,7 @@ export const works: Work[] = [
     why:
       "The timber story belongs in the ground, not only on a wall. Paths are how people first read a garden: where to enter, where to slow down, where to notice what is growing.",
     how:
-      "Reclaimed from St Mary's Cathedral in Sydney and being prepared for use as garden walkways at The Harvest. The source trail is still being checked; for now the timber speaks as material first. Used visibly so the grain, marks, and provenance remain part of the work.",
+      "Timber we believe came from St Mary's Cathedral in Sydney, being prepared for use as garden walkways at The Harvest. We are still tracing exactly how it left the cathedral and reached the range. Used visibly, so the grain, the old marks, and the honest gaps in its story stay part of the work.",
     wittaThreads: [
       {
         year: "1860",
@@ -346,6 +370,7 @@ export const works: Work[] = [
     slug: "kids-area",
     title: "Kids' Area",
     subtitle: "A play area shaped with the kids who will use it",
+    weight: "note",
     lifecycleTags: ["consulting", "planned"],
     materials: "Logs · shade · loose parts · local kids' ideas",
     year: "In design 2026",
@@ -362,7 +387,7 @@ export const works: Work[] = [
     wittaThreads: [
       {
         year: "Today",
-        moment: "Families, working bees, and open days bring children through the gate.",
+        moment: "Families, work days, and open days bring children through the gate.",
         thread:
           "The kids area makes room for children as contributors to the place, not just people waiting while adults talk.",
       },
@@ -385,6 +410,7 @@ export const works: Work[] = [
     slug: "the-milk-man",
     title: "The Milk Man",
     subtitle: "A milk crate sentinel at the front of The Harvest",
+    weight: "note",
     lifecycleTags: ["built", "made"],
     materials: "Milk crates · stacked figure · front gate marker · dairy memory",
     year: "Standing now",

--- a/client/src/pages/WorkDetail.tsx
+++ b/client/src/pages/WorkDetail.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Link } from "wouter";
 import { motion } from "framer-motion";
 import { ArrowLeft, ArrowRight, ExternalLink, Camera } from "lucide-react";
-import { worksBySlug, works, LIFECYCLE_VOCAB, sortLifecycleTags, type LifecycleTag } from "@/data/works";
+import { worksBySlug, works, LIFECYCLE_VOCAB, sortLifecycleTags, resolveWorkStatus, type LifecycleTag } from "@/data/works";
 import { trpc } from "@/lib/trpc";
 import { HarvestImage } from "@/components/HarvestImage";
 import { EditableText } from "@/components/EditableText";
@@ -145,6 +145,8 @@ export default function WorkDetail({ slug }: { slug: string }) {
   })();
   const activeTags: LifecycleTag[] = savedTags ?? work.lifecycleTags;
   const lifecycleTags = sortLifecycleTags(activeTags);
+  const status = resolveWorkStatus(activeTags);
+  const isNote = work.weight === "note";
   const index = works.findIndex((w) => w.slug === work.slug);
   const number = work.number ?? String(index + 1).padStart(2, "0");
   const next = works[(index + 1) % works.length];
@@ -181,17 +183,25 @@ export default function WorkDetail({ slug }: { slug: string }) {
                   {number}
                 </p>
                 <div className="flex flex-wrap gap-1.5">
-                  {lifecycleTags.map((tag) => {
-                    const meta = LIFECYCLE_VOCAB[tag];
-                    return (
-                      <span
-                        key={tag}
-                        className={`px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] ${meta.badgeClass}`}
-                      >
-                        {meta.label}
-                      </span>
-                    );
-                  })}
+                  {isAdmin ? (
+                    lifecycleTags.map((tag) => {
+                      const meta = LIFECYCLE_VOCAB[tag];
+                      return (
+                        <span
+                          key={tag}
+                          className={`px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] ${meta.badgeClass}`}
+                        >
+                          {meta.label}
+                        </span>
+                      );
+                    })
+                  ) : (
+                    <span
+                      className={`px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] ${status.badgeClass}`}
+                    >
+                      {status.label}
+                    </span>
+                  )}
                 </div>
               </div>
               <div className="md:col-span-2">
@@ -248,10 +258,8 @@ export default function WorkDetail({ slug }: { slug: string }) {
                 <p className="text-stone-800">{work.materials}</p>
               </div>
               <div>
-                <p className="font-mono text-stone-400 uppercase tracking-wider text-[11px] mb-2">Lifecycle</p>
-                <p className="text-stone-800">
-                  {lifecycleTags.map((t) => LIFECYCLE_VOCAB[t].label).join(" · ")}
-                </p>
+                <p className="font-mono text-stone-400 uppercase tracking-wider text-[11px] mb-2">Status</p>
+                <p className="text-stone-800 font-medium">{status.label}</p>
               </div>
             </motion.div>
           </div>
@@ -261,8 +269,9 @@ export default function WorkDetail({ slug }: { slug: string }) {
       {/* What it is */}
       <Section label="What it is" body={work.whatItIs} slot={`${work.slug}-whatItIs`} />
 
-      {/* Inline feature image — slot 1 (after "What it is") */}
-      <InlineFeatureImage work={work} slotKey="feature-1" />
+      {/* Inline feature image — slot 1 (after "What it is"). Notes skip the
+          inline image slots entirely. */}
+      {!isNote && <InlineFeatureImage work={work} slotKey="feature-1" />}
 
       {/* Why */}
       <Section label="Why" body={work.why} slot={`${work.slug}-why`} tone="dark" />
@@ -270,30 +279,37 @@ export default function WorkDetail({ slug }: { slug: string }) {
       {/* How */}
       <Section label="How" body={work.how} slot={`${work.slug}-how`} />
 
-      {/* Inline feature image — slot 2 (after "How") */}
-      <InlineFeatureImage work={work} slotKey="feature-2" caption="In the making." />
+      {/* Inline feature image — slot 2 (after "How"). */}
+      {!isNote && <InlineFeatureImage work={work} slotKey="feature-2" caption="In the making." />}
 
-      {/* Work story — free text, so each work can hold a note, poem, source story, or context */}
+      {/* Work story — free text. Notes skip the story text (it would just repeat
+          the blurb) but keep any calls to action; the section hides entirely when
+          a note has neither. */}
+      {(!isNote || (work.storyLinks && work.storyLinks.length > 0)) && (
       <section className="py-20 md:py-28 bg-stone-100">
         <div className="container">
           <div className="max-w-4xl mx-auto">
-            <motion.div {...fadeInUp} className="mb-12">
-              <p className="font-mono text-amber-700 text-sm mb-3 uppercase tracking-[0.2em]">
-                Story
-              </p>
-              <h2 className="text-3xl md:text-4xl font-serif font-bold text-stone-800">
-                A note on this work.
-              </h2>
-            </motion.div>
+            {!isNote && (
+              <>
+                <motion.div {...fadeInUp} className="mb-12">
+                  <p className="font-mono text-amber-700 text-sm mb-3 uppercase tracking-[0.2em]">
+                    Story
+                  </p>
+                  <h2 className="text-3xl md:text-4xl font-serif font-bold text-stone-800">
+                    A note on this work.
+                  </h2>
+                </motion.div>
 
-            <EditableText
-              page="works"
-              slot={`${work.slug}-story`}
-              defaultContent={work.blurb}
-              as="p"
-              className="max-w-3xl whitespace-pre-line text-xl leading-relaxed text-stone-700 md:text-2xl"
-              multiline
-            />
+                <EditableText
+                  page="works"
+                  slot={`${work.slug}-story`}
+                  defaultContent={work.blurb}
+                  as="p"
+                  className="max-w-3xl whitespace-pre-line text-xl leading-relaxed text-stone-700 md:text-2xl"
+                  multiline
+                />
+              </>
+            )}
             {work.storyLinks && work.storyLinks.length > 0 && (
               <div className="mt-8 flex flex-col items-start gap-3">
                 {work.storyLinks.map((link, linkIndex) => (
@@ -333,11 +349,12 @@ export default function WorkDetail({ slug }: { slug: string }) {
           </div>
         </div>
       </section>
+      )}
 
       {work.slug === "the-shop" && <ShopInterestSection />}
 
-      {/* Two-up spread — slots 3 and 4 (between Witta thread and Hands) */}
-      <InlineSpreadImages work={work} />
+      {/* Two-up spread — slots 3 and 4 (between Witta thread and Hands). */}
+      {!isNote && <InlineSpreadImages work={work} />}
 
       {/* Photographs from Empathy Ledger */}
       <WorkPhotographsSection slug={work.slug} />
@@ -1018,13 +1035,21 @@ function InlineFeatureImage({
   slotKey: string;
   caption?: string;
 }) {
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
+  const slot = `${work.slug}-${slotKey}`;
+  const overrideQuery = trpc.imageOverrides.get.useQuery({ page: "works", slot });
+  // Visitors only see this slot when a real photo override exists, so a work
+  // without its own photo library no longer repeats the hero image down the
+  // page. Admins always see it, so the swap affordance stays reachable.
+  if (!isAdmin && (overrideQuery.isPending || !overrideQuery.data)) return null;
   return (
     <section className="py-12 md:py-16">
       <div className="container">
         <div className="max-w-5xl mx-auto">
           <HarvestImage
             page="works"
-            slot={`${work.slug}-${slotKey}`}
+            slot={slot}
             defaultWorkSlug={work.slug}
             src={work.heroImage}
             alt={`${work.title} — feature image`}
@@ -1045,6 +1070,16 @@ function InlineFeatureImage({
  * Each side is its own slot so admins can swap them independently.
  */
 function InlineSpreadImages({ work }: { work: import("@/data/works").Work }) {
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
+  const leftQuery = trpc.imageOverrides.get.useQuery({ page: "works", slot: `${work.slug}-spread-left` });
+  const rightQuery = trpc.imageOverrides.get.useQuery({ page: "works", slot: `${work.slug}-spread-right` });
+  // Visitors only see the two-image spread when both slots have real photos, so
+  // we never show a half-empty spread or the hero image repeated twice. Admins
+  // always see it, so both swap affordances stay reachable.
+  const resolved = !leftQuery.isPending && !rightQuery.isPending;
+  const hasBoth = Boolean(leftQuery.data) && Boolean(rightQuery.data);
+  if (!isAdmin && (!resolved || !hasBoth)) return null;
   return (
     <section className="py-12 md:py-16 bg-stone-50">
       <div className="container">


### PR DESCRIPTION
## What

Aligns the `/works` pages so they read as one intentional collection, feel less "fake," and drop unverified claims. Diagnosis came from a multi-agent review of the page; this PR implements the **honesty + safe-structure** subset.

## Honesty (no fabricated facts)

- Strip the unverified **"eighty people / 7 March 2026"** pavilion build claim (blurb, how, hands, year, alt); reframe to the work's `building` status.
- `"working bees"` → `"work days"`; honest St Mary's timber provenance.
- Remove the inaccurate **"shared roof before walls"** line.

## Structure / coherence

- Inline + spread image slots render only when a **real photo override exists** — a work with no photos no longer repeats its hero image down the page.
- Visitors see **one resolved status** (Built / Growing / Forthcoming); the full 16-tag lifecycle taxonomy stays for admins via the editor.
- `weight` tier: **notes** (Milk Man, Kids' Area) render short — skip the image slots + the blurb-repeating Story section, keep their CTAs.

## Verification

- `tsc --noEmit` clean; `npm run build` clean.
- Visually confirmed (visitor view): Milk Man note renders short with a single badge and no repeated images; Pavilion feature shows a single badge, distinct EL photos, and the honesty copy.

## Notes / follow-ups (not in this PR)

- Hero images resolve from Empathy Ledger first; the real pavilion photo is curated via `/admin/media-library` ("Pavilion work hero" tile), not hardcoded.
- `the-cedar` slug intentionally **not** renamed — it is an EL `harvest-work` join key + admin slot + public URL; renaming is a data migration.
- Still needs a human: confirm pavilion built-vs-building (photo dated 8 May 2026), Milk Man status, and a citation pass on the regional history dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)