### PR TITLE
GHL inbox model: one capture helper, no cards for reply-only forms, waiting-list script

### DIFF
--- a/docs/strategy/ghl-pipeline-playbook.md
+++ b/docs/strategy/ghl-pipeline-playbook.md
@@ -196,13 +196,49 @@ engagement crowd) either way; those are tags, not a money motion. That pipeline,
 
 ## How to get back to people (the follow-up engine)
 
-Tracking is only half of it. The other half is making sure nobody waits on us.
+Rewritten 2026-09-05 after a two-day audit of the live location. What was here before assumed
+the board would be worked by hand. It was not: 43 cards sat in New, eleven of them labelled
+"Reply needed" since a July audit, and the oldest person had waited 112 days.
 
-- Give every pipeline card an **owner** and a **next-action date** in GHL.
-- The **nurture workflow** (shop nurture, spec 6) is the safety net: it follows up a few days
-  later so a card does not go cold while it waits for a human.
-- A simple daily habit beats any automation: open the board, work the left-most stages first,
-  move or date every card you touch.
+**Why the inbox lies.** Every form sends an instant acknowledgment. GHL then treats the thread as
+answered: unread drops to zero, "last message" is outbound, and the person disappears from every
+obvious view while they wait. The one signal GHL keeps that survives this is whether the last
+outbound message was **automated** (a workflow) or **manual** (a person typed it).
+
+**The model, two tags and one question.**
+
+| Tag | Means | Rule |
+| --- | --- | --- |
+| `project:act-XX` | which project this person belongs to | exactly one per contact, applied at capture |
+| `act-inquiry` | a human is expected to reply | applied by every ask-type form, in every project |
+
+*Waiting on a human* = tagged with the project, tagged `act-inquiry`, and the thread's last
+message is either inbound or an automated outbound. The moment someone replies from GHL the thread
+flips to manual and leaves the list on its own. Nothing to drag.
+
+**Where the list lives.** `npm run waiting:ghl` (`scripts/report-ghl-waiting.ts`, read-only)
+prints it with what each person asked; `--project gd` for Goods, `--all` for every project,
+`--md` for Notion. It works from the repo's API key and does not depend on which Conversations
+UI the account has. The same filter can be saved as a Conversations view where the UI allows
+tag plus last-outbound-type filtering; build it there for the daily reply loop, but the script is
+the reference.
+
+**What cannot be automated, and what to do instead.** GHL has no trigger for a manually sent
+message, so a pipeline card cannot move itself when you reply. That is why the board went stale.
+Do not use the Harvest Inbox pipeline as the reply queue; use it only for things that need more
+than a reply (a venue booking, a shop listing). Stop creating cards for RSVPs, newsletter signups
+and member comments, which never need one.
+
+**Blind spot.** Threads that only exist in Gmail (someone writes to benjamin@ or nicholas@
+directly) never reach GHL, so a long wait on the list is worth a Gmail `in:sent` check before
+treating it as real. The "Gmail Email to Contact" workflow misses these.
+
+**Reply from GHL, not Gmail,** so the manual flag is set and the person drops off the list.
+
+**Legacy ask tags** the script still honours until every form applies `act-inquiry`: Harvest
+`contact-form`, `venue-enquiry`, `shop-follow-up`, `shop-prospect`, `member-question`; Goods
+`goods-inquiry`, `goods-general-inquiry`. JusticeHub's contact form applies no ask tag at all and
+needs one before its enquiries can appear anywhere.
 
 ## Build checklist
 

--- a/docs/strategy/ghl-workflow-build-specs.md
+++ b/docs/strategy/ghl-workflow-build-specs.md
@@ -336,6 +336,50 @@ Notes:
 
 ---
 
+## 8. Harvest - Pizza RSVP Receipt
+
+Added 2026-09-05. The website RSVP (`/whats-on`, `eoi.submit`) tags the contact
+`rsvp:pizza` and `event:witta-pizza:YYYY-MM-DD`, writes the session and head count
+as a note, and posts the RSVP into Conversations. Nobody has been sent a confirmation
+since July because "Harvest - RSVP Pizza Dinner (tag)" was never published.
+
+**Trigger.** Contact tag added: `rsvp:pizza`. That fires on its own when the site
+tags the contact, and needs no env var. (The code also calls the workflow by id if
+`GHL_PIZZA_RSVP_WORKFLOW_ID` is set; use one or the other, not both, or people get
+two emails.)
+
+**Reply-To.** Set it to an inbox a person reads. `hi@act.place` is send-only, so
+"reply to this email" must not go there. Until decision 5 (sending domain,
+hello@theharvestwitta.com.au owner) is made, point Reply-To at benjamin@act.place.
+
+**Do not state** opening hours or the kids-eat-free rule in this email. Both are open
+decisions (hub page, decisions 1 and 4); link to /whats-on, which is edited once.
+
+**Email**
+
+Subject: You're on the list for pizza at The Harvest
+Preview: Thanks for letting us know you're coming.
+
+Hi {{contact.first_name}},
+
+You're on the list for pizza night at The Harvest, 9 Gumland Drive, Witta.
+
+Times for the night, and anything that changes, are on the What's On page:
+https://theharvestwitta.com.au/whats-on
+
+If your plans change, reply to this email and we'll take you off the count. The
+dough is made to the numbers, so it helps.
+
+Afterwards, two minutes here tells us what to do differently next time:
+https://theharvestwitta.com.au/pulse
+
+See you at the oven.
+
+The Harvest
+
+**After publishing:** run `npm run verify:forms:ghl`, then submit one RSVP with a
+test address and confirm one email arrives, not two.
+
 ## One-time cleanup: Harvest - Member Reconfirm
 
 Not a form workflow. A one-time campaign to clean up the 15 contacts tagged `harvest-member`

--- a/docs/strategy/harvest-ghl-tag-and-automation-map.md
+++ b/docs/strategy/harvest-ghl-tag-and-automation-map.md
@@ -20,6 +20,30 @@ To build the workflows that do not exist in GHL yet, and to see the current env 
 - Do not remove legacy tags such as `act-hv`, `eoi-gathering-march-2026`, or `locals-day-march-2026`. They are historical context, not new trigger tags.
 - Use GHL tags and notes as the source of truth for membership, shop interest, questions, and follow-up.
 
