### PR TITLE
Connect Harvest participation journeys

### DIFF
--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -7,6 +7,12 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://www.theharvestwitta.com.au/start</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.95</priority>
+  </url>
+  <url>
     <loc>https://www.theharvestwitta.com.au/membership</loc>
     <lastmod>2026-05-13</lastmod>
     <changefreq>weekly</changefreq>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -36,6 +36,7 @@ import Membership from "./pages/Membership";
 import Shop from "./pages/Shop";
 import Stories from "./pages/Stories";
 import GetInvolved from "./pages/GetInvolved";
+import StartHere from "./pages/StartHere";
 import Journey from "./pages/Journey";
 import People from "./pages/People";
 import SitePlan from "./pages/SitePlan";
@@ -131,6 +132,7 @@ function Router() {
   if (location === "/shop") return <Shop />;
   if (location === "/stories") return <Stories />;
   if (location === "/get-involved") return <GetInvolved />;
+  if (location === "/start" || location === "/start-here") return <StartHere />;
   if (location === "/story") return <Journey />;
   if (location === "/people") return <People />;
   if (location.startsWith("/people/")) {

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -191,3 +191,24 @@ export async function subscribeNewsletter(payload: Record<string, unknown>) {
 export async function communitySubmit(payload: Record<string, unknown>) {
   return callFunction<{ success: boolean; error?: string; contactId?: string }>("community-submit", payload);
 }
+
+export interface HarvestPublicSocialPost {
+  id: string;
+  platform: string;
+  account_name: string | null;
+  post_type: string | null;
+  message: string | null;
+  permalink: string | null;
+  published_at: string;
+  media: unknown[];
+}
+
+export async function fetchHarvestPublicSocialPosts(limit = 6): Promise<HarvestPublicSocialPost[]> {
+  const { data, error } = await supabase
+    .from("v_harvest_public_social_posts")
+    .select("id, platform, account_name, post_type, message, permalink, published_at, media")
+    .order("published_at", { ascending: false })
+    .limit(limit);
+  if (error) throw error;
+  return (data || []) as HarvestPublicSocialPost[];
+}

--- a/client/src/lib/seo.ts
+++ b/client/src/lib/seo.ts
@@ -1,0 +1,90 @@
+const SITE_URL = "https://www.theharvestwitta.com.au";
+const DEFAULT_IMAGE = "/images/social/harvest-social-card.jpg";
+const DEFAULT_IMAGE_ALT = "Milk crates stacked into a pavilion at The Harvest in Witta.";
+
+type PageSeo = {
+  title: string;
+  description: string;
+  path?: string;
+  type?: "website" | "article";
+  image?: string;
+  imageAlt?: string;
+  robots?: "index, follow" | "noindex, nofollow";
+};
+
+function absoluteUrl(value: string) {
+  return new URL(value, SITE_URL).toString();
+}
+
+function pageUrl(path = "/") {
+  const url = new URL(path, SITE_URL);
+  url.hash = "";
+  url.search = "";
+  return url.toString();
+}
+
+function setMeta(attribute: "name" | "property", key: string, content: string) {
+  let meta = document.querySelector(`meta[${attribute}="${key}"]`) as HTMLMetaElement | null;
+  if (!meta) {
+    meta = document.createElement("meta");
+    meta.setAttribute(attribute, key);
+    document.head.appendChild(meta);
+  }
+  meta.content = content;
+}
+
+function setCanonical(href: string) {
+  let link = document.querySelector('link[rel="canonical"]') as HTMLLinkElement | null;
+  if (!link) {
+    link = document.createElement("link");
+    link.rel = "canonical";
+    document.head.appendChild(link);
+  }
+  link.href = href;
+}
+
+export function setPageSeo({
+  title,
+  description,
+  path = "/",
+  type = "website",
+  image = DEFAULT_IMAGE,
+  imageAlt = DEFAULT_IMAGE_ALT,
+  robots = "index, follow",
+}: PageSeo) {
+  const url = pageUrl(path);
+  const imageUrl = absoluteUrl(image);
+
+  document.title = title;
+  setCanonical(url);
+  setMeta("name", "title", title);
+  setMeta("name", "description", description);
+  setMeta("name", "robots", robots);
+  setMeta("property", "og:type", type);
+  setMeta("property", "og:url", url);
+  setMeta("property", "og:title", title);
+  setMeta("property", "og:description", description);
+  setMeta("property", "og:image", imageUrl);
+  setMeta("property", "og:image:alt", imageAlt);
+  setMeta("property", "twitter:card", "summary_large_image");
+  setMeta("property", "twitter:url", url);
+  setMeta("property", "twitter:title", title);
+  setMeta("property", "twitter:description", description);
+  setMeta("property", "twitter:image", imageUrl);
+  setMeta("property", "twitter:image:alt", imageAlt);
+}
+
+export function setJsonLd(id: string, data: Record<string, unknown>) {
+  let script = document.getElementById(id) as HTMLScriptElement | null;
+  if (!script) {
+    script = document.createElement("script");
+    script.id = id;
+    script.type = "application/ld+json";
+    document.head.appendChild(script);
+  }
+  script.textContent = JSON.stringify(data);
+}
+
+export function clearJsonLd(id: string) {
+  document.getElementById(id)?.remove();
+}

--- a/client/src/lib/tracking.ts
+++ b/client/src/lib/tracking.ts
@@ -1,0 +1,21 @@
+export const START_HERE_CAMPAIGN = "start-here";
+
+export function trackedPath(path: string, content: string): string {
+  const url = new URL(path, "https://www.theharvestwitta.com.au");
+  url.searchParams.set("utm_source", "harvest-website");
+  url.searchParams.set("utm_medium", "website");
+  url.searchParams.set("utm_campaign", START_HERE_CAMPAIGN);
+  url.searchParams.set("utm_content", content);
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+export function currentAttribution() {
+  if (typeof window === "undefined") return {};
+  const params = new URLSearchParams(window.location.search);
+  return {
+    sourcePath: window.location.pathname,
+    sourceCampaign: params.get("utm_campaign") || undefined,
+    sourceContent: params.get("utm_content") || undefined,
+    sourceMedium: params.get("utm_medium") || undefined,
+  };
+}

--- a/client/src/pages/GetInvolved.tsx
+++ b/client/src/pages/GetInvolved.tsx
@@ -1,5 +1,6 @@
 import { useState, FormEvent } from "react";
 import { communitySubmit } from "@/lib/api";
+import { currentAttribution } from "@/lib/tracking";
 import { cn } from "@/lib/utils";
 import {
   Palette,
@@ -13,7 +14,7 @@ import {
   CheckCircle2,
 } from "lucide-react";
 
-type FormType = "residency" | "idea" | "business-interest" | "workshop-suggestion" | "story-feature";
+type FormType = "volunteer" | "residency" | "idea" | "business-interest" | "workshop-suggestion" | "story-feature";
 
 interface FormConfig {
   id: FormType;
@@ -33,6 +34,33 @@ interface FieldDef {
 }
 
 const FORMS: FormConfig[] = [
+  {
+    id: "volunteer",
+    label: "Lend a Hand",
+    icon: Hammer,
+    tagline: "Garden jobs, working days and practical help. Start with what you can do.",
+    fields: [
+      { name: "name", label: "Your name", type: "text", required: true },
+      { name: "email", label: "Email", type: "email", required: true },
+      { name: "phone", label: "Phone", type: "text" },
+      {
+        name: "helpType",
+        label: "Where could you help?",
+        type: "select",
+        required: true,
+        options: [
+          { value: "garden", label: "Garden and growing" },
+          { value: "making", label: "Building, repair or making" },
+          { value: "events", label: "Events and shared meals" },
+          { value: "shop", label: "Shop and local goods" },
+          { value: "stories", label: "Photos, stories or communications" },
+          { value: "anything-useful", label: "Whatever is useful" },
+        ],
+      },
+      { name: "availability", label: "When are you usually available?", type: "text", placeholder: "Weekends, weekdays, occasionally" },
+      { name: "message", label: "Anything we should know?", type: "textarea", placeholder: "Skills, tools, accessibility needs, or the kind of job you enjoy" },
+    ],
+  },
   {
     id: "residency",
     label: "Residencies",
@@ -163,7 +191,7 @@ export default function GetInvolved() {
     e.preventDefault();
     setStatus("loading");
     try {
-      const result = await communitySubmit({ type: activeForm, ...formData });
+      const result = await communitySubmit({ type: activeForm, ...formData, ...currentAttribution() });
       if (result.success) {
         setStatus("success");
       } else {

--- a/client/src/pages/HarvestReviewTest.tsx
+++ b/client/src/pages/HarvestReviewTest.tsx
@@ -227,6 +227,7 @@ const ideaGroups: IdeaGroup[] = [
 ];
 
 const pageNavLinks = [
+  { label: "Start Here", href: "/start" },
   { label: "About", href: "/what-is-the-harvest" },
   { label: "Works", href: "/works" },
   { label: "Shop", href: "/shop" },
@@ -235,6 +236,7 @@ const pageNavLinks = [
 ];
 
 const footerLinks = [
+  { label: "Start Here", href: "/start" },
   { label: "About", href: "/what-is-the-harvest" },
   { label: "Works", href: "/works" },
   { label: "Shop", href: "/shop" },

--- a/client/src/pages/Membership.tsx
+++ b/client/src/pages/Membership.tsx
@@ -18,6 +18,7 @@ import { HarvestPhotoPicker, type PickedPhoto } from "@/components/HarvestPhotoP
 import { useAuth } from "@/_core/hooks/useAuth";
 import { optimize } from "@/lib/imageOptimize";
 import { trpc } from "@/lib/trpc";
+import { currentAttribution } from "@/lib/tracking";
 import { harvestButtonClasses, SiteFooter, SiteNav } from "./HarvestReviewTest";
 
 const lanes = [
@@ -145,13 +146,14 @@ export default function Membership() {
     event.preventDefault();
     const { firstName, lastName } = splitName(name);
     const taggedInterests = Array.from(new Set<Interest>(["membership", ...interests]));
+    const attribution = currentAttribution();
 
     joinMutation.mutate({
       email: email.trim(),
       phone: phone.trim() || undefined,
       firstName,
       lastName,
-      source: "Harvest | Member Signup",
+      source: attribution.sourceContent ? `Harvest | Member Signup | ${attribution.sourceContent}` : "Harvest | Member Signup",
       interests: taggedInterests,
       member: true,
       notes: comments.trim() || undefined,
@@ -161,12 +163,13 @@ export default function Membership() {
 
   function handleQuestionSubmit(event: React.FormEvent) {
     event.preventDefault();
+    const attribution = currentAttribution();
     questionMutation.mutate({
       name: questionName.trim(),
       email: questionEmail.trim(),
       phone: questionPhone.trim() || null,
       question: question.trim(),
-      source: "Harvest | Member Question",
+      source: attribution.sourceContent ? `Harvest | Member Question | ${attribution.sourceContent}` : "Harvest | Member Question",
     });
   }
 

--- a/client/src/pages/StartHere.tsx
+++ b/client/src/pages/StartHere.tsx
@@ -1,0 +1,85 @@
+import { useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "wouter";
+import { ArrowRight, CalendarDays, HandHeart, Store, Users, Utensils, Warehouse } from "lucide-react";
+import { SiteFooter, SiteNav, harvestButtonClasses } from "./HarvestReviewTest";
+import { fetchHarvestPublicSocialPosts } from "@/lib/api";
+import { setPageSeo } from "@/lib/seo";
+import { trackedPath } from "@/lib/tracking";
+
+const paths = [
+  { title: "Visit this weekend", body: "See the current opening times, DIY pizza sessions and gatherings before you leave home.", href: trackedPath("/whats-on", "visit"), action: "See what is on", icon: Utensils, colour: "bg-[#C4922A]" },
+  { title: "Lend a hand", body: "Garden jobs, working days and practical help. Come for ten minutes or two hours.", href: trackedPath("/get-involved?form=volunteer", "volunteer"), action: "Offer some help", icon: HandHeart, colour: "bg-[#4A6741] text-white" },
+  { title: "Host something", body: "Bring a workshop, dinner, performance, meeting or small gathering into the place.", href: trackedPath("/venue-hire", "host"), action: "Talk about hosting", icon: Warehouse, colour: "bg-[#3B5563] text-white" },
+  { title: "Grow or make locally", body: "Put produce, food or useful local goods forward for the shared shelf and future shop.", href: trackedPath("/get-involved?form=business-interest", "supply"), action: "Put something forward", icon: Store, colour: "bg-[#8B4A2A] text-white" },
+  { title: "Become a member", body: "Membership is free. Get dates, work-day calls and invitations first.", href: trackedPath("/membership#join", "join"), action: "Join The Harvest", icon: Users, colour: "bg-[#B58B70]" },
+  { title: "Share a story", body: "Tell us about Witta, a craft, a memory or a person whose work should be carried forward.", href: trackedPath("/get-involved?form=story-feature", "story"), action: "Start a story", icon: CalendarDays, colour: "bg-[#3D3832] text-white" },
+] as const;
+
+export default function StartHere() {
+  const social = useQuery({
+    queryKey: ["harvest-public-social", 6],
+    queryFn: () => fetchHarvestPublicSocialPosts(6),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  useEffect(() => {
+    setPageSeo({
+      title: "Start here · The Harvest Witta",
+      description: "Visit, lend a hand, host something, supply local goods or become a member of The Harvest in Witta.",
+      path: "/start",
+    });
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-[#F5F0E8] text-[#1C1917]">
+      <SiteNav />
+      <section className="border-b border-stone-900/10 px-5 pb-16 pt-36 md:px-8 md:pb-24 md:pt-44">
+        <div className="mx-auto max-w-7xl">
+          <p className="font-mono text-xs uppercase tracking-[0.22em] text-[#8B4A2A]">Witta · Jinibara Country</p>
+          <h1 className="mt-5 max-w-4xl text-5xl font-black leading-[0.94] sm:text-6xl lg:text-8xl">Start where you are.</h1>
+          <p className="mt-7 max-w-2xl text-lg leading-relaxed text-stone-700 sm:text-xl">Visit for pizza. Pull weeds for an hour. Bring a workshop. Put something local on the shelf. There is more than one way into The Harvest.</p>
+        </div>
+      </section>
+
+      <section className="px-5 py-16 md:px-8 md:py-24">
+        <div className="mx-auto grid max-w-7xl gap-px overflow-hidden border border-stone-900/14 bg-stone-900/14 md:grid-cols-2 lg:grid-cols-3">
+          {paths.map(({ title, body, href, action, icon: Icon, colour }) => (
+            <Link key={title} href={href} className="group flex min-h-72 flex-col bg-[#F5F0E8] p-7 transition hover:bg-white md:p-9">
+              <div className={`flex h-12 w-12 items-center justify-center ${colour}`}><Icon className="h-5 w-5" /></div>
+              <h2 className="mt-8 text-2xl font-black">{title}</h2>
+              <p className="mt-3 leading-relaxed text-stone-600">{body}</p>
+              <span className="mt-auto inline-flex items-center gap-2 pt-8 text-sm font-bold text-[#8B4A2A]">{action}<ArrowRight className="h-4 w-4 transition group-hover:translate-x-1" /></span>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <section className="bg-[#1C1917] px-5 py-16 text-[#F5F0E8] md:px-8 md:py-24">
+        <div className="mx-auto max-w-7xl">
+          <div className="flex flex-col gap-5 border-b border-white/15 pb-8 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.22em] text-[#C4922A]">From the gate</p>
+              <h2 className="mt-3 text-3xl font-black sm:text-5xl">What has been happening</h2>
+            </div>
+            <a href="https://www.instagram.com/theharvestwitta/" target="_blank" rel="noreferrer" className={harvestButtonClasses.onDark}>See Instagram</a>
+          </div>
+          {social.isLoading && <p className="py-12 text-stone-400">Loading the latest notes...</p>}
+          {social.isError && <p className="py-12 text-stone-400">The latest notes are taking a moment. The rest of the page still works.</p>}
+          {social.data && (
+            <div className="grid gap-px bg-white/15 md:grid-cols-2 lg:grid-cols-3">
+              {social.data.map((post) => (
+                <article key={post.id} className="flex min-h-72 flex-col bg-[#1C1917] py-8 md:p-8">
+                  <div className="flex items-center justify-between gap-4 text-xs uppercase tracking-[0.16em] text-stone-500"><span>{post.platform}</span><time>{new Date(post.published_at).toLocaleDateString("en-AU", { day: "numeric", month: "short", year: "numeric" })}</time></div>
+                  <p className="mt-6 line-clamp-6 whitespace-pre-line leading-relaxed text-stone-200">{post.message || "A note from The Harvest."}</p>
+                  {post.permalink && <a href={post.permalink} target="_blank" rel="noreferrer" className="mt-auto inline-flex items-center gap-2 pt-8 text-sm font-bold text-[#C4922A]">Open the post<ArrowRight className="h-4 w-4" /></a>}
+                </article>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+      <SiteFooter />
+    </main>
+  );
+}

--- a/client/src/pages/VenueHire.tsx
+++ b/client/src/pages/VenueHire.tsx
@@ -15,6 +15,7 @@ import {
   Loader2,
 } from "lucide-react";
 import { communitySubmit } from "@/lib/api";
+import { currentAttribution } from "@/lib/tracking";
 
 const fadeInUp = {
   initial: { opacity: 0, y: 30 },
@@ -81,6 +82,7 @@ export default function VenueHire() {
       const result = await communitySubmit({
         type: "venue-enquiry",
         ...formData,
+        ...currentAttribution(),
       });
       if (result.success) {
         setStatus("success");

--- a/docs/operating-system/connected-platform.md
+++ b/docs/operating-system/connected-platform.md
@@ -1,0 +1,42 @@
+# Connected platform
+
+The Harvest Website is the public front door. ACT infrastructure is the private
+control room. They share the ACT Supabase project, so data is exposed through
+restricted views rather than copied between databases.
+
+Canonical architecture:
+
+```text
+../act-global-infrastructure/docs/architecture/harvest-connected-platform.md
+```
+
+## Daily flow
+
+```text
+Shape and approve in Harvest docs or Notion
+Publish through GHL
+ACT pulls the actual result into Supabase
+Command Center reviews performance and failures
+The public website reads published Harvest posts only
+```
+
+## Public entry point
+
+`/start` is the permanent front door for:
+
+- visiting
+- volunteering
+- hosting
+- supplying local goods
+- joining
+- sharing a story
+
+Links carry `utm_campaign=start-here` and a specific `utm_content` value. Form
+submissions preserve that attribution and apply matching GHL source tags.
+
+## Do not duplicate
+
+- Do not create a second social-post ledger in this repo.
+- Do not move ACT finance or entity facts into Harvest working docs.
+- Do not make Notion the machine ledger for published posts.
+- Do not expose social drafts, failures or private engagement metrics publicly.

--- a/scripts/build-sitemap.ts
+++ b/scripts/build-sitemap.ts
@@ -32,6 +32,7 @@ type Entry = {
 
 const STATIC_ROUTES: Entry[] = [
   { loc: "/", priority: "1.0", changefreq: "weekly" },
+  { loc: "/start", priority: "0.95", changefreq: "weekly" },
   { loc: "/membership", priority: "0.9", changefreq: "weekly" },
   { loc: "/shop", priority: "0.8", changefreq: "weekly" },
   { loc: "/what-is-the-harvest", priority: "0.8", changefreq: "monthly" },

--- a/supabase/functions/community-submit/index.ts
+++ b/supabase/functions/community-submit/index.ts
@@ -52,6 +52,7 @@ async function upsertHarvestInboxOpportunity(input: {
 // (community-idea, residency-applicant, business-interest, workshop-suggestion,
 // story-feature, venue-enquiry, residency-*/idea-*/biz-*) are dropped.
 const TYPE_TAGS: Record<string, string[]> = {
+  volunteer: ["role:volunteer", "interest:volunteer"],
   idea: ["interest:community"],
   residency: ["role:resident", "interest:community"],
   "business-interest": ["role:supplier", "interest:markets"],
@@ -94,6 +95,9 @@ Deno.serve(async (req) => {
     "harvest-website",
     "harvest-inbox",
   ];
+  if (fields.helpType) tags.push(`pod:${String(fields.helpType).replace(/[^a-z0-9]+/gi, "-").toLowerCase()}`);
+  if (fields.sourceCampaign) tags.push(`source:campaign:${String(fields.sourceCampaign).replace(/[^a-z0-9]+/gi, "-").toLowerCase()}`);
+  if (fields.sourceContent) tags.push(`source:content:${String(fields.sourceContent).replace(/[^a-z0-9]+/gi, "-").toLowerCase()}`);
 
   // Parse name
   const nameParts = String(name).trim().split(/\s+/).filter(Boolean);


### PR DESCRIPTION
## Outcome\nAdds a clear Start Here journey and connects public participation actions to the shared Harvest operating model.\n\n## Included\n- /start and /start-here routes\n- participation paths for visit, volunteer, host, supply, membership, and story\n- UTM/source-content attribution on community submissions\n- public social feed from the safe Supabase view\n- SEO helper and sitemap coverage\n- connected-platform operating note\n\n## Verified\n- TypeScript passed\n- production build passed\n- sitemap generated 23 URLs including /start\n- git diff check and staged secret scan passed\n\n## Deployment notes\nThe community-submit Edge Function update is already live. No production website deployment is performed by this PR.