### PR TITLE
Harvest June launch fixes: GHL workflows + tag taxonomy + GardenLaunch

### DIFF
--- a/client/src/data/works.ts
+++ b/client/src/data/works.ts
@@ -68,6 +68,27 @@ export function sortLifecycleTags(tags: LifecycleTag[]): LifecycleTag[] {
   });
 }
 
+export type WorkStatusLabel = "Built" | "Growing" | "Forthcoming";
+
+/**
+ * Resolve a work's many lifecycle tags down to the single human status the
+ * /works hero promises ("some built, some growing, some forthcoming"). The full
+ * tag taxonomy stays for admins and comms; visitors see one honest word.
+ */
+export function resolveWorkStatus(
+  tags: LifecycleTag[],
+): { label: WorkStatusLabel; badgeClass: string } {
+  const growing: LifecycleTag[] = ["growing", "building", "making", "extending"];
+  const built: LifecycleTag[] = ["built", "made", "harvested", "open", "maintained"];
+  if (tags.some((t) => growing.includes(t))) {
+    return { label: "Growing", badgeClass: "bg-emerald-700 text-emerald-50" };
+  }
+  if (tags.some((t) => built.includes(t))) {
+    return { label: "Built", badgeClass: "bg-stone-800 text-amber-300" };
+  }
+  return { label: "Forthcoming", badgeClass: "bg-amber-100 text-stone-800 border border-amber-300" };
+}
+
 /** @deprecated Use lifecycleTags array instead. Kept only for legacy callers. */
 export type WorkStatus = "built" | "growing" | "forthcoming";
 