+## The Inbox Axis (verified 2026-09-05)
+
+Two tags decide whether a person appears on the "waiting on a human" list. Everything else in
+this document is segmentation.
+
+| Tag | Means | Live count (2026-09-05) |
+| --- | --- | --- |
+| `project:act-hv` | belongs to The Harvest | 342 |
+| `act-inquiry` | a human is expected to reply | 17 on Harvest, 29 location-wide |
+
+Rules:
+- One `project:act-XX` per contact, applied at capture. The code form (`project:act-hv`) is
+  canonical across ACT. Hyphen forms are strays: `project-harvest` (2 contacts), `project-goods`
+  (14). `act-hv` exists in the tag library with zero contacts and should be deleted.
+- Every form whose submitter expects a reply applies `act-inquiry`. Today only the contact form
+  does. Shop EOI, venue enquiry and member question rely on their own tags
+  (`shop-follow-up`, `venue-enquiry`, `member-question`), which `scripts/report-ghl-waiting.ts`
+  honours as legacy until the handlers are updated.
+- `harvest-website`, `harvest-inbox`, `source:website` are source and state tags. None of them
+  means "asked something", and none of them is a project tag.
+
+The list itself: `npm run waiting:ghl`. See `ghl-pipeline-playbook.md`, "How to get back to
+people", for why the Conversations tab cannot show this on its own.
+
 ## Flow Tags
 
 > Reconciled to website code 2026-05-29. The code (`server/routers.ts` `buildNewsletterTags` + the Supabase edge functions `contact-form` / `community-submit`) is the source of truth for tags; this doc is kept in sync with it.
@@ -213,7 +237,7 @@ Note: the follow-vs-member split is live as of 2026-05-27. The footer "follow al
 - Shop follow-up: trigger on `interest:markets`, then branch by `shop-produce`, `shop-maker`, `shop-food`, or `shop-consignment`.
 - Current event RSVP: trigger on `witta-gathering-2026-06-20` or `harvest-event-attendee`.
 - Photo wall follow-up: trigger on `photo-wall` or `harvest-gathering-photos`; use `photo-wall-ready` to filter contacts with a response ready to display.
-- Contact form: trigger on `contact-form`; ACT notification routing uses `act-inquiry` + `project-harvest`.
+- Contact form: trigger on `contact-form`; ACT notification routing uses `act-inquiry` + `project:act-hv` (the doc previously said `project-harvest`, a stray hyphen tag on 2 contacts).
 - Inbox triage: filter on `harvest-inbox` --- set by event submission, business registration, workshop booking, member question, photo wall response, community submit, and gathering RSVP handler.
 - Community / GetInvolved triage: filter by type tag (`community-idea`, `residency-applicant`, `business-interest`, `workshop-suggestion`, `story-feature`, `venue-enquiry`).
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "audit:contacts:ghl": "tsx scripts/audit-ghl-contacts.ts",
     "report:member-audience:ghl": "tsx scripts/export-ghl-member-audience.ts",
     "desk:ghl": "tsx scripts/report-ghl-harvest-desk.ts",
+    "waiting:ghl": "tsx scripts/report-ghl-waiting.ts",
     "check:member-welcome:ghl": "tsx scripts/check-ghl-member-welcome.ts",
     "send:member-welcome:ghl": "tsx scripts/send-ghl-member-welcome-catchup.ts",
     "check:mighty-tags:ghl": "tsx scripts/ensure-ghl-mighty-tags.ts",

--- a/scripts/backfill-ghl-harvest-inbox.ts
+++ b/scripts/backfill-ghl-harvest-inbox.ts
@@ -3,8 +3,8 @@ import "dotenv/config";
 const GHL_API_BASE = "https://services.leadconnectorhq.com";
 const GHL_API_VERSION = "2021-07-28";
 const BRISBANE_UTC_OFFSET_HOURS = 10;
-const DEFAULT_HARVEST_INBOX_PIPELINE_ID = "ggQw10DuH0XRji6keimS";
-const DEFAULT_HARVEST_INBOX_NEW_STAGE_ID = "2eded979-7439-407d-89b6-762499b56658";
+const DEFAULT_HARVEST_INBOX_PIPELINE_ID = "5ZqAuFokM4LsNqMCMPmY";
+const DEFAULT_HARVEST_INBOX_NEW_STAGE_ID = "aafc9a01-1ad6-42c8-8c47-69a74cf1141d";
 
 type GhlContact = {
   id: string;

--- a/scripts/report-ghl-waiting.ts
+++ b/scripts/report-ghl-waiting.ts
@@ -112,6 +112,8 @@ type GhlConversation = {
   lastMessageDate?: number;
   lastMessageDirection?: "inbound" | "outbound";
   lastOutboundMessageAction?: "manual" | "automated";
+  /** Epoch ms of the last message a person typed. Absent if nobody ever has. */
+  lastManualMessageDate?: number;
   opportunities?: { id: string; pipelineId: string; pipelineStageId: string; status: string }[];
   sort?: number[];
 };
@@ -180,7 +182,9 @@ async function listConversations(query: Record<string, string>): Promise<GhlConv
   return all;
 }
 
-async function firstInboundMessage(conversationId: string): Promise<GhlMessage | undefined> {
+// The most recent thing they wrote, not the first: a person can be answered and
+// then ask again in the same thread, and the current question is the one waiting.
+async function latestInboundMessage(conversationId: string): Promise<GhlMessage | undefined> {
   const data = await ghl<{ messages?: { messages?: GhlMessage[] } | GhlMessage[] }>(
     `/conversations/${conversationId}/messages?limit=50`,
     CONVERSATIONS_API_VERSION,
@@ -188,7 +192,7 @@ async function firstInboundMessage(conversationId: string): Promise<GhlMessage |
   const messages = Array.isArray(data.messages) ? data.messages : (data.messages?.messages ?? []);
   return messages
     .filter((m) => m.direction === "inbound" && m.messageType !== "TYPE_ACTIVITY_OPPORTUNITY")
-    .sort((a, b) => Date.parse(a.dateAdded ?? "") - Date.parse(b.dateAdded ?? ""))[0];
+    .sort((a, b) => Date.parse(b.dateAdded ?? "") - Date.parse(a.dateAdded ?? ""))[0];
 }
 
 async function storedFormMessage(contactId: string): Promise<string> {
@@ -254,8 +258,12 @@ async function waitingFor(project: Project, inbound: GhlConversation[], robotAns
 
   const waiting: Waiting[] = [];
   for (const c of candidates) {
-    const inboundMessage = await firstInboundMessage(c.id);
+    const inboundMessage = await latestInboundMessage(c.id);
     const since = inboundMessage?.dateAdded ? new Date(inboundMessage.dateAdded) : new Date(c.dateAdded ?? Date.now());
+    // A person already answered since they last wrote: not waiting. act-inquiry
+    // stays on the contact, so without this a later automated email (newsletter,
+    // nurture) would put an answered enquiry straight back on the list.
+    if (c.lastManualMessageDate && c.lastManualMessageDate >= since.getTime()) continue;
     const card = project.inboxPipelineId
       ? (c.opportunities ?? []).find((o) => o.pipelineId === project.inboxPipelineId && o.status === "open")
       : undefined;

--- a/scripts/report-ghl-waiting.ts
+++ b/scripts/report-ghl-waiting.ts
@@ -1,0 +1,331 @@
+import "dotenv/config";
+
+/**
+ * Who is waiting on a human reply, per ACT project.
+ *
+ * The GHL Conversations tab cannot answer this on its own, because the
+ * auto-acknowledgment replies to everyone within seconds and every thread then
+ * reads as "answered". GHL does record whether the last outbound message was
+ * sent by a workflow or typed by a person, and that is the signal this uses:
+ *
+ *   waiting = last message is inbound
+ *          OR last message is outbound and was automated
+ *
+ * scoped to one project's contacts who actually asked something, not
+ * newsletter or member signups who only ever received a welcome email.
+ *
+ * Two tags carry the whole model:
+ *   project:act-XX   which project this person belongs to (one per contact)
+ *   act-inquiry      a human is expected to reply
+ * Until every form applies act-inquiry at capture, each project below lists
+ * the legacy tags its forms use instead.
+ *
+ * Blind spot: threads that only exist in Gmail (someone emails benjamin@ or
+ * nicholas@ directly) never reach GHL, so a long wait here is worth a
+ * `in:sent` check in Gmail before treating it as real.
+ *
+ * Read-only. No writes to GHL.
+ *
+ *   npm run waiting:ghl                    Harvest, plain table
+ *   npm run waiting:ghl -- --project gd    Goods
+ *   npm run waiting:ghl -- --all           every project
+ *   npm run waiting:ghl -- --md            markdown, for pasting into Notion
+ */
+
+const GHL_API_BASE = "https://services.leadconnectorhq.com";
+const CONVERSATIONS_API_VERSION = "2021-04-15";
+const CONTACTS_API_VERSION = "2021-07-28";
+const BRISBANE_UTC_OFFSET_HOURS = 10;
+
+// The universal "a human is expected to reply" tag. Every project's ask-type
+// forms should apply it at capture. The per-project lists are the legacy tags
+// those forms apply today; they can be deleted once the forms are fixed.
+const ASKED_TAG = "act-inquiry";
+
+type Project = {
+  code: string;
+  name: string;
+  projectTag: string;
+  legacyAskedTags: string[];
+  /** Pipeline used as a manual worklist, if the project has one. */
+  inboxPipelineId?: string;
+  inboxStages?: Record<string, string>;
+};
+
+const PROJECTS: Record<string, Project> = {
+  hv: {
+    code: "hv",
+    name: "The Harvest",
+    projectTag: "project:act-hv",
+    legacyAskedTags: ["contact-form", "venue-enquiry", "shop-follow-up", "shop-prospect", "member-question"],
+    inboxPipelineId: process.env.GHL_HARVEST_INBOX_PIPELINE_ID ?? "5ZqAuFokM4LsNqMCMPmY",
+    inboxStages: {
+      "aafc9a01-1ad6-42c8-8c47-69a74cf1141d": "New",
+      "b72b1b9d-0e1a-495d-9b81-e1df4c9cdd09": "In progress",
+      "b09e201d-bd10-4e84-b501-ca6a25fb1a94": "Waiting on them",
+      "c343a664-7e10-4f96-b62d-8eda57748036": "Resolved",
+    },
+  },
+  gd: {
+    code: "gd",
+    name: "Goods on Country",
+    projectTag: "project:act-gd",
+    legacyAskedTags: ["goods-inquiry", "goods-general-inquiry"],
+  },
+  jh: {
+    code: "jh",
+    name: "JusticeHub",
+    projectTag: "project:act-jh",
+    // The JusticeHub contact form applies no ask tag today. Until it does,
+    // nothing from that form can appear here.
+    legacyAskedTags: ["goods-inquiry"],
+  },
+  el: {
+    code: "el",
+    name: "Empathy Ledger",
+    projectTag: "project:act-el",
+    legacyAskedTags: [],
+  },
+  contained: {
+    code: "contained",
+    name: "CONTAINED",
+    projectTag: "project:contained",
+    legacyAskedTags: ["goods-inquiry"],
+  },
+};
+
+// Staff and test records. Never a reply owed.
+const IGNORED_EMAIL_PATTERNS = [/@act\.placee?$/i, /^knighttss@gmail\.com$/i, /@benjamink\.com\.au$/i, /^jane@gmail\.com$/i];
+
+// The Harvest contact-form handler stores the submitted message here. Threads
+// created before 2026-07-06 have no inbound message, so this is the only copy.
+const MESSAGE_CUSTOM_FIELD_ID = "ceJz9FUf8dE4fmvnPDKd";
+
+type GhlConversation = {
+  id: string;
+  contactId: string;
+  contactName?: string | null;
+  fullName?: string | null;
+  email?: string | null;
+  tags?: string[];
+  dateAdded?: number;
+  lastMessageDate?: number;
+  lastMessageDirection?: "inbound" | "outbound";
+  lastOutboundMessageAction?: "manual" | "automated";
+  opportunities?: { id: string; pipelineId: string; pipelineStageId: string; status: string }[];
+  sort?: number[];
+};
+
+type GhlMessage = {
+  direction?: "inbound" | "outbound";
+  body?: string | null;
+  dateAdded?: string;
+  messageType?: string;
+};
+
+type Waiting = {
+  name: string;
+  email: string;
+  askedTags: string[];
+  waitingSince: Date;
+  days: number;
+  message: string;
+  card: string;
+  conversationId: string;
+};
+
+const apiKey = process.env.GHL_API_KEY;
+const locationId = process.env.GHL_LOCATION_ID;
+if (!apiKey || !locationId) {
+  console.error("GHL_API_KEY and GHL_LOCATION_ID are required.");
+  process.exit(1);
+}
+
+async function ghl<T>(path: string, version: string): Promise<T> {
+  const response = await fetch(`${GHL_API_BASE}${path}`, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      Version: version,
+      Accept: "application/json",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`GHL ${response.status} on ${path}: ${(await response.text()).slice(0, 200)}`);
+  }
+  return (await response.json()) as T;
+}
+
+async function listConversations(query: Record<string, string>): Promise<GhlConversation[]> {
+  const all: GhlConversation[] = [];
+  let startAfterDate: number | undefined;
+  for (;;) {
+    const params = new URLSearchParams({
+      locationId: locationId!,
+      limit: "100",
+      sortBy: "last_message_date",
+      sort: "desc",
+      ...query,
+    });
+    if (startAfterDate) params.set("startAfterDate", String(startAfterDate));
+    const page = await ghl<{ conversations?: GhlConversation[] }>(
+      `/conversations/search?${params.toString()}`,
+      CONVERSATIONS_API_VERSION,
+    );
+    const rows = page.conversations ?? [];
+    all.push(...rows);
+    const last = rows.at(-1);
+    if (rows.length < 100 || !last?.sort?.[0]) break;
+    startAfterDate = last.sort[0];
+  }
+  return all;
+}
+
+async function firstInboundMessage(conversationId: string): Promise<GhlMessage | undefined> {
+  const data = await ghl<{ messages?: { messages?: GhlMessage[] } | GhlMessage[] }>(
+    `/conversations/${conversationId}/messages?limit=50`,
+    CONVERSATIONS_API_VERSION,
+  );
+  const messages = Array.isArray(data.messages) ? data.messages : (data.messages?.messages ?? []);
+  return messages
+    .filter((m) => m.direction === "inbound" && m.messageType !== "TYPE_ACTIVITY_OPPORTUNITY")
+    .sort((a, b) => Date.parse(a.dateAdded ?? "") - Date.parse(b.dateAdded ?? ""))[0];
+}
+
+async function storedFormMessage(contactId: string): Promise<string> {
+  const data = await ghl<{ contact?: { customFields?: { id: string; value?: string | null }[] } }>(
+    `/contacts/${contactId}`,
+    CONTACTS_API_VERSION,
+  );
+  return data.contact?.customFields?.find((f) => f.id === MESSAGE_CUSTOM_FIELD_ID)?.value?.trim() ?? "";
+}
+
+// Shop, venue and member-question forms write what the person said as a note.
+async function latestNote(contactId: string): Promise<string> {
+  const data = await ghl<{ notes?: { body?: string | null; dateAdded?: string }[] }>(
+    `/contacts/${contactId}/notes`,
+    CONTACTS_API_VERSION,
+  );
+  return (
+    (data.notes ?? [])
+      .sort((a, b) => Date.parse(b.dateAdded ?? "") - Date.parse(a.dateAdded ?? ""))[0]
+      ?.body?.trim() ?? ""
+  );
+}
+
+// Last resort: the card title carries the topic ("Reply needed - Serge - shop makers").
+async function cardTitle(opportunityId: string): Promise<string> {
+  const data = await ghl<{ opportunity?: { name?: string | null } }>(`/opportunities/${opportunityId}`, CONTACTS_API_VERSION);
+  return data.opportunity?.name?.trim() ?? "";
+}
+
+async function whatTheyAsked(c: GhlConversation, inboundBody: string, cardId?: string): Promise<string> {
+  if (inboundBody) return inboundBody;
+  const stored = await storedFormMessage(c.contactId);
+  if (stored) return stored;
+  const note = await latestNote(c.contactId);
+  if (note) return note;
+  if (cardId) {
+    const title = await cardTitle(cardId);
+    if (title) return `Card: ${title}`;
+  }
+  return "(registered interest, nothing written)";
+}
+
+function isIgnored(email: string): boolean {
+  return IGNORED_EMAIL_PATTERNS.some((pattern) => pattern.test(email));
+}
+
+function brisbaneDate(date: Date): string {
+  return new Date(date.getTime() + BRISBANE_UTC_OFFSET_HOURS * 3600_000).toISOString().slice(0, 10);
+}
+
+function preview(text: string, max = 140): string {
+  const flat = text.replace(/^Subject:\s*/i, "").replace(/\*\*/g, "").replace(/\s+/g, " ").trim();
+  return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat;
+}
+
+async function waitingFor(project: Project, inbound: GhlConversation[], robotAnswered: GhlConversation[]): Promise<Waiting[]> {
+  const asked = new Set([ASKED_TAG, ...project.legacyAskedTags]);
+  const candidates = [...inbound, ...robotAnswered].filter((c) => {
+    const tags = c.tags ?? [];
+    const email = c.email ?? "";
+    return tags.includes(project.projectTag) && tags.some((t) => asked.has(t)) && email && !isIgnored(email);
+  });
+
+  const waiting: Waiting[] = [];
+  for (const c of candidates) {
+    const inboundMessage = await firstInboundMessage(c.id);
+    const since = inboundMessage?.dateAdded ? new Date(inboundMessage.dateAdded) : new Date(c.dateAdded ?? Date.now());
+    const card = project.inboxPipelineId
+      ? (c.opportunities ?? []).find((o) => o.pipelineId === project.inboxPipelineId && o.status === "open")
+      : undefined;
+    const message = await whatTheyAsked(c, inboundMessage?.body?.trim() ?? "", card?.id);
+    waiting.push({
+      name: (c.contactName ?? c.fullName ?? c.email ?? "").trim(),
+      email: c.email ?? "",
+      askedTags: (c.tags ?? []).filter((t) => asked.has(t)),
+      waitingSince: since,
+      days: Math.floor((Date.now() - since.getTime()) / 86_400_000),
+      message,
+      card: project.inboxPipelineId
+        ? card
+          ? (project.inboxStages?.[card.pipelineStageId] ?? "other stage")
+          : "no card"
+        : "n/a",
+      conversationId: c.id,
+    });
+  }
+  return waiting.sort((a, b) => b.days - a.days);
+}
+
+function print(project: Project, waiting: Waiting[], markdown: boolean, today: string) {
+  if (markdown) {
+    console.log(`## ${project.name}: waiting on a human reply, ${today}\n`);
+    console.log(`${waiting.length} people. Unanswered or robot-answered, tagged \`${project.projectTag}\`, asked something.\n`);
+    console.log("| Days | Who | Asked | Board | What they said |");
+    console.log("|---:|---|---|---|---|");
+    for (const w of waiting) {
+      console.log(`| ${w.days} | ${w.name} <${w.email}> | ${w.askedTags.join(", ")} | ${w.card} | ${preview(w.message, 110)} |`);
+    }
+    console.log();
+    return;
+  }
+  console.log(`${project.name} (${project.projectTag}), waiting on a human reply, ${today}: ${waiting.length}\n`);
+  for (const w of waiting) {
+    console.log(`${String(w.days).padStart(3)}d  ${w.name.padEnd(24)} ${w.email.padEnd(32)} card: ${w.card}`);
+    console.log(`      ${preview(w.message)}`);
+  }
+  console.log();
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const markdown = args.includes("--md");
+  const all = args.includes("--all");
+  const projectArg = args[args.indexOf("--project") + 1];
+  const codes = all ? Object.keys(PROJECTS) : [args.includes("--project") ? projectArg : "hv"];
+  const unknown = codes.filter((c) => !PROJECTS[c]);
+  if (unknown.length) {
+    console.error(`Unknown project ${unknown.join(", ")}. Known: ${Object.keys(PROJECTS).join(", ")}`);
+    process.exit(1);
+  }
+
+  // One pull of the location's threads serves every project.
+  const [inbound, robotAnswered] = await Promise.all([
+    listConversations({ lastMessageDirection: "inbound" }),
+    listConversations({ lastMessageDirection: "outbound", lastMessageAction: "automated" }),
+  ]);
+  const today = brisbaneDate(new Date());
+  if (!markdown) {
+    console.log(`Location-wide: ${inbound.length} threads unanswered, ${robotAnswered.length} robot-answered.\n`);
+  }
+  for (const code of codes) {
+    const project = PROJECTS[code];
+    print(project, await waitingFor(project, inbound, robotAnswered), markdown, today);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/server/__tests__/newsletter.test.ts
+++ b/server/__tests__/newsletter.test.ts
@@ -3,6 +3,15 @@ import { createGHLContact, upsertGHLContact } from "../gohighlevel";
 import { appRouter, buildNewsletterTags } from "../routers";
 import type { TrpcContext } from "../_core/context";
 
+// Pizza RSVP validation rejects past dates, so these tests must use a date
+// ahead of today rather than a fixed one. Weekday is computed in UTC, the same
+// way routers.ts reads an ISO date.
+function isoDateOfNextWeekday(weekday: number): string {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() + ((weekday - date.getUTCDay() + 7) % 7 || 7) + 7);
+  return date.toISOString().slice(0, 10);
+}
+
 vi.mock("../db", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../db")>();
   return {
@@ -282,19 +291,11 @@ describe("Go High Level Newsletter Integration", () => {
       );
       expect(JSON.parse(noteCall![1].body).body).toContain("I can help with planting days.");
 
+      // A signup comment is read, not replied to: note only, no inbox card.
       const opportunityCall = mockFetch.mock.calls.find(([url]) =>
         String(url).endsWith("/opportunities/upsert")
       );
-      expect(opportunityCall).toBeDefined();
-      const opportunityBody = JSON.parse(opportunityCall![1].body);
-      expect(opportunityBody).toMatchObject({
-        contactId: "contact-123",
-        name: "Mira Stone - Member comment",
-        source: "Harvest | Member Signup",
-        pipelineId: "ggQw10DuH0XRji6keimS",
-        pipelineStageId: "2eded979-7439-407d-89b6-762499b56658",
-        status: "open",
-      });
+      expect(opportunityCall).toBeUndefined();
     });
 
     it("does not sync pulse survey submissions to GHL without a name", async () => {
@@ -418,11 +419,12 @@ describe("Go High Level Newsletter Integration", () => {
 
     it("tags a pizza RSVP with its occurrence date and no historical launch tag", async () => {
       const caller = appRouter.createCaller(ctx);
+      const nextSaturday = isoDateOfNextWeekday(6);
 
       await caller.eoi.submit({
         name: "Phone Guest",
         phone: "0400000000",
-        occurrenceDate: "2026-07-25",
+        occurrenceDate: nextSaturday,
         session: "saturday",
         source: "What's On page",
       });
@@ -440,7 +442,7 @@ describe("Go High Level Newsletter Integration", () => {
       );
       expect(JSON.parse(tagCall![1].body).tags).toEqual(expect.arrayContaining([
         "event:witta-pizza",
-        "event:witta-pizza:2026-07-25",
+        `event:witta-pizza:${nextSaturday}`,
         "rsvp:pizza",
         "harvest-event-attendee",
         "harvest-website",
@@ -448,15 +450,11 @@ describe("Go High Level Newsletter Integration", () => {
       ]));
       expect(JSON.parse(tagCall![1].body).tags).not.toContain("witta-gathering-2026-06-20");
 
+      // An RSVP needs a confirmation, not a human reply: no inbox card.
       const opportunityCall = mockFetch.mock.calls.find(([url]) =>
         String(url).endsWith("/opportunities/upsert")
       );
-      expect(opportunityCall).toBeDefined();
-      expect(JSON.parse(opportunityCall![1].body)).toMatchObject({
-        contactId: "contact-123",
-        name: "Phone Guest - RSVP Witta Pizza 2026-07-25",
-        source: "Harvest | RSVP Witta Pizza 2026-07-25",
-      });
+      expect(opportunityCall).toBeUndefined();
     });
 
     it("rejects pizza RSVPs for invalid weekdays or mismatched sessions", async () => {
@@ -465,14 +463,14 @@ describe("Go High Level Newsletter Integration", () => {
       await expect(caller.eoi.submit({
         name: "Wrong Weekday",
         phone: "0400000000",
-        occurrenceDate: "2026-07-27",
+        occurrenceDate: isoDateOfNextWeekday(1),
         session: "unsure",
       })).rejects.toThrow("Choose a Friday, Saturday or Sunday pizza date.");
 
       await expect(caller.eoi.submit({
         name: "Wrong Session",
         phone: "0400000000",
-        occurrenceDate: "2026-07-25",
+        occurrenceDate: isoDateOfNextWeekday(6),
         session: "friday",
       })).rejects.toThrow("The session does not match the date you selected.");
     });
@@ -528,15 +526,11 @@ describe("Go High Level Newsletter Integration", () => {
         "harvest-inbox",
       ]));
 
+      // A photo-wall answer is read, not replied to: no inbox card.
       const opportunityCall = mockFetch.mock.calls.find(([url]) =>
         String(url).endsWith("/opportunities/upsert")
       );
-      expect(opportunityCall).toBeDefined();
-      expect(JSON.parse(opportunityCall![1].body)).toMatchObject({
-        contactId: "contact-123",
-        name: "Mira - Photo wall response",
-        source: "Harvest | Photo Wall",
-      });
+      expect(opportunityCall).toBeUndefined();
     });
 
     it("slugifies pulse interest tags before syncing to GHL", async () => {

--- a/server/gohighlevel.ts
+++ b/server/gohighlevel.ts
@@ -46,8 +46,8 @@ interface GHLOpportunityInput {
   monetaryValue?: number;
 }
 
-const DEFAULT_HARVEST_INBOX_PIPELINE_ID = "ggQw10DuH0XRji6keimS";
-const DEFAULT_HARVEST_INBOX_NEW_STAGE_ID = "2eded979-7439-407d-89b6-762499b56658";
+const DEFAULT_HARVEST_INBOX_PIPELINE_ID = "5ZqAuFokM4LsNqMCMPmY";
+const DEFAULT_HARVEST_INBOX_NEW_STAGE_ID = "aafc9a01-1ad6-42c8-8c47-69a74cf1141d";
 
 /**
  * Create a contact in Go High Level

--- a/server/harvestCapture.ts
+++ b/server/harvestCapture.ts
@@ -1,0 +1,129 @@
+import {
+  upsertGHLContact,
+  addGHLContactNote,
+  addGHLInboundFormMessage,
+  upsertGHLHarvestInboxOpportunity,
+  triggerGHLWorkflow,
+} from "./gohighlevel.js";
+
+/**
+ * One way in for every Harvest form.
+ *
+ * Every public form used to hand-roll the same five steps (upsert the contact,
+ * tag it, keep a note, post the message into GHL Conversations, fire a receipt
+ * workflow), and that is how three forms ended up with no receipt and one with
+ * no ask tag. This is the chokepoint instead. A new form is one call.
+ *
+ * What a caller decides:
+ *   needsReply   true when a person is expected to write back. Adds `act-inquiry`,
+ *                which is what puts someone on the waiting list
+ *                (scripts/report-ghl-waiting.ts, and the 7am check-in).
+ *   card         only when the thing needs more than a reply: a booking, a listing,
+ *                a business registration. Cards cannot move themselves when you
+ *                reply (GHL has no trigger for that), so reply-only forms must
+ *                not create them.
+ *   receiptWorkflowEnv   the env var holding the GHL receipt workflow id. Unset
+ *                means the submitter hears nothing, which is logged so it is
+ *                never silent by accident.
+ *
+ * What is always done: `project:act-hv` (stamped inside upsertGHLContact) and
+ * `harvest-website`. See docs/strategy/ghl-pipeline-playbook.md, "How to get
+ * back to people".
+ */
+export interface HarvestSubmission {
+  /** Short form id for logs, e.g. "rsvp", "contact", "shop-interest". */
+  form: string;
+  name: string;
+  email?: string | null;
+  phone?: string | null;
+  /** GHL contact source, e.g. "Harvest | RSVP Witta Pizza 2026-09-05". */
+  source: string;
+  /** Form-specific tags. `harvest-website` and `project:act-hv` are added for you. */
+  tags: string[];
+  /** A person is expected to reply. Adds `act-inquiry`. */
+  needsReply: boolean;
+  /** Markdown note kept on the contact record. */
+  note?: string;
+  /** Lands in GHL Conversations so the thread exists and the reply goes from GHL. */
+  message?: { subject: string; html: string };
+  /** Only for things that need more than a reply. Falls back to the Harvest Inbox pipeline. */
+  card?: { title: string; pipelineId?: string; pipelineStageId?: string };
+  /** Name of the env var holding the receipt workflow id, e.g. "GHL_PIZZA_RSVP_WORKFLOW_ID". */
+  receiptWorkflowEnv?: string;
+}
+
+export interface HarvestCaptureResult {
+  success: boolean;
+  contactId?: string;
+  error?: string;
+}
+
+export function splitPersonName(name: string) {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  return {
+    firstName: parts[0],
+    lastName: parts.slice(1).join(" ") || undefined,
+  };
+}
+
+export async function captureHarvestSubmission(submission: HarvestSubmission): Promise<HarvestCaptureResult> {
+  const { firstName, lastName } = splitPersonName(submission.name);
+  const tags = Array.from(
+    new Set(["harvest-website", ...submission.tags, ...(submission.needsReply ? ["act-inquiry"] : [])]),
+  );
+
+  const contact = await upsertGHLContact({
+    email: submission.email || undefined,
+    firstName,
+    lastName,
+    phone: submission.phone || undefined,
+    source: submission.source,
+    tags,
+  });
+  if (!contact.success || !contact.contactId) {
+    return { success: false, error: contact.error };
+  }
+  const contactId = contact.contactId;
+
+  // Everything below is best-effort: the contact exists and is tagged, which is
+  // what the waiting list and the receipt depend on. Each step is awaited, not
+  // fire-and-forget, because Vercel ends the function when the handler returns.
+  if (submission.note) {
+    const note = await addGHLContactNote(contactId, submission.note);
+    if (!note.success) console.error(`GHL note failed (${submission.form}):`, note.error);
+  }
+
+  if (submission.message) {
+    await addGHLInboundFormMessage({
+      contactId,
+      fromEmail: submission.email || undefined,
+      subject: submission.message.subject,
+      html: submission.message.html,
+    }).catch((err) => console.error(`GHL inbox message failed (${submission.form}):`, err));
+  }
+
+  if (submission.card) {
+    const card = await upsertGHLHarvestInboxOpportunity({
+      contactId,
+      name: `${submission.name.trim()} - ${submission.card.title}`,
+      source: submission.source,
+      ...(submission.card.pipelineId && submission.card.pipelineStageId
+        ? { pipelineId: submission.card.pipelineId, pipelineStageId: submission.card.pipelineStageId }
+        : {}),
+    });
+    if (!card.success) console.error(`GHL card failed (${submission.form}):`, card.error);
+  }
+
+  if (submission.receiptWorkflowEnv) {
+    const workflowId = process.env[submission.receiptWorkflowEnv];
+    if (workflowId) {
+      await triggerGHLWorkflow(workflowId, contactId).catch((err) =>
+        console.error(`GHL receipt workflow failed (${submission.form}):`, err),
+      );
+    } else {
+      console.warn(`No receipt for ${submission.form}: ${submission.receiptWorkflowEnv} is not set.`);
+    }
+  }
+
+  return { success: true, contactId };
+}

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -714,11 +714,8 @@ export const appRouter = router({
             ].join(""),
           }).catch(err => console.error("GHL inbox message failed (rsvp):", err));
 
-          await upsertGHLHarvestInboxOpportunity({
-            contactId: result.contactId,
-            name: formatHarvestInboxOpportunityName(input.name, `RSVP ${eventLabel}`),
-            source: `Harvest | RSVP ${eventLabel}`,
-          });
+          // No inbox card: an RSVP needs a confirmation, not a human reply.
+          // See docs/strategy/ghl-pipeline-playbook.md, "How to get back to people".
 
           // Receipt workflow: set GHL_PIZZA_RSVP_WORKFLOW_ID once the
           // "Harvest - RSVP Pizza Dinner (tag)" workflow is published in the
@@ -927,14 +924,8 @@ export const appRouter = router({
               result.contactId,
               `**Harvest member note**\n\n${input.notes}`,
             );
-            await upsertGHLHarvestInboxOpportunity({
-              contactId: result.contactId,
-              name: formatHarvestInboxOpportunityName(
-                [input.firstName, input.lastName].filter(Boolean).join(" "),
-                "Member comment",
-              ),
-              source: input.source || "Harvest | Member Signup",
-            });
+            // No inbox card: a signup comment is read, not replied to. The note
+            // keeps it on the contact. See ghl-pipeline-playbook.md.
           }
           const workflowId = isMember
             ? process.env.GHL_MEMBER_WELCOME_WORKFLOW_ID || process.env.GHL_NEWSLETTER_WORKFLOW_ID
@@ -1050,7 +1041,7 @@ export const appRouter = router({
           lastName: rest.join(" ") || undefined,
           phone: input.phone || undefined,
           source: input.source || "Harvest | Member Question",
-          tags: ["harvest-website", "tier:curious", "member-question", "harvest-inbox"],
+          tags: ["harvest-website", "tier:curious", "member-question", "harvest-inbox", "act-inquiry"],
         });
 
         if (!result.success) {
@@ -1119,6 +1110,7 @@ export const appRouter = router({
           tags: [
             "harvest-website",
             "shop-follow-up",
+            "act-inquiry",
             "shop-stage-1",
             "role:supplier",
             "interest:markets",
@@ -1217,11 +1209,7 @@ export const appRouter = router({
             result.contactId,
             `**Photo Wall — What would you love to see grow here?**\n\n${input.response}`
           ).catch(err => console.error("Photo wall note failed:", err));
-          upsertGHLHarvestInboxOpportunity({
-            contactId: result.contactId,
-            name: formatHarvestInboxOpportunityName(input.firstName, "Photo wall response"),
-            source: "Harvest | Photo Wall",
-          }).catch(err => console.error("GHL opportunity upsert failed (photo wall):", err));
+          // No inbox card: a photo-wall answer is read, not replied to.
         }
 
         // Trigger notification workflow if configured

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -5,6 +5,7 @@ import { storagePut } from "./storage.js";
 import { getDb } from "./db.js";
 import { pulseResponses } from "../drizzle/schema.js";
 import { eq } from "drizzle-orm";
+import { captureHarvestSubmission } from "./harvestCapture.js";
 import { upsertGHLContact, upsertGHLHarvestInboxOpportunity, addGHLContactNote, addGHLContactTag, addGHLInboundFormMessage, getGHLContact, triggerGHLWorkflow, getGHLContactCountByTag, getGHLSocialAccounts, createGHLSocialPost, getGHLSocialPosts, searchGHLContactsByTag, createGHLEmailTemplate } from "./gohighlevel.js";
 import { getGalleryPhotos, addGalleryPhoto, removeGalleryPhoto } from "./photoWallGallery.js";
 import { empathyLedgerClient } from "./empathyLedgerClient.js";
@@ -677,34 +678,23 @@ export const appRouter = router({
           },
         });
 
-        const { firstName, lastName } = splitPersonName(input.name);
-        const result = await upsertGHLContact({
-          email: input.email || undefined,
-          firstName,
-          lastName,
-          phone: input.phone || undefined,
+        const result = await captureHarvestSubmission({
+          form: "rsvp",
+          name: input.name,
+          email: input.email,
+          phone: input.phone,
           source: `Harvest | RSVP ${eventLabel}`,
-          tags: [
-            "event:witta-pizza",
-            occurrenceTag,
-            "rsvp:pizza",
-            "harvest-event-attendee",
-            "harvest-website",
-            "harvest-inbox",
-          ],
-        });
-
-        if (result.contactId) {
-          const noteLines = [`**RSVP - ${eventLabel}**`];
-          noteLines.push(`**Session:** ${sessionLabel}`);
-          if (input.people) noteLines.push(`**People:** ${input.people}`);
-          if (input.message) noteLines.push(`**Message:** ${input.message}`);
-          noteLines.push(`**Source:** ${input.source || "whats-on"}`);
-          await addGHLContactNote(result.contactId, noteLines.join("\n\n"));
-
-          await addGHLInboundFormMessage({
-            contactId: result.contactId,
-            fromEmail: input.email || undefined,
+          tags: ["event:witta-pizza", occurrenceTag, "rsvp:pizza", "harvest-event-attendee", "harvest-inbox"],
+          // An RSVP needs a confirmation, not a human reply, so no act-inquiry and no card.
+          needsReply: false,
+          note: [
+            `**RSVP - ${eventLabel}**`,
+            `**Session:** ${sessionLabel}`,
+            input.people ? `**People:** ${input.people}` : "",
+            input.message ? `**Message:** ${input.message}` : "",
+            `**Source:** ${input.source || "whats-on"}`,
+          ].filter(Boolean).join("\n\n"),
+          message: {
             subject: `RSVP: ${input.name.trim()} for ${eventLabel} (${sessionLabel})`,
             html: [
               `<p><strong>RSVP for ${eventLabel} (website)</strong></p>`,
@@ -712,21 +702,11 @@ export const appRouter = router({
               input.people ? `<p>People: ${input.people}</p>` : "",
               input.message ? `<p>${escapeHtml(input.message)}</p>` : "",
             ].join(""),
-          }).catch(err => console.error("GHL inbox message failed (rsvp):", err));
-
-          // No inbox card: an RSVP needs a confirmation, not a human reply.
-          // See docs/strategy/ghl-pipeline-playbook.md, "How to get back to people".
-
-          // Receipt workflow: set GHL_PIZZA_RSVP_WORKFLOW_ID once the
-          // "Harvest - RSVP Pizza Dinner (tag)" workflow is published in the
-          // GHL UI (it is DRAFT as of 2026-07-06). Skipped silently until then.
-          const workflowId = process.env.GHL_PIZZA_RSVP_WORKFLOW_ID;
-          if (workflowId) {
-            triggerGHLWorkflow(workflowId, result.contactId).catch(err =>
-              console.error("GHL workflow trigger failed (pizza rsvp):", err)
-            );
-          }
-        }
+          },
+          // "Harvest - RSVP Pizza Dinner" in GHL. Spec 8 in ghl-workflow-build-specs.md.
+          // Logged as missing until the workflow is published and the id is set.
+          receiptWorkflowEnv: "GHL_PIZZA_RSVP_WORKFLOW_ID",
+        });
 
         if (!submission && !result.contactId) {
           throw new Error(

--- a/supabase/functions/community-submit/index.ts
+++ b/supabase/functions/community-submit/index.ts
@@ -1,7 +1,7 @@
 const GHL_API_BASE = "https://services.leadconnectorhq.com";
 const GHL_API_VERSION = "2021-07-28";
-const DEFAULT_HARVEST_INBOX_PIPELINE_ID = "ggQw10DuH0XRji6keimS";
-const DEFAULT_HARVEST_INBOX_NEW_STAGE_ID = "2eded979-7439-407d-89b6-762499b56658";
+const DEFAULT_HARVEST_INBOX_PIPELINE_ID = "5ZqAuFokM4LsNqMCMPmY";
+const DEFAULT_HARVEST_INBOX_NEW_STAGE_ID = "aafc9a01-1ad6-42c8-8c47-69a74cf1141d";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -125,7 +125,7 @@ const TYPE_TAGS: Record<string, string[]> = {
   "business-interest": ["role:supplier", "interest:markets"],
   "workshop-suggestion": ["interest:workshops"],
   "story-feature": ["role:storyteller", "interest:community"],
-  "venue-enquiry": ["interest:venue"],
+  "venue-enquiry": ["interest:venue", "act-inquiry"],
 };
 
 Deno.serve(async (req) => {

--- a/supabase/functions/contact-form/index.ts
+++ b/supabase/functions/contact-form/index.ts
@@ -1,7 +1,7 @@
 const GHL_API_BASE = "https://services.leadconnectorhq.com";
 const GHL_API_VERSION = "2021-07-28";
-const DEFAULT_HARVEST_INBOX_PIPELINE_ID = "ggQw10DuH0XRji6keimS";
-const DEFAULT_HARVEST_INBOX_NEW_STAGE_ID = "2eded979-7439-407d-89b6-762499b56658";
+const DEFAULT_HARVEST_INBOX_PIPELINE_ID = "5ZqAuFokM4LsNqMCMPmY";
+const DEFAULT_HARVEST_INBOX_NEW_STAGE_ID = "aafc9a01-1ad6-42c8-8c47-69a74cf1141d";
 // The existing "Message" custom field (contact.message). Populated so the ACT
 // notification workflow email can render the submitter's message via {{ contact.message }}.
 const DEFAULT_CONTACT_MESSAGE_FIELD_ID = "ceJz9FUf8dE4fmvnPDKd";


### PR DESCRIPTION
## Why

The auto-acknowledgment answers every website form within seconds, so GHL marks every thread as handled: unread sits at 0, "last message" is outbound, and people disappear from every obvious view while they wait. On 4 Sep the Harvest Inbox pipeline held 43 cards in New, eleven of them labelled "Reply needed" since a July audit nobody worked, and the oldest person had waited 112 days.

The one signal GHL keeps that survives the auto-ack is whether the last outbound message was **automated** (a workflow) or **manual** (a person). This PR makes that the model. Full write-up: `docs/strategy/ghl-pipeline-playbook.md`, "How to get back to people". Rollout plan lives on the Notion hub ("GHL Inbox Rollout: one model, every project").

## What changes

**Two tags carry the model.** `project:act-hv` says whose (already stamped at the `upsertGHLContact` chokepoint); `act-inquiry` says a human owes a reply. A thread is "waiting" when it has both and its last message is inbound or an automated outbound. Reply from GHL and it leaves the list on its own.

- `scripts/report-ghl-waiting.ts` (`npm run waiting:ghl`, `--project gd|jh|el|contained`, `--all`, `--md`): who is waiting on a human, per project, with what they wrote. Read-only. Does not depend on which Conversations UI the account has.
- `server/harvestCapture.ts`: `captureHarvestSubmission()`, one way in for every form. Upsert and tag, note, message into Conversations, card only when the thing needs more than a reply, receipt workflow. `needsReply` adds `act-inquiry`; a missing receipt env var is logged instead of silent; every step awaited because Vercel ends the function on return. Pizza RSVP is the first form on it, behaviour unchanged.
- **RSVP, member-signup comment and photo-wall submissions no longer create Harvest Inbox cards.** They need a confirmation or a read, not a reply, and cards cannot move themselves when someone replies (GHL has no trigger for a manually sent message). Notes and Conversations messages are unchanged.
- Shop, venue-enquiry and member-question forms now apply `act-inquiry` alongside their own tags.
- Fallback pipeline ids in `server/gohighlevel.ts`, both Supabase functions and the backfill script now point at Harvest Inbox (`5ZqAuFokM4LsNqMCMPmY`), not Universal Inquiry. With the env var unset, cards were landing on the wrong board; Helen Killeen has one in each.
- Two RSVP tests hardcoded `2026-07-25` and had been failing on `main` since that date passed; they now compute a future Saturday.
- Docs: playbook section rewritten; tag map gains "The Inbox Axis"; spec 8 (pizza RSVP receipt email) added to `ghl-workflow-build-specs.md`.

## What does not change

Nothing visible on the site. Every form still submits, tags and notes the same way. Only what lands in GHL differs: fewer cards, one more tag on three forms.

## Needs a click in GHL after merge

"Harvest - RSVP Pizza Dinner (tag)" has been a draft since July, so RSVP-ers get no confirmation. Publish it with the tag trigger `rsvp:pizza`, paste spec 8, set Reply-To to a human inbox (hi@act.place is send-only). No env var needed on that path.

## Verification

- `npx tsc --noEmit`: 0 errors
- `npx vitest run`: 32/32
- `npm run waiting:ghl -- --all` against the live location: Harvest 9, Goods 17 (12 already emailed from Gmail, which GHL cannot see), JusticeHub 2, CONTAINED 3, EL 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QM3fGsu6RzSPYVCBt82CK8