@@ -127,6 +148,9 @@ export type Work = {
   storyLinks?: { label: string; href: string }[];
   /** Optional related works for cross-linking */
   related?: string[];
+  /** Display weight. "note" renders a short template (label, intro, hands, any
+   *  calls to action); "feature" (the default) renders the full long-form page. */
+  weight?: "feature" | "note";
 };
 
 export const works: Work[] = [
@@ -188,18 +212,18 @@ export const works: Work[] = [
     subtitle: "A gathering structure made from the dairy industry’s everyday object.",
     lifecycleTags: ["building"],
     materials: "Reclaimed milk crates · scaffold · salvaged timber · community hands",
-    year: "Built March 2026",
+    year: "Building through 2026",
     heroImage: "/images/optimized/gathering-recap-crowd-1200.webp",
-    heroAlt: "People gathered at The Harvest during the milk crate pavilion build",
+    heroAlt: "People gathered at The Harvest",
     heroCredit: "Radical Scoops fellowship · Regional Arts Australia",
     blurb:
-      "Eighty people built it together in a single weekend. Milk crates from the dairy industry, scaffold poles, found timber. The first piece of architecture on the site is also the most communal.",
+      "The community is building it together. Milk crates from the dairy industry, scaffold poles, found timber. The first piece of architecture on the site, and the most communal.",
     whatItIs:
       "A modular open-air pavilion at the heart of The Harvest. Roughly 14m × 9m, sized to fit comfortably under the pecan trees. Plays the role of gallery, theatre, market hall, dining room and weather shelter, sometimes in the same afternoon. Designed to come apart, rearrange, and grow.",
     why:
-      "We needed a shared roof before we needed walls. A pavilion lets the community show up before the buildings finish. Markets, exhibitions, films, dinners, conversations. It says clearly: this place is for gathering, and gathering is the first work.",
+      "A pavilion lets the community gather before anything else is finished. Markets, exhibitions, films, dinners, conversations. It says clearly: this place is for gathering, and gathering is the first work.",
     how:
-      "Built across one weekend in March 2026 with more than eighty community members under the Radical Scoops fellowship. Milk crates were sourced from the dairy industry that once powered Witta. Scaffold was hired and rebuilt as structure. Timber was offcuts, salvage, and gifts. No single builder. Everyone took a corner.",
+      "Being built by community members under the Radical Scoops fellowship. Milk crates were sourced from the dairy industry that once powered Witta. Scaffold was hired and rebuilt as structure. Timber is offcuts, salvage, and gifts. No single builder. Everyone takes a corner.",
     wittaThreads: [
       {
         year: "1904",
@@ -221,7 +245,7 @@ export const works: Work[] = [
       },
     ],
     hands: [
-      { name: "Eighty community members", role: "Builders, weekend of 7 March 2026" },
+      { name: "Community members", role: "Builders" },
       { name: "Regional Arts Australia", role: "Radical Scoops fellowship funder" },
       { name: "Ben Knight & Nicholas Marchesi", role: "Co-founders, project leads" },
     ],
@@ -254,7 +278,7 @@ export const works: Work[] = [
     why:
       "The timber story belongs in the ground, not only on a wall. Paths are how people first read a garden: where to enter, where to slow down, where to notice what is growing.",
     how:
-      "Reclaimed from St Mary's Cathedral in Sydney and being prepared for use as garden walkways at The Harvest. The source trail is still being checked; for now the timber speaks as material first. Used visibly so the grain, marks, and provenance remain part of the work.",
+      "Timber we believe came from St Mary's Cathedral in Sydney, being prepared for use as garden walkways at The Harvest. We are still tracing exactly how it left the cathedral and reached the range. Used visibly, so the grain, the old marks, and the honest gaps in its story stay part of the work.",
     wittaThreads: [
       {
         year: "1860",
@@ -346,6 +370,7 @@ export const works: Work[] = [
     slug: "kids-area",
     title: "Kids' Area",
     subtitle: "A play area shaped with the kids who will use it",
+    weight: "note",
     lifecycleTags: ["consulting", "planned"],
     materials: "Logs · shade · loose parts · local kids' ideas",
     year: "In design 2026",
@@ -362,7 +387,7 @@ export const works: Work[] = [
     wittaThreads: [
       {
         year: "Today",
-        moment: "Families, working bees, and open days bring children through the gate.",
+        moment: "Families, work days, and open days bring children through the gate.",
         thread:
           "The kids area makes room for children as contributors to the place, not just people waiting while adults talk.",
       },
@@ -385,6 +410,7 @@ export const works: Work[] = [
     slug: "the-milk-man",
     title: "The Milk Man",
     subtitle: "A milk crate sentinel at the front of The Harvest",
+    weight: "note",
     lifecycleTags: ["built", "made"],
     materials: "Milk crates · stacked figure · front gate marker · dairy memory",
     year: "Standing now",

--- a/client/src/pages/GardenLaunch.tsx
+++ b/client/src/pages/GardenLaunch.tsx
@@ -16,7 +16,7 @@ import { Card, CardContent } from "@/components/ui/card";
 
 const EVENT = {
   date: "Saturday 20 June 2026",
-  time: "3pm – 7pm",
+  time: "From 2pm",
   address: "9 Gumland Drive, Witta QLD 4552",
   shortAddress: "Witta · Sunshine Coast Hinterland",
   acknowledgement: "Jinibara Country",
@@ -57,7 +57,7 @@ export default function GardenLaunch() {
       meta.name = "description";
       document.head.appendChild(meta);
     }
-    meta.content = "Saturday 20 June 2026, 3pm-7pm. The first soft opening at The Harvest, Witta. Member list only for this one. Join the member list for the invite.";
+    meta.content = "Saturday 20 June 2026, from 2pm. The first soft opening at The Harvest, Witta. Member list only for this one. Join the member list for the invite.";
   }, []);
 
   return (
@@ -183,7 +183,7 @@ export default function GardenLaunch() {
                     Confirmed
                   </p>
                   <ul className="space-y-2 text-stone-700">
-                    <li className="flex gap-2"><CheckCircle2 className="h-4 w-4 mt-1 flex-none text-emerald-700" /> Saturday 20 June 2026, 3pm to 7pm</li>
+                    <li className="flex gap-2"><CheckCircle2 className="h-4 w-4 mt-1 flex-none text-emerald-700" /> Saturday 20 June 2026, from 2pm</li>
                     <li className="flex gap-2"><CheckCircle2 className="h-4 w-4 mt-1 flex-none text-emerald-700" /> 9 Gumland Drive, Witta. Jinibara Country.</li>
                     <li className="flex gap-2"><CheckCircle2 className="h-4 w-4 mt-1 flex-none text-emerald-700" /> Member list only. About 40 seats.</li>
                     <li className="flex gap-2"><CheckCircle2 className="h-4 w-4 mt-1 flex-none text-emerald-700" /> Free. No register, no bar.</li>

--- a/client/src/pages/WorkDetail.tsx
+++ b/client/src/pages/WorkDetail.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Link } from "wouter";
 import { motion } from "framer-motion";
 import { ArrowLeft, ArrowRight, ExternalLink, Camera } from "lucide-react";
-import { worksBySlug, works, LIFECYCLE_VOCAB, sortLifecycleTags, type LifecycleTag } from "@/data/works";
+import { worksBySlug, works, LIFECYCLE_VOCAB, sortLifecycleTags, resolveWorkStatus, type LifecycleTag } from "@/data/works";
 import { trpc } from "@/lib/trpc";
 import { HarvestImage } from "@/components/HarvestImage";
 import { EditableText } from "@/components/EditableText";
@@ -145,6 +145,8 @@ export default function WorkDetail({ slug }: { slug: string }) {
   })();
   const activeTags: LifecycleTag[] = savedTags ?? work.lifecycleTags;
   const lifecycleTags = sortLifecycleTags(activeTags);
+  const status = resolveWorkStatus(activeTags);
+  const isNote = work.weight === "note";
   const index = works.findIndex((w) => w.slug === work.slug);
   const number = work.number ?? String(index + 1).padStart(2, "0");
   const next = works[(index + 1) % works.length];
@@ -181,17 +183,25 @@ export default function WorkDetail({ slug }: { slug: string }) {
                   {number}
                 </p>
                 <div className="flex flex-wrap gap-1.5">
-                  {lifecycleTags.map((tag) => {
-                    const meta = LIFECYCLE_VOCAB[tag];
-                    return (
-                      <span
-                        key={tag}
-                        className={`px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] ${meta.badgeClass}`}
-                      >
-                        {meta.label}
-                      </span>
-                    );
-                  })}
+                  {isAdmin ? (
+                    lifecycleTags.map((tag) => {
+                      const meta = LIFECYCLE_VOCAB[tag];
+                      return (
+                        <span
+                          key={tag}
+                          className={`px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] ${meta.badgeClass}`}
+                        >
+                          {meta.label}
+                        </span>
+                      );
+                    })
+                  ) : (
+                    <span
+                      className={`px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] ${status.badgeClass}`}
+                    >
+                      {status.label}
+                    </span>
+                  )}
                 </div>
               </div>
               <div className="md:col-span-2">
@@ -248,10 +258,8 @@ export default function WorkDetail({ slug }: { slug: string }) {
                 <p className="text-stone-800">{work.materials}</p>
               </div>
               <div>
-                <p className="font-mono text-stone-400 uppercase tracking-wider text-[11px] mb-2">Lifecycle</p>
-                <p className="text-stone-800">
-                  {lifecycleTags.map((t) => LIFECYCLE_VOCAB[t].label).join(" · ")}
-                </p>
+                <p className="font-mono text-stone-400 uppercase tracking-wider text-[11px] mb-2">Status</p>
+                <p className="text-stone-800 font-medium">{status.label}</p>
               </div>
             </motion.div>
           </div>
@@ -261,8 +269,9 @@ export default function WorkDetail({ slug }: { slug: string }) {
       {/* What it is */}
       <Section label="What it is" body={work.whatItIs} slot={`${work.slug}-whatItIs`} />
 
-      {/* Inline feature image — slot 1 (after "What it is") */}
-      <InlineFeatureImage work={work} slotKey="feature-1" />
+      {/* Inline feature image — slot 1 (after "What it is"). Notes skip the
+          inline image slots entirely. */}
+      {!isNote && <InlineFeatureImage work={work} slotKey="feature-1" />}
 
       {/* Why */}
       <Section label="Why" body={work.why} slot={`${work.slug}-why`} tone="dark" />
@@ -270,30 +279,37 @@ export default function WorkDetail({ slug }: { slug: string }) {
       {/* How */}
       <Section label="How" body={work.how} slot={`${work.slug}-how`} />
 
-      {/* Inline feature image — slot 2 (after "How") */}
-      <InlineFeatureImage work={work} slotKey="feature-2" caption="In the making." />
+      {/* Inline feature image — slot 2 (after "How"). */}
+      {!isNote && <InlineFeatureImage work={work} slotKey="feature-2" caption="In the making." />}
 
-      {/* Work story — free text, so each work can hold a note, poem, source story, or context */}
+      {/* Work story — free text. Notes skip the story text (it would just repeat
+          the blurb) but keep any calls to action; the section hides entirely when
+          a note has neither. */}
+      {(!isNote || (work.storyLinks && work.storyLinks.length > 0)) && (
       <section className="py-20 md:py-28 bg-stone-100">
         <div className="container">
           <div className="max-w-4xl mx-auto">
-            <motion.div {...fadeInUp} className="mb-12">
-              <p className="font-mono text-amber-700 text-sm mb-3 uppercase tracking-[0.2em]">
-                Story
-              </p>
-              <h2 className="text-3xl md:text-4xl font-serif font-bold text-stone-800">
-                A note on this work.
-              </h2>
-            </motion.div>
+            {!isNote && (
+              <>
+                <motion.div {...fadeInUp} className="mb-12">
+                  <p className="font-mono text-amber-700 text-sm mb-3 uppercase tracking-[0.2em]">
+                    Story
+                  </p>
+                  <h2 className="text-3xl md:text-4xl font-serif font-bold text-stone-800">
+                    A note on this work.
+                  </h2>
+                </motion.div>
 
-            <EditableText
-              page="works"
-              slot={`${work.slug}-story`}
-              defaultContent={work.blurb}
-              as="p"
-              className="max-w-3xl whitespace-pre-line text-xl leading-relaxed text-stone-700 md:text-2xl"
-              multiline
-            />
+                <EditableText
+                  page="works"
+                  slot={`${work.slug}-story`}
+                  defaultContent={work.blurb}
+                  as="p"
+                  className="max-w-3xl whitespace-pre-line text-xl leading-relaxed text-stone-700 md:text-2xl"
+                  multiline
+                />
+              </>
+            )}
             {work.storyLinks && work.storyLinks.length > 0 && (
               <div className="mt-8 flex flex-col items-start gap-3">
                 {work.storyLinks.map((link, linkIndex) => (
@@ -333,11 +349,12 @@ export default function WorkDetail({ slug }: { slug: string }) {
           </div>
         </div>
       </section>
+      )}
 
       {work.slug === "the-shop" && <ShopInterestSection />}
 
-      {/* Two-up spread — slots 3 and 4 (between Witta thread and Hands) */}
-      <InlineSpreadImages work={work} />
+      {/* Two-up spread — slots 3 and 4 (between Witta thread and Hands). */}
+      {!isNote && <InlineSpreadImages work={work} />}
 
       {/* Photographs from Empathy Ledger */}
       <WorkPhotographsSection slug={work.slug} />
@@ -1018,13 +1035,21 @@ function InlineFeatureImage({
   slotKey: string;
   caption?: string;
 }) {
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
+  const slot = `${work.slug}-${slotKey}`;
+  const overrideQuery = trpc.imageOverrides.get.useQuery({ page: "works", slot });
+  // Visitors only see this slot when a real photo override exists, so a work
+  // without its own photo library no longer repeats the hero image down the
+  // page. Admins always see it, so the swap affordance stays reachable.
+  if (!isAdmin && (overrideQuery.isPending || !overrideQuery.data)) return null;
   return (
     <section className="py-12 md:py-16">
       <div className="container">
         <div className="max-w-5xl mx-auto">
           <HarvestImage
             page="works"
-            slot={`${work.slug}-${slotKey}`}
+            slot={slot}
             defaultWorkSlug={work.slug}
             src={work.heroImage}
             alt={`${work.title} — feature image`}
@@ -1045,6 +1070,16 @@ function InlineFeatureImage({
  * Each side is its own slot so admins can swap them independently.
  */
 function InlineSpreadImages({ work }: { work: import("@/data/works").Work }) {
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
+  const leftQuery = trpc.imageOverrides.get.useQuery({ page: "works", slot: `${work.slug}-spread-left` });
+  const rightQuery = trpc.imageOverrides.get.useQuery({ page: "works", slot: `${work.slug}-spread-right` });
+  // Visitors only see the two-image spread when both slots have real photos, so
+  // we never show a half-empty spread or the hero image repeated twice. Admins
+  // always see it, so both swap affordances stay reachable.
+  const resolved = !leftQuery.isPending && !rightQuery.isPending;
+  const hasBoth = Boolean(leftQuery.data) && Boolean(rightQuery.data);
+  if (!isAdmin && (!resolved || !hasBoth)) return null;
   return (
     <section className="py-12 md:py-16 bg-stone-50">
       <div className="container">

--- a/docs/strategy/community-launch-engagement-strategy-2026-06-02.md
+++ b/docs/strategy/community-launch-engagement-strategy-2026-06-02.md
@@ -1,0 +1,120 @@
+# The Harvest — 20 June Soft Launch Playbook
+
+> Community-engagement + art-led content strategy for the 20 June 2026 soft launch.
+> Generated 2026-06-02 by a 6-lane research workflow (community-launch · controlled-reveal · art-led posting · simple countdown · shop-contribution · internal grounding), synthesised and voice-checked against the Harvest/ACT voice (Curtis method; AI tells and drama em-dashes stripped). Builds on the locked date spine and existing assets — net-new is deliberately tiny. Members-first, no public RSVP form, free night, nothing sold.
+
+## 1. The through-line
+
+The launch is a slow reveal of a real place, not an ad for a future one. For three weeks the public sees fragments: soil, the oven, hands, the H pressed into dough. The people we already know get the date, the door, and the first seat. The gathering on 20 June is not a preview of The Harvest. It is The Harvest. Free, members-first, nothing sold, a good afternoon in the garden with pizza. We hold back the wide shot and the words so people lean in. Then we open the gate.
+
+## 2. The reveal arc
+
+Tease the craft. Hold back the pitch. One beat every few days, each one closer to the gate. Each post is a close-up that asks a question; the answer is the next post. The wide shot belongs to the day.
+
+| Week (spine) | SHOW (public, close-up, one line max) | HOLD BACK (deliberately withheld) |
+|---|---|---|
+| **Wk4 (2–8 Jun)** — public Field Note, no date | The ground. Soil in a hand. The shed. Witta's old dairy line. The H mark, small, in one corner. | The date. The event. Any "come along". The wide shot of the place. |
+| **Wk5 (9–15 Jun)** — members get the date Tue 9 Jun | The build. The oven door, the fire, hands tearing bread. Process, not people-posed. | Still no public date. Who is coming. Any price or order link. The full room. |
+| **16–19 Jun** — RSVPs close, final prep | The mark and the char. The H pressed into flour. Steam. The first loaf going in. | The faces. The long table. The whole space. Save it for Saturday. |
+| **SAT 20 JUN** — the day | The wide shot. The space, the garden, the loaves out of the oven. Name it: this is The Harvest. | Nothing now. This is the reveal. It only lands because of the three weeks of fragments before it. |
+| **21–26 Jun** — after-story | One real photo from the day plus one line. The door is open. | The hard sell. The newsletter funnel. Let people follow by choice. |
+
+Rules carried from the research: no wide shots in the lead-up (wide shots answer questions, close-ups ask them); no price, no public date, no call-to-action in the build-up; one anchor mark repeated every time (the H); captions one line, no hashtag stacking. Members get the inside track privately while the public gets pull.
+
+## 3. How we post
+
+Four repeatable formats. All shot on a phone, in the weekly rhythm we already run (Place Note / Practical Ask / weekend moment). Reuse real photo buckets. Never fabricate, never AI-photorealistic, never stock. The graphite-pencil illustration system is only for named zones, objects, and marks, never for people or scenes.
+
+1. **The H corner.** Every designed post carries the growing-H mark, same corner (bottom-left or top-right), same small size, every time. Treat it like a potter's stamp: present, never loud. This is the visual fingerprint that needs no designer.
+
+2. **Hand-in-frame close-up.** Soil, dough, a vegetable, the oven brick, always with a hand or forearm in shot. One rule of composition that makes every post read as made, not marketed, and shows scale without a posed photo. Pull from `compendium/`, `compendium/barry/`, and the 456 WhatsApp garden-crew exports (consent-gated for any visible person).
+
+3. **Same-light shot.** One shooting window: the half-hour after sunrise or before sunset. The warm low light becomes the Harvest palette, so people know a Harvest post before they read it. No preset; the light does the work.
+
+4. **The week card.** Once a week, plain text on a warm cream or linen ground, one typeface throughout: e.g. "Week 24. The oven is in." Or a named thing plus one question. The H in its corner, nothing else. This is the calendar heartbeat and the only thing built in Canva, built from scratch, never a farm template.
+
+Optional fifth, only when a real moment happens: a 15–30s process clip (weeding, tying tomatoes, fire lit). No music, no voiceover. The sound of the farm is the soundtrack. Add it because something real happened, not to fill a slot.
+
+## 4. The simple countdown
+
+No new tool, no live timer, no new list, no third email. The countdown rides inside the Field Notes and Harvest Notes already locked, plus the four-ish social beats above. It reuses what exists:
+
+- **Wk4 Field Note** (public list, template `6a1de93fa5ab652f24f6bee8`, subject "Witta hasn't had a shop in a long time") — stays date-light. One photo, one line of "something is coming". No date.
+- **Wk4 Makers' invite** (makers/doers, template `6a1de93f6972087910787f77`, RSVP calendar links live) — the maker session ask, off the public list.
+- **Harvest Note 02** (members, Tue 9 Jun, template `6a1de9407526e35f3eb1506a`, subject "You are hearing this first: the garden opens Saturday 20 June") — the date reveal plus B2 pizza RSVP opens via the emailed calendar link.
+- **Harvest Note 03** (members, 18–19 Jun, template `6a1de941eae4d2744602e305`) — final nudge, what to bring, what the afternoon feels like.
+
+The whole countdown is two habits: a plain count of days in the subject or first line of member sends ("11 days", "4 days" — plain specificity beats clever teaser copy), and the social close-ups dripping every 3–4 days, never daily. Three emails plus four-to-five social posts is the cap. Always set first-name fallback to "there". Test-send to Ben's mobile first. Never add a tag in a broadcast (it re-triggers the welcome workflow). An RSVP never auto-subscribes anyone.
+
+## 5. Shop-contribution campaign
+
+The campaign for makers and growers is warm, one-to-one, and identity-first: your name on a shelf your neighbours walk past. Not a form, not a broadcast, not a volume commitment. This runs in parallel and feeds the 20 June maker session. It is the second flywheel, not part of the pizza-night RSVP.
+
+**The invitation (verbal, by name, from a face they know):**
+- The Knock. Ben or a founding maker personally asks the named warm leads first, in the documented order: Leeza, Rebecca, Monita, Lachie → then Witta/Wootha neighbours (Robyn Jay, Fleur / Pinch & Spin, Jacky Lowry, Fresh Flavours Farm) → then shelf-stable wins (honey, coffee, chai, preserves) → then gallery and market channels. One-to-one email, DM, or call. Never a generic maker blast.
+- The wording is surplus and pride, not sales: "We'd love your honey on the shelf. Bring whatever you have spare to the maker session on Saturday 20 June, and we'll get it on." Odd shapes welcome. Garden tomatoes are exactly what we want.
+- Counter the "good enough" worry out loud. Most hobby growers assume the shop wants commercial-grade. Say plainly it doesn't.
+
+**The frictionless first step:**
+- A kraft label and a pen at the drop-off, one card: "Write your name and what it is. That's it." No online form, no barcode, no advance notice.
+- The name on the label is the headline benefit. When a maker's thing first lands on the shelf, photograph it and send it to them. That single photo is what turns a one-off contributor into a regular. Do it before asking for more.
+- A small "new from the neighbourhood" section makes the first contribution feel like a test, not a contract.
+- Close the loop fast: if it sells, tell them that day. Silence after a contribution is the quickest way to lose a maker.
+- Each reply moves the person to "In conversation" in the existing GHL Shop pipeline. Ask each new maker to name one other person in the valley worth asking. Follow that thread person to person.
+
+The 20 June maker session (calendar B1, 10am–2pm, Nic-led, 18 seats) is the first gathering of this community. After it, a simple makers' channel or a regular work day turns stockists into a community who shape the shop.
+
+## 6. The pizza night, kept simple
+
+**Framing:** This is a founding afternoon for people we want to shape this place with us, not a launch event. Free. Nothing sold. Members-first, invite-only, RSVP through the emailed GHL calendar link, never a public web form. The garden does not need to be finished and the oven does not need to be perfect. The roughness is the point; it tells people they are here early. The program is the program: a walk through the garden, the fire, a long table, make-your-own pizza. No slide deck, no speeches, no pitch. If we talk about what the place will be instead of what it is today, it starts to feel like a sell.
+
+**Run-of-feel (2pm onward, B2, 40 seats):**
+- **Arrive.** Coffee or a drink in hand within a minute. The fire is already going.
+- **A small job for everyone, straight away.** Pick basil and rocket, tear bread, carry the paddle, write on the chalkboard what you most want to grow. Jobs dissolve the guest/host line inside ten minutes and turn guests into people with a story to tell.
+- **A short, easy garden walk** — no tour script, just "come and see".
+- **Make your own pizza** at the oven. The making is the event.
+- **The long table.** Eat, talk, let it run.
+- **One concrete next step at the end, not "stay in touch".** Name a real thing: "We've got a work day in two weeks, who's in?" A specific next step keeps the thread alive without a funnel.
+- **A paper sheet on the table** (not a QR code), two columns: "I'd like to come back" and "I can help with…". People fill it in conversation. At the end you have a warm list and a skills map.
+
+**After (21–26 Jun, before Ben travels 27 Jun):** send each guest a single photo from the day and one line about what's next on the farm. A message from a person, not a template. This is the step most launches drop. Keeping it human here is what turns a guest into a member.
+
+Keep the rooms in the language: garden, kitchen, oven, fire, table, shed. One room, one object, one action.
+
+## 7. The 18-day calendar
+
+The date spine is fixed. This only adds the content, reveal, and shop beats onto it. Social drips every 3–4 days, never daily. Three emails total, four-to-five social posts total.
+
+| Date | Spine (fixed) | Content / reveal beat | Shop invite beat |
+|---|---|---|---|
+| **Mon 1 / 2 Jun** | Wk4 begins | Lineage post (verbatim, ready): "Before it was The Harvest, this place was a plant nursery called The Green Harvest." Pair with a real photo. | — |
+| **2–8 Jun** | Wk4 Makers' invite sent; Wk4 Field Note sent (public, no date) | Field Note: the ground / soil close-up, H in corner, date-light. Makers' invite carries the live RSVP calendar links. | Begin The Knock — 1:1 to warm leads (Leeza, Rebecca, Monita, Lachie). Verbal, surplus framing. |
+| **~Thu 4 / 5 Jun** | — | Social close-up #1 (soil / shed). One line. | — |
+| **~Sun 7 / 8 Jun** | — | Week card: "Week [X]." + one named thing. | — |
+| **Tue 9 Jun** | **Harvest Note 02 → members. B2 pizza RSVP opens** (emailed calendar link) | Reveal the date to members only. "You are hearing this first." Inside-track voice note/photo to members. | Continue The Knock — Witta/Wootha neighbours. Photograph any first contribution and send it back. |
+| **~Wed 11 / 12 Jun** | — | Social close-up #2 (the build: oven door, fire, hands). Public still has no date. | — |
+| **~Fri 13 / 14 Jun** | — | Process clip (only if a real moment) — silent, sound of the farm. | — |
+| **Mon 16 Jun** | **RSVPs close, headcount fixed** | Members get a short "we're nearly full" nudge inside the existing thread (plain "4 days"). No public date still. | Confirm what makers are bringing to the Sat session. "On the shelf" / "In conversation" pipeline tidy. |
+| **18–19 Jun** | **Insurance bound, final prep. Harvest Note 03 → members** | Note 03: what to bring, what the afternoon feels like. Social close-up #3 (the mark / the char / first loaf in). | Final 1:1 confirmations for the maker drop-off window. |
+| **SAT 20 JUN** | **Maker session 10am–2pm (B1, 18). Community gathering + make-your-own pizza from 2pm (B2, 40). Free. Nothing sold.** | The wide shot. The space, garden, loaves. Name it. The reveal. Paper come-back / can-help sheet on the table. | Maker drop-off at the session. Kraft label + pen. "Write your name and what it is." Photograph the shelf. |
+| **21–26 Jun** | After-story comms (Ben overseas from 27 Jun) | One after-story social post plus a personal photo-and-one-line message to each guest. Invite to follow by choice. | Loop closed with makers: tell them same-day if their thing sold; ask each for one more name in the valley. |
+
+## 8. Reuse vs net-new
+
+**Lean on (already built — do not rebuild):**
+- The locked 20 June date spine and the three-list members-first sequence (harvest-newsletter / harvest-member / harvest-shop-interest).
+- The four email templates and their written subjects (Field Note `6a1de93fa5ab652f24f6bee8`, Makers' invite `6a1de93f6972087910787f77`, Harvest Note 02 `6a1de9407526e35f3eb1506a`, Harvest Note 03 `6a1de941eae4d2744602e305`).
+- The two live RSVP calendar slots (maker session + afternoon pizza) and the welcome workflows.
+- The weekly content rhythm (Place / People / Making / Invitation) and the four content pillars. The posting engine already exists.
+- The GHL Shop pipeline (New interest → In conversation → Sampling/trial shelf → On the shelf), the maker smart list, and the documented warm-lead outreach order.
+- Real photo buckets (`compendium/`, `compendium/barry/`, `witta/history/`, the 456 WhatsApp exports), the verified facts (~1,300 in Witta; Witta hasn't had a shop in a long time; postal-area figures), the social card (milk-crate photo), the H mark with its lifecycle stages, and the graphite-pencil illustration system.
+- Verbatim-ready social posts (Post C, Post D, the lineage post) in `content-calendar-june-2026.md`.
+
+**Small net-new (the only things to make):**
+- A short "drip cadence" line added to the existing member emails (a plain "X days", no tooling).
+- Four-to-five close-up social posts following the reveal ladder, shot in the same-light window, H in the corner.
+- One reusable **week card** layout (built from scratch in Canva: the palette and one typeface).
+- A printed **kraft drop-off card** ("Write your name and what it is") and a **paper come-back / can-help sheet** for the long table.
+- A one-line **after-the-day** social post and the personal photo-and-line message to each guest.
+
+**Hard gates that stay on:** never name 20 June on the public list before the member reveal; never add a tag in a broadcast; never auto-subscribe an RSVP; consent confirmed in the Notion asset review before any person-led photo goes public; never fill `[MAKER NAME]` or `[needs real name/photo — do not invent]` with a fabricated person; reach Barry and older long-timers only through people they trust (Rec Club, RSL, a personal invite), never digital-only.

--- a/docs/strategy/ghl-calendar-tag-workflows-runbook.md
+++ b/docs/strategy/ghl-calendar-tag-workflows-runbook.md
@@ -1,0 +1,67 @@
+# Runbook — build the 3 calendar-tag workflows (GHL UI)
+
+> Why a runbook and not a script: GHL has no workflow-create API. Workflows with a
+> *Customer Booked Appointment* trigger are built in the workflow UI only. The API can
+> enrol/trigger and list workflows, not create them. This is a ~10-minute click job.
+> Source spec: `ghl-workflow-build-specs.md` §7. Tags already exist in the location library.
+
+**Location:** The Harvest (LeadConnector / GHL). **Build order:** 7a first, then *Clone* it for 7b and 7c.
+
+---
+
+## Workflow 7a — RSVP: Maker session (B1)
+
+1. **Automation → Workflows → + Create Workflow → Start from scratch.**
+2. Name it: **`Harvest - RSVP Maker Session (tag)`**
+3. **Add Trigger → "Customer Booked Appointment".**
+   - Filter: **In Calendar** → **is** → `RSVP: Maker session, Sat 20 June` (ID `M0KzSu7Bo3jJ3ZQta3ag`)
+4. **Add Action → "Add Contact Tag":**
+   - `witta-gathering-2026-06-20`
+   - `rsvp-maker-morning`
+5. **Settings → Re-entry: OFF** (a contact who re-books should not re-tag — once is enough).
+6. **No email step** — the calendar sends its own booking confirmation. Do NOT add `harvest-newsletter` or `harvest-member` (an RSVP is not a subscribe).
+7. **Save → Publish (toggle to Publish, top-right).**
+
+---
+
+## Workflow 7b — RSVP: Afternoon + pizza (B2)  *(clone of 7a)*
+
+1. On 7a: **⋮ → Clone.** Rename the clone: **`Harvest - RSVP Afternoon + Pizza (tag)`**
+2. **Edit the trigger filter:** In Calendar → is → `RSVP: Afternoon + pizza, Sat 20 June` (ID `4IpU9GnzAChTMkKFJPWi`)
+3. **Edit the Add-Tag action** to:
+   - `witta-gathering-2026-06-20`
+   - `rsvp-pizza-dinner`   ← **this count is the pizza-dough headcount**
+4. **Re-entry: OFF.**
+5. **Publish.**
+
+---
+
+## Workflow 7c — Book a chat about the shop  *(clone of 7a)*
+
+1. On 7a: **⋮ → Clone.** Rename: **`Harvest - Shop Chat Booked (tag)`**
+2. **Edit the trigger filter:** In Calendar → is → `Book a chat about the shop` (ID `viM1BRnHG9gwpIEZd4HM`)
+3. **Edit the Add-Tag action** to:
+   - `harvest-shop-interest`  ← reuses the shop tag so a booked chat flows into the Shop pipeline + nurture
+   - `shop-call-booked`       ← distinguishes a booked call from a form EOI
+4. **Re-entry: ON** (someone may book more than one chat over time).
+5. **Publish.**
+
+---
+
+## Test (do this once per workflow before trusting the count)
+
+1. Open each calendar's public booking link, book a test slot with a throwaway/your-own contact.
+2. In **Contacts**, open that contact → confirm the two expected tags appear within ~1 min.
+3. Check the smart list: a booking on B2 should make **`rsvp-pizza-dinner`** count = 1.
+4. Delete the test appointment + remove the test tags (or delete the test contact) so the headcount starts clean.
+
+## Acceptance
+- [ ] 7a published, test booking tagged `witta-gathering-2026-06-20` + `rsvp-maker-morning`
+- [ ] 7b published, test booking tagged `witta-gathering-2026-06-20` + `rsvp-pizza-dinner`
+- [ ] 7c published, test booking tagged `harvest-shop-interest` + `shop-call-booked`
+- [ ] all three test bookings + tags cleaned up so live counts are zero at start
+
+## Guardrails
+- No email/notification step inside these (the calendar handles confirmations).
+- Never auto-apply `harvest-newsletter` / `harvest-member` on an RSVP.
+- These tags drive the pizza headcount and the Events smart list — a wrong calendar filter = wrong count, so test each one.

--- a/docs/strategy/harvest-ghl-alignment-2026-06-02.md
+++ b/docs/strategy/harvest-ghl-alignment-2026-06-02.md
@@ -57,11 +57,12 @@ One tag per job. Scope + tier + role are the spine; interest/source/consent are 
    - Shop Interest Receipt → add action *Add Tag* `role:supplier`
 3. **Build the 3 calendar-tag workflows** per `ghl-calendar-tag-workflows-runbook.md` (7a/b/c). RSVP tags only — no tier change (an RSVP is not a subscribe).
 
-### B. Website code — I do, Phase 2 (one PR, deployed + verified)
-Migrate the form handlers so they apply the canonical tags at source instead of the in-workflow bridge:
-- `server/routers.ts` (`buildNewsletterTags`, shop/quiz/member handlers) + `server/gohighlevel.ts`
-- flat `interest-*` → `interest:*`; flat `source-*` → `source:*`; apply `tier:`/`role:` at submit.
-- Keep `harvest-*` scope tags. Don't break the live forms; ship behind the existing upsert path.
+### B. Website code — SHIPPED to branch `wip/harvest-launch-fixes-2026-06-02` (not yet deployed)
+All in `server/routers.ts` (no `gohighlevel.ts` change needed — it POSTs tags to `/contacts/{id}/tags`, which merges and preserves colons):
+- `interest:*` / `source:*` are now canonical, **dual-written** with their flat `interest-*` / `source-*` aliases via `withFlatAlias()` so existing smart lists keep receiving contacts (NOT a hard switch — avoids silently dropping new contacts from flat-tag segments mid-launch).
+- Journey bridge applied at submit: member → `tier:member` + `role:member`; follower → `tier:connected`; quiz → `tier:curious`; shop EOI → `role:supplier`. Channel tag `comms:harvest-newsletter` added.
+- Kept `harvest-*` scope tags + bare `newsletter`. 22 tests pass (2 new assertions pin the namespaced/tier output). `tsc` clean.
+- **Note:** because code now applies `tier:`/`role:`, the in-workflow bridge in A2 becomes redundant once this deploys — but tags are idempotent (set membership), so running both is harmless. After deploy, A2 can be dropped.
 
 ### C. Tag hygiene — later, after B ships
 Deprecate the duplicate flat `interest-*` / `source-*` tags (stop applying, then archive — never bulk-delete mid-launch; check no other ACT project relies on them first).

--- a/docs/strategy/harvest-ghl-alignment-2026-06-02.md
+++ b/docs/strategy/harvest-ghl-alignment-2026-06-02.md
@@ -1,0 +1,76 @@
+# Harvest GHL Alignment — verified state + realignment plan
+
+> 2026-06-02. Verified live via `scripts/list-ghl-workflows-and-tags.ts` (read-only GHL API) + the workflow-list UI. Supersedes the "workflows verified live" claims in the May docs — they are now `draft`. Three problems, one decision, a clicked plan + a code plan.
+
+## Verified live state
+
+**Workflows (Harvest-relevant, from 18 in the shared ACT location):**
+
+| Workflow | ID | Status | Note |
+|---|---|---|---|
+| Harvest - Follow Welcome | `0cf2479e-791c-43ac-a8cd-a3395a03cdaa` | **draft** | not firing |
+| Harvest - Member Welcome | `19cc358a-05f6-4d99-8e6b-91b31c63e8c4` | **draft** | 46 enrolled, not firing |
+| Harvest - Member Question Receipt | `62aa2b50-c4f3-4564-84c3-3aa81c0c36f8` | **draft** | not firing |
+| Harvest - Shop Interest Receipt | `ff4ff43e-0174-415d-828e-3610f5386de5` | **draft** | not firing |
+| Shop prospect → create card | `570b1e7a-a6c3-49f5-8989-dca0eee5dbfa` | **draft** | not firing |
+| Contact Form to Universal Inquiry | `f0c1f3db-8809-4283-ba91-907626ac0bb7` | **draft** | not firing |
+| Harvest Membership Journey | `cadc781e-f1c5-4c2a-9568-0f2fd93daef6` | published | **0 enrolled — orphaned** |
+
+All five share `Last Updated Jun 02 12:04 PM` → a bulk change today likely reverted them to draft (cause inferred).
+
+**Tags:** 397 in the shared location. Harvest-relevant + the collisions:
+- `harvest-*` (8): harvest-website, harvest-newsletter, harvest-member, harvest-shop-interest, harvest-event-attendee, harvest-gathering-photos, harvest-inbox, harvest-people-hq
+- `interest-*` (10, FLAT — website applies these) vs `interest:*` (16, NAMESPACED — ACT-wide standard) ← **duplicate taxonomy**
+- `source-*` (2) vs `source:*` (17) ← **duplicate taxonomy**
+- `tier:` (curious, connected, member) · `role:` (19) · `comms:` (13) · `consent:` (newsletter-yes, withdrawn) · `action:` (5)
+- operational (keep as-is): `rsvp-maker-morning`, `rsvp-pizza-dinner`, `shop-*` (7), `quiz-*` (6), `witta-gathering-2026-06-20`, `member-question`, `pulse-respondent`, `event-submission`, `business-registration`
+
+## The three problems
+
+1. **Workflows draft → no automated emails fire.** Launch-critical: members joining now hear nothing back.
+2. **Membership Journey orphaned** → published but nothing applies `tier:` tags, so 0 inflow.
+3. **Tag drift** → flat `interest-*`/`source-*` (website) vs namespaced `interest:`/`source:` (ACT-wide); 397-tag sprawl with no canonical Harvest subset.
+
+## Target model — canonical Harvest tag set
+
+One tag per job. Scope + tier + role are the spine; interest/source/consent are namespaced; operational tags stay flat.
+
+| Job | Canonical tag(s) | Deprecate |
+|---|---|---|
+| Scope (which list/site) | `harvest-website`, `harvest-newsletter` (the list), `comms:harvest-newsletter` (channel/consent) | — |
+| Journey stage | `tier:curious` → `tier:connected` → `tier:member` | — |
+| Role | `role:member`, `role:buyer`, `role:supplier` (maker/grower), `role:volunteer`, `role:partner` | — |
+| Interest | `interest:*` (namespaced) | `interest-*` (flat, after code migration) |
+| Source | `source:*` (namespaced) | `source-*` (flat, after code migration) |
+| Consent | `consent:newsletter-yes` | — |
+| Operational (events/shop/quiz) | keep flat: `rsvp-pizza-dinner`, `rsvp-maker-morning`, `shop-call-booked`, `harvest-shop-interest`, `quiz-*`, `witta-gathering-2026-06-20` | — |
+
+**The bridge that fixes the orphaned Journey:** whenever someone becomes a member, apply `tier:member` + `role:member` (not just `harvest-member`). Whenever someone follows, apply `tier:connected`. That feeds the Journey pipeline.
+
+## Realignment actions
+
+### A. GHL UI — Ben clicks, launch-critical, do now (no deploy)
+1. **Publish the 5 draft workflows** (Follow Welcome, Member Welcome, Member Question, Shop Interest Receipt, Shop prospect→card). Test one enrol each — confirm the email fires.
+2. **Feed the Journey (in-workflow, no code):**
+   - Member Welcome → add action *Add Tag* `tier:member` + `role:member`
+   - Follow Welcome → add action *Add Tag* `tier:connected`
+   - Shop Interest Receipt → add action *Add Tag* `role:supplier`
+3. **Build the 3 calendar-tag workflows** per `ghl-calendar-tag-workflows-runbook.md` (7a/b/c). RSVP tags only — no tier change (an RSVP is not a subscribe).
+
+### B. Website code — I do, Phase 2 (one PR, deployed + verified)
+Migrate the form handlers so they apply the canonical tags at source instead of the in-workflow bridge:
+- `server/routers.ts` (`buildNewsletterTags`, shop/quiz/member handlers) + `server/gohighlevel.ts`
+- flat `interest-*` → `interest:*`; flat `source-*` → `source:*`; apply `tier:`/`role:` at submit.
+- Keep `harvest-*` scope tags. Don't break the live forms; ship behind the existing upsert path.
+
+### C. Tag hygiene — later, after B ships
+Deprecate the duplicate flat `interest-*` / `source-*` tags (stop applying, then archive — never bulk-delete mid-launch; check no other ACT project relies on them first).
+
+## The one decision (gates Phase B)
+**Converge the Harvest website onto the namespaced ACT-wide taxonomy?** (Recommended: yes — it's already the standard across Goods/JusticeHub/funders, and it makes the Journey + cross-project segments work.) If yes, Phase B is a code PR. If you'd rather keep Harvest on flat tags for now, we skip B and rely on the in-workflow bridge (A2) alone — the Journey still gets fed, but the duplicate taxonomies persist.
+
+## Guardrails
+- Don't bulk-delete tags during launch — deprecate by ceasing to apply, archive later, verify no cross-project dependency first.
+- Publishing a workflow does not re-enrol the historical 46 — it only fires for new triggers from now.
+- Never add `harvest-newsletter`/`harvest-member` on an RSVP (event yes ≠ subscribe).
+- Adding tags inside a published workflow is safe + reversible; test one contact before trusting counts.

--- a/scripts/list-ghl-workflows-and-tags.ts
+++ b/scripts/list-ghl-workflows-and-tags.ts
@@ -1,0 +1,68 @@
+import "dotenv/config";
+
+// Read-only audit: list all GHL workflows (status) + the location tag library.
+// GHL exposes workflow status + the tag library via API, but NOT a workflow's
+// internal steps/actions (those are UI-only). Use this to ground tag/workflow
+// alignment in live state rather than stale docs.
+
+const GHL_API_BASE = "https://services.leadconnectorhq.com";
+const VERSION = "2021-07-28";
+
+function requireEnv(name: string) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing ${name}`);
+  return value.trim();
+}
+
+async function ghlJson<T>(pathname: string): Promise<T> {
+  const response = await fetch(`${GHL_API_BASE}${pathname}`, {
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${requireEnv("GHL_API_KEY")}`,
+      Version: VERSION,
+    },
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GHL ${response.status} on ${pathname}: ${body.slice(0, 300)}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+async function main() {
+  const locationId = requireEnv("GHL_LOCATION_ID");
+
+  // Workflows
+  const wf = await ghlJson<{ workflows?: Array<{ id: string; name?: string; status?: string; version?: number }> }>(
+    `/workflows/?locationId=${locationId}`,
+  );
+  const workflows = (wf.workflows ?? []).sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+  console.log(`\n=== WORKFLOWS (${workflows.length}) ===`);
+  for (const w of workflows) {
+    console.log(`${(w.status || "?").padEnd(10)} | ${w.id} | v${w.version ?? "?"} | ${w.name || "(no name)"}`);
+  }
+
+  // Tag library
+  try {
+    const tg = await ghlJson<{ tags?: Array<{ id: string; name?: string }> }>(`/locations/${locationId}/tags`);
+    const tags = (tg.tags ?? []).map((t) => t.name || "").filter(Boolean).sort();
+    console.log(`\n=== TAG LIBRARY (${tags.length}) ===`);
+    // group by prefix for readability
+    const groups: Record<string, string[]> = {};
+    for (const name of tags) {
+      const prefix = name.includes(":") ? name.split(":")[0] + ":" : (name.split("-")[0] || "other");
+      (groups[prefix] ||= []).push(name);
+    }
+    for (const prefix of Object.keys(groups).sort()) {
+      console.log(`\n[${prefix}] (${groups[prefix].length})`);
+      console.log("  " + groups[prefix].join(", "));
+    }
+  } catch (err) {
+    console.log(`\n=== TAG LIBRARY ===\nCould not fetch tags: ${(err as Error).message}`);
+  }
+}
+
+main().catch((error) => {
+  console.error("FAILED:", (error as Error).message);
+  process.exit(1);
+});

--- a/server/__tests__/newsletter.test.ts
+++ b/server/__tests__/newsletter.test.ts
@@ -521,3 +521,31 @@ describe("Go High Level Newsletter Integration", () => {
     });
   });
 });
+
+describe("Phase B — namespaced taxonomy + Journey bridge", () => {
+  it("tags a member with tier:member, role:member, comms + namespaced interest (dual-written)", () => {
+    const tags = buildNewsletterTags({ member: true, interests: ["membership", "community"] });
+    expect(tags).toEqual(expect.arrayContaining([
+      "tier:member",
+      "role:member",
+      "comms:harvest-newsletter",
+      "interest:membership",
+      "interest:community",
+    ]));
+    // legacy flat aliases still dual-written during the migration (remove in Phase C)
+    expect(tags).toEqual(expect.arrayContaining(["interest-membership", "interest-community"]));
+    expect(tags).not.toContain("tier:connected");
+  });
+
+  it("tags a non-member follower as tier:connected, never as a member", () => {
+    const tags = buildNewsletterTags({ member: false, interests: ["events"] });
+    expect(tags).toEqual(expect.arrayContaining([
+      "tier:connected",
+      "comms:harvest-newsletter",
+      "interest:events",
+      "interest-events",
+    ]));
+    expect(tags).not.toContain("tier:member");
+    expect(tags).not.toContain("harvest-member");
+  });
+});

--- a/server/__tests__/newsletter.test.ts
+++ b/server/__tests__/newsletter.test.ts
@@ -241,6 +241,9 @@ describe("Go High Level Newsletter Integration", () => {
           "newsletter",
           "harvest-newsletter",
           "harvest-member",
+          "project:act-hv",
+          "tier:member",
+          "interest:membership",
           "interest-membership",
           "interest-community",
           "interest-sustainability",
@@ -523,18 +526,21 @@ describe("Go High Level Newsletter Integration", () => {
 });
 
 describe("Phase B — namespaced taxonomy + Journey bridge", () => {
-  it("tags a member with tier:member, role:member, comms + namespaced interest (dual-written)", () => {
+  it("tags a member with tier:member + comms + namespaced interest (no role:member; that's a tier)", () => {
     const tags = buildNewsletterTags({ member: true, interests: ["membership", "community"] });
     expect(tags).toEqual(expect.arrayContaining([
       "tier:member",
-      "role:member",
       "comms:harvest-newsletter",
       "interest:membership",
       "interest:community",
     ]));
     // legacy flat aliases still dual-written during the migration (remove in Phase C)
     expect(tags).toEqual(expect.arrayContaining(["interest-membership", "interest-community"]));
+    // membership is a tier: rung, never a role: — role:member is not in the canonical vocabulary
+    expect(tags).not.toContain("role:member");
     expect(tags).not.toContain("tier:connected");
+    // project:act-hv is stamped at the GHL-client chokepoint, not in buildNewsletterTags
+    expect(tags).not.toContain("project:act-hv");
   });
 
   it("tags a non-member follower as tier:connected, never as a member", () => {

--- a/server/gohighlevel.ts
+++ b/server/gohighlevel.ts
@@ -81,7 +81,9 @@ export async function createGHLContact(input: GHLContactInput): Promise<{ succes
         phone: input.phone || undefined,
         locationId: locationId,
         source: input.source || "Harvest | Website",
-        tags: input.tags || ["newsletter", "website-signup"],
+        // Every contact from the Harvest site belongs to project:act-hv — stamp the
+        // canonical router tag here so no individual handler can omit it.
+        tags: Array.from(new Set([...(input.tags || ["newsletter", "website-signup"]), "project:act-hv"])),
       }),
     });
 
@@ -181,8 +183,10 @@ export async function upsertGHLContact(input: GHLContactInput): Promise<{ succes
       }
     }
 
-    // 3. Add tags separately (merges with existing tags)
-    const tags = input.tags || ["newsletter", "harvest-website"];
+    // 3. Add tags separately (merges with existing tags).
+    // Stamp the canonical project:act-hv router tag at this chokepoint so every
+    // Harvest contact carries it regardless of which handler created them.
+    const tags = Array.from(new Set([...(input.tags || ["newsletter", "harvest-website"]), "project:act-hv"]));
     if (tags.length > 0 && contactId) {
       try {
         await fetch(`${GHL_API_BASE}/contacts/${contactId}/tags`, {

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -179,12 +179,12 @@ export function buildNewsletterTags(input: {
     for (const t of withFlatAlias(NEWSLETTER_INTEREST_TAGS[interest])) tags.add(t);
   }
 
-  // Journey bridge: a member is tier:member + role:member; everyone else who
-  // subscribes has raised a hand, so tier:connected. Feeds the Membership Journey pipeline.
+  // Journey bridge: membership is a tier: rung, NOT a role: (canonical vocabulary
+  // has no role:member). Everyone else who subscribes has raised a hand -> tier:connected.
+  // project:act-hv is stamped at the GHL-client chokepoint. Feeds the Membership Journey.
   if (input.member || input.interests?.includes("membership")) {
     tags.add("harvest-member");
     tags.add("tier:member");
-    tags.add("role:member");
     for (const t of withFlatAlias("interest:membership")) tags.add(t);
   } else {
     tags.add("tier:connected");
@@ -805,7 +805,6 @@ export const appRouter = router({
               tags: [
                 "harvest-member",
                 "tier:member",
-                "role:member",
                 ...withFlatAlias("interest:membership"),
                 ...withFlatAlias("interest:community"),
                 "member-wall",
@@ -924,6 +923,7 @@ export const appRouter = router({
             "shop-follow-up",
             "shop-stage-1",
             "role:supplier",
+            "interest:markets",
             offerTag,
           ],
         });

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -894,6 +894,7 @@ export const appRouter = router({
             "harvest-shop-interest",
             "harvest-website",
             "shop-follow-up",
+            "shop-stage-1",
             offerTag,
           ],
         });

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -101,24 +101,29 @@ export const REFERRAL_SOURCE_OPTIONS = [
 
 type ReferralSource = (typeof REFERRAL_SOURCE_OPTIONS)[number];
 
+// Namespaced ACT-wide taxonomy (source:* / interest:*) is canonical. The flat
+// source-* / interest-* aliases are dual-written at apply-time via withFlatAlias()
+// so existing GHL smart lists keep receiving contacts; remove the flat aliases in
+// Phase C once smart lists are repointed.
+// See docs/strategy/harvest-ghl-alignment-2026-06-02.md
 const REFERRAL_SOURCE_TAGS: Record<ReferralSource, string> = {
-  "friend-or-neighbour": "source-referral",
-  "social-media": "source-social",
-  "in-witta": "source-local-witta",
-  other: "source-other",
+  "friend-or-neighbour": "source:referral",
+  "social-media": "source:social",
+  "in-witta": "source:local-witta",
+  other: "source:other",
 };
 
 const NEWSLETTER_INTEREST_TAGS: Record<NewsletterInterest, string> = {
-  events: "interest-events",
-  workshops: "interest-workshops",
-  markets: "interest-markets",
-  "venue-hire": "interest-venue",
-  "garden-centre": "interest-garden",
-  "food-kitchen": "interest-food",
-  community: "interest-community",
-  volunteering: "interest-volunteer",
-  membership: "interest-membership",
-  sustainability: "interest-sustainability",
+  events: "interest:events",
+  workshops: "interest:workshops",
+  markets: "interest:markets",
+  "venue-hire": "interest:venue",
+  "garden-centre": "interest:garden",
+  "food-kitchen": "interest:food",
+  community: "interest:community",
+  volunteering: "interest:volunteer",
+  membership: "interest:membership",
+  sustainability: "interest:sustainability",
 };
 
 const SHOP_INTEREST_TAGS: Record<ShopInterestOfferType, string> = {
@@ -149,20 +154,40 @@ function slugifyTagPart(value: string) {
     .replace(/^-+|-+$/g, "");
 }
 
+// Dual-write a namespaced tag alongside its legacy flat alias (colon -> hyphen)
+// during the 2026-06 tag migration. Only call on interest:* / source:* tags that
+// have an existing flat smart-list dependency — NOT on tier:/role:/comms: (no legacy).
+function withFlatAlias(tag: string): string[] {
+  const flat = tag.replace(":", "-");
+  return flat === tag ? [tag] : [tag, flat];
+}
+
 export function buildNewsletterTags(input: {
   interests?: NewsletterInterest[];
   member?: boolean;
   extraTags?: string[];
 }) {
-  const tags = new Set(["newsletter", "harvest-newsletter", "harvest-website"]);
+  // Scope + channel tags. `newsletter` (bare) is legacy cross-location; keep until Phase C.
+  const tags = new Set([
+    "newsletter",
+    "harvest-newsletter",
+    "harvest-website",
+    "comms:harvest-newsletter",
+  ]);
 
   for (const interest of input.interests || []) {
-    tags.add(NEWSLETTER_INTEREST_TAGS[interest]);
+    for (const t of withFlatAlias(NEWSLETTER_INTEREST_TAGS[interest])) tags.add(t);
   }
 
+  // Journey bridge: a member is tier:member + role:member; everyone else who
+  // subscribes has raised a hand, so tier:connected. Feeds the Membership Journey pipeline.
   if (input.member || input.interests?.includes("membership")) {
     tags.add("harvest-member");
-    tags.add("interest-membership");
+    tags.add("tier:member");
+    tags.add("role:member");
+    for (const t of withFlatAlias("interest:membership")) tags.add(t);
+  } else {
+    tags.add("tier:connected");
   }
 
   for (const tag of input.extraTags || []) {
@@ -572,7 +597,8 @@ export const appRouter = router({
           firstName,
           lastName,
           source: "Harvest | Quiz",
-          tags: [...input.ghlTags, "quiz-completed", "harvest-website"],
+          // A quiz-taker is a first touch: tier:curious feeds the top of the Journey.
+          tags: [...input.ghlTags, "quiz-completed", "harvest-website", "tier:curious"],
         });
 
         if (result.contactId) {
@@ -648,7 +674,7 @@ export const appRouter = router({
         const interests = input.interests || [];
         const extraTags = input.notes ? ["member-comments", "harvest-inbox"] : [];
         if (input.heardAbout) {
-          extraTags.push(REFERRAL_SOURCE_TAGS[input.heardAbout]);
+          extraTags.push(...withFlatAlias(REFERRAL_SOURCE_TAGS[input.heardAbout]));
         }
         const allTags = buildNewsletterTags({
           interests,
@@ -778,8 +804,10 @@ export const appRouter = router({
               source: "Harvest | Member Wall",
               tags: [
                 "harvest-member",
-                "interest-membership",
-                "interest-community",
+                "tier:member",
+                "role:member",
+                ...withFlatAlias("interest:membership"),
+                ...withFlatAlias("interest:community"),
                 "member-wall",
                 "harvest-website",
               ],
@@ -895,6 +923,7 @@ export const appRouter = router({
             "harvest-website",
             "shop-follow-up",
             "shop-stage-1",
+            "role:supplier",
             offerTag,
           ],
         });
@@ -1533,7 +1562,7 @@ export const appRouter = router({
 
         // Only sync to GHL when we have both email and a real name.
         if (cleanEmail && cleanName) {
-          const interestTags = (input.wouldUse || []).map(u => `interest-${slugifyTagPart(u)}`);
+          const interestTags = (input.wouldUse || []).flatMap(u => withFlatAlias(`interest:${slugifyTagPart(u)}`));
           const pulseResult = await upsertGHLContact({
             email: cleanEmail,
             firstName: cleanName.split(" ")[0],


### PR DESCRIPTION
## What

Consolidates the `wip/harvest-launch-fixes-2026-06-02` session's launch work for the 20 June members' day.

Commits:
- Fix 20-June launch: correct GardenLaunch times + add shop-stage-1 tag
- Add 20-June community-launch engagement playbook (workflow-researched, voice-checked)
- Add GHL calendar-tag workflows runbook (7a/b/c) for 20-June RSVP headcount
- Add GHL workflow+tag alignment spec + read-only audit tool
- Phase B: converge Harvest forms onto namespaced GHL taxonomy + Journey bridge
- Reconcile Harvest tags to canonical ecosystem vocabulary

## Notes

- Also contains a duplicate of the Works-page alignment commit (`9a5dc8c`), already on main via #25 (`fc1c1fc`). Identical diff, de-dupes cleanly on merge.
- Verified: `tsc --noEmit` clean, `npm run build` clean. Consolidated by a separate session and build-checked here; not line-reviewed in this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)