### PR TITLE
Fix review regressions in consent, pagination, and public views

### DIFF
--- a/_archive/2026-07-06-newsletter-subscribe-edge-fn/RESTORE.md
+++ b/_archive/2026-07-06-newsletter-subscribe-edge-fn/RESTORE.md
@@ -6,9 +6,20 @@ the footer and /membership both submit through trpc newsletter.subscribe, and
 lib/api.ts subscribeNewsletter() was exported but never imported.
 
 Keeping two copies of the member-tag rule risked silent divergence, so the
-local source moved here. The DEPLOYED copy in Supabase project
-tednluwflfhxyucgwigh is still live but uncalled; delete it from the dashboard
-(Edge Functions > newsletter-subscribe) during the next day-shift GHL/Supabase
-hygiene pass.
+local source moved here. The deployed copy in Supabase project
+tednluwflfhxyucgwigh remained live after the local archive.
 
-To restore: `git mv _archive/2026-07-06-newsletter-subscribe-edge-fn/newsletter-subscribe supabase/functions/newsletter-subscribe`
+Read-only verification on 5 September 2026 confirmed that version 35 was still
+ACTIVE in the same project. Its deployed handler adds newsletter tags without
+checking explicit consent. Current website signups use `trpc.newsletter.subscribe`;
+the unused `lib/api.ts` wrapper and stale setup deployment command have now been
+removed.
+
+After Ben's approval, the deployed `newsletter-subscribe` function was deleted
+on 5 September 2026 at 08:29 Brisbane (4 September at 22:29 UTC). Supabase's
+before/after inventories confirmed it was the only removal: 13 functions became
+12, and every remaining function retained its ID, version, status, and code hash.
+No contacts, workflows, database records, or other functions were changed.
+
+This archive is retained for reference. The archived handler lacks consent
+enforcement; do not redeploy it unchanged.

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -184,10 +184,6 @@ export async function updateBusinessProfile(payload: Record<string, unknown>) {
   return response.business;
 }
 
-export async function subscribeNewsletter(payload: Record<string, unknown>) {
-  return callFunction<{ success: boolean; error?: string }>("newsletter-subscribe", payload);
-}
-
 export async function communitySubmit(payload: Record<string, unknown>) {
   return callFunction<{ success: boolean; error?: string; contactId?: string }>("community-submit", payload);
 }

--- a/client/src/pages/Works.tsx
+++ b/client/src/pages/Works.tsx
@@ -2,13 +2,14 @@ import { useEffect } from "react";
 import { Link } from "wouter";
 import { motion } from "framer-motion";
 import { ArrowRight } from "lucide-react";
-import { works, LIFECYCLE_VOCAB, sortLifecycleTags } from "@/data/works";
+import { works, LIFECYCLE_VOCAB, sortLifecycleTags, resolveWorkStatus, type LifecycleTag } from "@/data/works";
 import { EditableText } from "@/components/EditableText";
 import { HarvestImage } from "@/components/HarvestImage";
 import { useAuth } from "@/_core/hooks/useAuth";
 import { setPageSeo } from "@/lib/seo";
 import { harvestButtonClasses, SiteFooter, SiteNav } from "./HarvestReviewTest";
 import { VisitStrip } from "@/components/VisitStrip";
+import { trpc } from "@/lib/trpc";
 
 const fadeInUp = {
   initial: { opacity: 0, y: 30 },
@@ -16,6 +17,41 @@ const fadeInUp = {
   viewport: { once: true, margin: "-50px" },
   transition: { duration: 0.6 },
 };
+
+function WorkLifecycleBadges({ work, isAdmin }: {
+  work: { slug: string; lifecycleTags: LifecycleTag[] };
+  isAdmin: boolean;
+}) {
+  const { data: savedContent } = trpc.content.get.useQuery({
+    page: "works",
+    slot: `${work.slug}-lifecycleTags`,
+  });
+  let activeTags = work.lifecycleTags;
+  if (savedContent?.content) {
+    try {
+      const parsed: unknown = JSON.parse(savedContent.content);
+      if (Array.isArray(parsed) && parsed.every(
+        (tag): tag is LifecycleTag => typeof tag === "string" && Object.hasOwn(LIFECYCLE_VOCAB, tag),
+      )) {
+        activeTags = parsed;
+      }
+    } catch {
+      // Keep the default tags when an override cannot be read.
+    }
+  }
+
+  const badges = isAdmin
+    ? sortLifecycleTags(activeTags).map((tag) => LIFECYCLE_VOCAB[tag])
+    : [resolveWorkStatus(activeTags)];
+  return badges.map((meta) => (
+    <span
+      key={meta.label}
+      className={`inline-flex items-center px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider rounded-full ${meta.badgeClass}`}
+    >
+      {meta.label}
+    </span>
+  ));
+}
 
 
 export default function Works() {
@@ -65,7 +101,6 @@ export default function Works() {
         <div className="container">
           <div className="max-w-6xl mx-auto grid gap-10 md:gap-14 md:grid-cols-2">
             {works.map((work, i) => {
-              const lifecycleTags = sortLifecycleTags(work.lifecycleTags);
               const number = String(i + 1).padStart(2, "0");
 
               return (
@@ -88,17 +123,7 @@ export default function Works() {
                       imgClassName="h-full w-full object-cover transition-transform duration-700 group-hover:scale-105"
                     />
                     <div className="absolute top-4 left-4 flex flex-wrap gap-1.5">
-                      {lifecycleTags.map((tag) => {
-                        const meta = LIFECYCLE_VOCAB[tag];
-                        return (
-                          <span
-                            key={tag}
-                            className={`inline-flex items-center px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider rounded-full ${meta.badgeClass}`}
-                          >
-                            {meta.label}
-                          </span>
-                        );
-                      })}
+                      <WorkLifecycleBadges work={work} isAdmin={isAdmin} />
                     </div>
                     {!isAdmin && (
                       <Link

--- a/docs/communications/newsletter-ghl-template.html
+++ b/docs/communications/newsletter-ghl-template.html
@@ -102,7 +102,7 @@
                 &nbsp; | &nbsp;
                 <a href="FACEBOOK_URL" style="color:#C4922A;text-decoration:underline;">Facebook</a>
                 &nbsp; | &nbsp;
-                <a href="{{unsubscribe_link}}" style="color:#C4922A;text-decoration:underline;">Unsubscribe</a>
+                <span style="color:#C4922A;text-decoration:underline;">{{unsubscribe}}</span>
               </p>
             </td>
           </tr>

--- a/docs/launch-kit/01-launch-newsletter.html
+++ b/docs/launch-kit/01-launch-newsletter.html
@@ -167,7 +167,7 @@
         We acknowledge the Jinibara people as the traditional custodians of this land.
       </p>
       <p style="margin:0;font-size:11px;color:#57534e;">
-        <a href="{{unsubscribe_link}}" style="color:#78716c;">Unsubscribe</a> &nbsp;|&nbsp;
+        <span style="color:#78716c;">{{unsubscribe}}</span> &nbsp;|&nbsp;
         <a href="https://theharvestwitta.com.au" style="color:#78716c;">Visit website</a>
       </p>
     </td>

--- a/docs/launch-kit/05-first-gathering-newsletter.html
+++ b/docs/launch-kit/05-first-gathering-newsletter.html
@@ -282,7 +282,7 @@
         We acknowledge the Jinibara people as the traditional custodians of this land.
       </p>
       <p style="margin:0;font-size:11px;color:#57534e;">
-        <a href="{{unsubscribe_link}}" style="color:#78716c;">Unsubscribe</a> &nbsp;|&nbsp;
+        <span style="color:#78716c;">{{unsubscribe}}</span> &nbsp;|&nbsp;
         <a href="https://theharvestwitta.com.au" style="color:#78716c;">Visit website</a>
       </p>
     </td>

--- a/docs/launch-kit/website-launch-2026-05/newsletter.html
+++ b/docs/launch-kit/website-launch-2026-05/newsletter.html
@@ -196,7 +196,7 @@
       </p>
       <p style="margin:16px 0 0;font-size:11px;line-height:1.6;color:#57534e;">
         You are receiving this because you signed up at theharvestwitta.com.au or said yes at a gathering.
-        <a href="{{unsubscribe_url}}" style="color:#78716c;">Unsubscribe</a>.
+        <span style="color:#78716c;">{{unsubscribe}}</span>.
       </p>
     </td>
   </tr>

--- a/docs/runbooks/vercel-preview-smoke.md
+++ b/docs/runbooks/vercel-preview-smoke.md
@@ -21,6 +21,14 @@ After changing env vars, redeploy the preview. Existing deployments do not autom
 
 ## Preview-first flow
 
+Live configuration checked on 5 September 2026: the Vercel project `the-harvest`
+has automatic custom-domain assignment disabled. GitHub `main` requires the
+TypeScript/test/build/route-smoke check and the Vercel check, including for admins.
+Those checks do not enforce smoke verification of the deployed preview before a
+manual promotion. Run the preview command below and retain its passing output
+with the deployment URL before promoting. The production check runs afterward
+for detection and rollback. See the [production release contract](production-release-gates.md).
+
 1. Commit a clean worktree.
 2. Push a branch and let Vercel create a preview deployment.
 3. If the preview is protected, create a temporary Vercel share link and copy the `_vercel_share` token from the URL.
@@ -44,7 +52,7 @@ The smoke check verifies:
 - `/pizza` redirects to `/witta-pizza`
 - `/gather` and `/photo-wall` redirect to `/whats-on`
 - Sitemap includes `/witta-pizza` and excludes retired routes
-- A real headless browser mounts React and the rendered DOM is not blank
+- A real headless browser verifies stable route markers for all eight principal routes, independent of editable page copy
 
 Only promote the preview after this command passes.
 

--- a/docs/strategy/ghl-setup-runbook.md
+++ b/docs/strategy/ghl-setup-runbook.md
@@ -46,7 +46,7 @@ npm run setup:june-sprint-calendars:ghl
 Use `-- --apply` only when you intend to create missing calendars.
 
 In `Settings -> Calendars` (or the `Calendars` nav). First, **connect Google Calendar with
-2-way sync** for Susie + Joey + Ben so GHL respects real availability and writes bookings back.
+2-way sync** for Susie + Joey + Ben + Nic so GHL respects real availability and writes bookings back.
 That shared sync is what stops double-booking. Then build two:
 
 **A. "Book a chat about the shop"** --- a regular booking calendar, owned by Susie/Joey (or
@@ -72,7 +72,7 @@ Order matters. Do the Google sync first, then the two 20 June events, then the s
 About 45 minutes. The three booking links are the goal: they unblock the launch emails.
 
 **Step 0. Google 2-way sync (once each).**
-- [ ] Susie, Joey, and Ben each connect their own Google Calendar in GHL (your user profile,
+- [ ] Susie, Joey, Ben, and Nic each connect their own Google Calendar in GHL (your user profile,
       then Calendar Connections, then Google, allow 2-way). Done when each shows "2-way".
 - Why: GHL then reads real availability and writes bookings back, so nobody double-books.
 

--- a/docs/strategy/harvest-ghl-alignment-2026-06-02.md
+++ b/docs/strategy/harvest-ghl-alignment-2026-06-02.md
@@ -2,6 +2,8 @@
 
 > 2026-06-02. Verified live via `scripts/list-ghl-workflows-and-tags.ts` (read-only GHL API) + the workflow-list UI. Supersedes the "workflows verified live" claims in the May docs — they are now `draft`. Three problems, one decision, a clicked plan + a code plan.
 
+> Membership tag correction: the website represents membership with `tier:member` only. For the current tag contract, see [Harvest GHL Tag and Automation Map](harvest-ghl-tag-and-automation-map.md). The live-state observations below remain dated 2 June.
+
 ## Verified live state
 
 **Workflows (Harvest-relevant, from 18 in the shared ACT location):**
@@ -39,20 +41,20 @@ One tag per job. Scope + tier + role are the spine; interest/source/consent are 
 |---|---|---|
 | Scope (which list/site) | `harvest-website`, `harvest-newsletter` (the list), `comms:harvest-newsletter` (channel/consent) | — |
 | Journey stage | `tier:curious` → `tier:connected` → `tier:member` | — |
-| Role | `role:member`, `role:buyer`, `role:supplier` (maker/grower), `role:volunteer`, `role:partner` | — |
+| Role | `role:buyer`, `role:supplier` (maker/grower), `role:volunteer`, `role:partner` | — |
 | Interest | `interest:*` (namespaced) | `interest-*` (flat, after code migration) |
 | Source | `source:*` (namespaced) | `source-*` (flat, after code migration) |
 | Consent | `consent:newsletter-yes` | — |
 | Operational (events/shop/quiz) | keep flat: `rsvp-pizza-dinner`, `rsvp-maker-morning`, `shop-call-booked`, `quiz-*`, `witta-gathering-2026-06-20`; use namespaced `interest:markets` + `role:supplier` for shop intent | — |
 
-**The bridge that fixes the orphaned Journey:** whenever someone becomes a member, apply `tier:member` + `role:member` (not just `harvest-member`). Whenever someone follows, apply `tier:connected`. That feeds the Journey pipeline.
+**The bridge that fixes the orphaned Journey:** whenever someone becomes a member, apply `tier:member` (not just `harvest-member`). Membership is a tier; there is no separate member role tag. Whenever someone follows, apply `tier:connected`. That feeds the Journey pipeline.
 
 ## Realignment actions
 
 ### A. GHL UI — Ben clicks, launch-critical, do now (no deploy)
 1. **Publish the 5 draft workflows** (Follow Welcome, Member Welcome, Member Question, Shop Interest Receipt, Shop prospect→card). Test one enrol each — confirm the email fires.
 2. **Feed the Journey (in-workflow, no code):**
-   - Member Welcome → add action *Add Tag* `tier:member` + `role:member`
+   - Member Welcome → add action *Add Tag* `tier:member`
    - Follow Welcome → add action *Add Tag* `tier:connected`
    - Shop Interest Receipt → add action *Add Tag* `role:supplier`
 3. **Build the 3 calendar-tag workflows** per `ghl-calendar-tag-workflows-runbook.md` (7a/b/c). RSVP tags only — no tier change (an RSVP is not a subscribe).
@@ -60,7 +62,7 @@ One tag per job. Scope + tier + role are the spine; interest/source/consent are 
 ### B. Website code — SHIPPED to branch `wip/harvest-launch-fixes-2026-06-02` (not yet deployed)
 All in `server/routers.ts` (no `gohighlevel.ts` change needed — it POSTs tags to `/contacts/{id}/tags`, which merges and preserves colons):
 - `interest:*` / `source:*` are now canonical, **dual-written** with their flat `interest-*` / `source-*` aliases via `withFlatAlias()` so existing smart lists keep receiving contacts (NOT a hard switch — avoids silently dropping new contacts from flat-tag segments mid-launch).
-- Journey bridge applied at submit: member → `tier:member` + `role:member`; follower → `tier:connected`; quiz → `tier:curious`; shop EOI → `role:supplier`. Channel tag `comms:harvest-newsletter` added.
+- Journey bridge applied at submit: member → `tier:member`; follower → `tier:connected`; quiz → `tier:curious`; shop EOI → `role:supplier`. Channel tag `comms:harvest-newsletter` added.
 - Kept `harvest-*` scope tags + bare `newsletter`. 22 tests pass (2 new assertions pin the namespaced/tier output). `tsc` clean.
 - **Note:** because code now applies `tier:`/`role:`, the in-workflow bridge in A2 becomes redundant once this deploys — but tags are idempotent (set membership), so running both is harmless. After deploy, A2 can be dropped.
 

--- a/docs/strategy/launch-ops-run-sheet.md
+++ b/docs/strategy/launch-ops-run-sheet.md
@@ -1,5 +1,7 @@
 # Launch Ops Run Sheet: 20 June Members' Day
 
+> **Historical plan, superseded on 3 June 2026.** The [reconciled public open-day decision](RECONCILED-20-june-public-open-day-2026-06-03.md) replaces this private members' event model. The BYO proposal below is not evidence of clearance: the [council and insurance call brief](../communications/launch-calls-brief.md) describes an event with no alcohol. Confirm the recorded clearance before reusing any alcohol provision.
+
 > Created 2026-05-29. The operational layer under `launch-readiness-20-june-2026.md`
 > (which sequences the threads and names the gates). This doc is the day-of detail:
 > locked decisions, role roster, run sheet, open/serve/close checklist, signage, stock,
@@ -19,8 +21,8 @@
   Defaults set 29 May; change either number and the RSVP calendars follow.
 - **Pizza: three types.** Margherita; roast veg + feta; salami. Make-your-own bar on set
   bases. Gluten-free base option and a dairy-free cheese option.
-- **Drinks.** Water, tea and coffee, a few soft drinks. BYO alcohol (no liquor licence needed
-  if nothing is sold; confirm on the council call).
+- **Drinks.** Water, tea and coffee, a few soft drinks. BYO was proposed in this draft,
+  but council and insurance clearance for it is not recorded here. The call brief says no alcohol.
 - **Host: Nic.** Stock ordering owner: Susie (Joey backs up). Confirm if wrong.
 
 ## Role roster
@@ -79,7 +81,7 @@ Holland contact).
 
 Gate "The Harvest, welcome" plus arrow; parking; welcome / check-in point; the three zones
 (garden, maker session, gathering); toilets; handwashing; pizza bar plus allergens; kids
-area; fire and oven keep-clear; BYO and free-night note; exit. Use the graphite-pencil brand
+area; fire and oven keep-clear; free-night note; exit. Use the graphite-pencil brand
 look where printed; simple and clear over polished.
 
 ## Stock + supplier list (estimate, confirm headcount first)
@@ -109,7 +111,7 @@ against each line before the shop run.
 
 Before the day, every helper gets: their role and window (from the roster), the safety basics
 (fire and oven keep-clear, first-aid and incident process, who the host is), the free-night
-rule (nothing is sold, BYO alcohol), the consent rule for photos, and the close checklist if
+rule (nothing is sold; this draft does not confirm BYO approval), the consent rule for photos, and the close checklist if
 they are on pack-down. Keep it to one page; send it with the crew brief on 19 June.
 
 ## Pre-launch scripts (ready to use)

--- a/docs/strategy/launch-readiness-20-june-2026.md
+++ b/docs/strategy/launch-readiness-20-june-2026.md
@@ -96,7 +96,7 @@ Built per `ghl-setup-runbook.md` Part 0. Three calendars are live:
   Link: `https://api.leadconnectorhq.com/widget/bookings/harvest-shop-chat`.
   Move this to Susie/Joey after their GHL users exist. This serves thread 3.
 
-Connect Google Calendar 2-way for Susie + Joey + Ben first, so availability is real and
+Connect Google Calendar 2-way for Susie + Joey + Ben + Nic first, so availability is real and
 bookings write back. Keep both 20 June links members-first; never on the public site.
 
 Then build one calendar tag workflow per calendar:

--- a/server/__tests__/communityHelpPreferences.test.ts
+++ b/server/__tests__/communityHelpPreferences.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type CommunityHandler = (request: Request) => Promise<Response>;
+type CapturedBody = {
+  payload?: { helpType?: string; availability?: string };
+  tags?: string[];
+  body?: string;
+  html?: string;
+};
+
+describe("community volunteer help preferences", () => {
+  let handler: CommunityHandler;
+  const calls: { url: string; body: CapturedBody | undefined }[] = [];
+
+  beforeEach(async () => {
+    vi.resetModules();
+    calls.length = 0;
+    const env: Record<string, string> = {
+      SUPABASE_URL: "https://storage.invalid",
+      SUPABASE_SERVICE_ROLE_KEY: "fixture-only",
+      GHL_API_KEY: "fixture-only",
+      GHL_LOCATION_ID: "fixture-location",
+    };
+    vi.stubGlobal("Deno", {
+      env: { get: (key: string) => env[key] },
+      serve: (callback: CommunityHandler) => { handler = callback; },
+    });
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      calls.push({ url, body });
+      if (url === "https://storage.invalid/rest/v1/community_submissions") {
+        return Response.json([{ id: "fixture-submission" }]);
+      }
+      if (url.endsWith("/contacts/upsert")) {
+        return Response.json({ contact: { id: "fixture-contact" } });
+      }
+      if (url.includes("/conversations/search?")) {
+        return Response.json({ conversations: [{ id: "fixture-conversation" }] });
+      }
+      if ([
+        "/community_submissions?id=eq.fixture-submission",
+        "/contacts/fixture-contact/tags",
+        "/contacts/fixture-contact/notes",
+        "/conversations/messages/inbound",
+        "/opportunities/upsert",
+      ].some((suffix) => url.endsWith(suffix))) {
+        return Response.json({});
+      }
+      throw new Error(`Unexpected request in isolated community preference test: ${url}`);
+    }));
+
+    await import("../../supabase/functions/community-submit/index");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const submit = (helpType?: string) => handler(new Request("https://function.invalid/community-submit", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      type: "volunteer",
+      name: "Fixture Person",
+      email: "fixture@example.invalid",
+      helpType,
+      availability: "Occasional weekends",
+      message: "I would like to help.",
+    }),
+  }));
+
+  const bodyFor = (suffix: string) => calls.find((call) => call.url.endsWith(suffix))?.body;
+
+  it.each(["garden", "making", "events", "shop", "stories", "anything-useful"])(
+    "records %s as a preference for review without assigning a crew",
+    async (helpType) => {
+      const response = await submit(helpType);
+
+      expect(response.status).toBe(200);
+      expect(bodyFor("/community_submissions")?.payload).toMatchObject({
+        helpType,
+        availability: "Occasional weekends",
+      });
+      const tags = bodyFor("/contacts/fixture-contact/tags")?.tags;
+      expect(tags).toEqual(expect.arrayContaining(["interest:volunteer", "lane:community", "harvest-inbox", "project:act-hv"]));
+      expect(tags?.some((tag) => tag.startsWith("pod:"))).toBe(false);
+      expect(bodyFor("/contacts/fixture-contact/notes")?.body).toContain(`**Help preference:** ${helpType}`);
+      expect(bodyFor("/conversations/messages/inbound")?.html).toContain(`<p>Help preference: ${helpType}</p>`);
+    },
+  );
+
+  it("escapes a submitted preference in the inbox while preserving the original in storage", async () => {
+    const helpType = "<img src=x onerror=alert(1)>";
+
+    await submit(helpType);
+
+    expect(bodyFor("/community_submissions")?.payload?.helpType).toBe(helpType);
+    expect(bodyFor("/conversations/messages/inbound")?.html).toContain("&lt;img src=x onerror=alert(1)&gt;");
+    expect(bodyFor("/conversations/messages/inbound")?.html).not.toContain(helpType);
+  });
+
+  it("does not invent a preference when none was supplied", async () => {
+    const response = await submit();
+
+    expect(response.status).toBe(200);
+    expect(bodyFor("/community_submissions")?.payload).not.toHaveProperty("helpType");
+    expect(bodyFor("/contacts/fixture-contact/notes")?.body).not.toContain("Help preference:");
+    expect(bodyFor("/conversations/messages/inbound")?.html).not.toContain("Help preference:");
+    expect(bodyFor("/contacts/fixture-contact/tags")?.tags?.some((tag) => tag.startsWith("pod:"))).toBe(false);
+  });
+});

--- a/server/__tests__/contactFormConsent.test.ts
+++ b/server/__tests__/contactFormConsent.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type ContactHandler = (request: Request) => Promise<Response>;
+type CapturedBody = {
+  tags?: string[];
+  customFields?: { id: string; fieldValue?: string }[];
+};
+
+describe("contact form newsletter consent", () => {
+  let handler: ContactHandler;
+  let env: Record<string, string | undefined>;
+  let failContactUpsert: boolean;
+  const calls: { url: string; body: CapturedBody | undefined }[] = [];
+
+  beforeEach(async () => {
+    vi.resetModules();
+    calls.length = 0;
+    failContactUpsert = false;
+    env = {
+      GHL_API_KEY: "fixture-only",
+      GHL_LOCATION_ID: "fixture-location",
+      GHL_CONTACT_FORM_WORKFLOW_ID: "fixture-contact-workflow",
+      GHL_NEWSLETTER_CONSENT_FIELD_ID: "fixture-newsletter-consent",
+    };
+    vi.stubGlobal("Deno", {
+      env: { get: (key: string) => env[key] },
+      serve: (callback: ContactHandler) => { handler = callback; },
+    });
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      calls.push({ url, body });
+      const json = (value: unknown, status = 200) => new Response(JSON.stringify(value), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      });
+      if (url.endsWith("/contacts/upsert")) {
+        return failContactUpsert
+          ? json({ message: "Fixture CRM failure" }, 503)
+          : json({ contact: { id: "fixture-contact" } });
+      }
+      if (url.includes("/conversations/search?")) {
+        return json({ conversations: [{ id: "fixture-conversation" }] });
+      }
+      if ([
+        "/contacts/fixture-contact/tags",
+        "/contacts/fixture-contact/notes",
+        "/contacts/fixture-contact/workflow/fixture-contact-workflow",
+        "/conversations/messages/inbound",
+        "/opportunities/upsert",
+      ].some(path => url.endsWith(path))) {
+        return json({});
+      }
+      throw new Error(`Unexpected request in isolated contact-form test: ${url}`);
+    }));
+
+    // Import the real edge entry point with its Deno host and all HTTP calls mocked.
+    await import("../../supabase/functions/contact-form/index");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const submit = (subscribe: unknown) => handler(new Request("https://function.invalid/contact-form", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      name: "Fixture Person",
+      email: "fixture@example.invalid",
+      subject: "A question",
+      message: "Fixture message",
+      subscribe,
+    }),
+  }));
+
+  const bodyFor = (suffix: string) => calls.find(call => call.url.endsWith(suffix))?.body;
+
+  it.each([false, undefined, null, "false", "true", "Yes", 1, {}, []].map(value => ({ value })))(
+    "does not infer consent from $value",
+    async ({ value }) => {
+      const response = await submit(value);
+      expect(response.status).toBe(200);
+      expect(bodyFor("/contacts/fixture-contact/tags")?.tags).toContain("act-inquiry");
+      expect(bodyFor("/contacts/fixture-contact/tags")?.tags).not.toContain("comms:harvest-newsletter");
+      expect(bodyFor("/contacts/upsert")?.customFields).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({ id: "fixture-newsletter-consent" }),
+      ]));
+    },
+  );
+
+  it("persists explicit consent before adding the sendable newsletter tag", async () => {
+    const response = await submit(true);
+    expect(response.status).toBe(200);
+    expect(bodyFor("/contacts/upsert")?.customFields).toEqual(expect.arrayContaining([
+      { id: "fixture-newsletter-consent", fieldValue: "Yes" },
+      { id: "ceJz9FUf8dE4fmvnPDKd", fieldValue: "Subject: A question\n\nFixture message" },
+    ]));
+    expect(bodyFor("/contacts/fixture-contact/tags")?.tags).toContain("comms:harvest-newsletter");
+    expect(calls.findIndex(call => call.url.endsWith("/contacts/upsert")))
+      .toBeLessThan(calls.findIndex(call => call.url.endsWith("/contacts/fixture-contact/tags")));
+  });
+
+  it("uses the existing Harvest consent field when no override is configured", async () => {
+    delete env.GHL_NEWSLETTER_CONSENT_FIELD_ID;
+    await submit(true);
+    expect(bodyFor("/contacts/upsert")?.customFields).toContainEqual({
+      id: "aVnqmajnysMtGYhLD0oA", fieldValue: "Yes",
+    });
+  });
+
+  it("does not apply marketing tags when persisting the contact fails", async () => {
+    failContactUpsert = true;
+    const response = await submit(true);
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({ success: false });
+    expect(bodyFor("/contacts/fixture-contact/tags")).toBeUndefined();
+    expect(calls.some(call => call.url.includes("/workflow/"))).toBe(false);
+  });
+});

--- a/server/__tests__/empathyLedgerMediaPagination.test.ts
+++ b/server/__tests__/empathyLedgerMediaPagination.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EmpathyLedgerClient } from "../empathyLedgerClient";
+
+vi.mock("../harvestImageStorage.js", () => ({
+  mirrorHarvestImage: vi.fn(async (_id: string, src: string) => src),
+}));
+
+function mockMediaLibrary(total: number) {
+  const records = Array.from({ length: total }, (_, index) => ({
+    id: String(index + 1),
+    url: `https://images.example.test/${index + 1}.jpg`,
+    title: `Photo ${index + 1}`,
+    description: null,
+    altText: null,
+    projectId: "harvest",
+    createdAt: "2026-09-05T00:00:00Z",
+  }));
+  const fetchMock = vi.fn(async (input: string | URL | Request) => {
+    const url = new URL(typeof input === "string" ? input : input instanceof URL ? input.href : input.url);
+    expect(url.pathname).toBe("/api/v1/content-hub/media");
+    const page = Number(url.searchParams.get("page") ?? 1);
+    const limit = Math.min(Number(url.searchParams.get("limit") ?? 20), 50);
+    return Response.json({
+      media: records.slice((page - 1) * limit, page * limit),
+      pagination: { page, limit, total, hasMore: page * limit < total },
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return new EmpathyLedgerClient("https://el.example.test", "test-key");
+}
+
+function idsBetween(first: number, last: number) {
+  return Array.from({ length: Math.max(0, last - first + 1) }, (_, index) => String(first + index));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("full Harvest media pagination", () => {
+  it("returns consecutive 100-item pages without overlap", async () => {
+    const client = mockMediaLibrary(250);
+
+    const first = await client.fetchAllHarvestMedia({ page: 1, limit: 100 });
+    const second = await client.fetchAllHarvestMedia({ page: 2, limit: 100 });
+
+    expect(first.media.map((item) => item.id)).toEqual(idsBetween(1, 100));
+    expect(second.media.map((item) => item.id)).toEqual(idsBetween(101, 200));
+    expect(second.pagination).toEqual({ page: 2, limit: 100, total: 250, hasMore: true });
+  });
+
+  it.each([
+    { page: 2, limit: 75, first: 76, last: 150 },
+    { page: 2, limit: 20, first: 21, last: 40 },
+    { page: 3, limit: 20, first: 41, last: 60 },
+  ])("preserves offsets for page $page with limit $limit", async ({ page, limit, first, last }) => {
+    const client = mockMediaLibrary(250);
+
+    const result = await client.fetchAllHarvestMedia({ page, limit });
+
+    expect(result.media.map((item) => item.id)).toEqual(idsBetween(first, last));
+    expect(result.pagination).toEqual({ page, limit, total: 250, hasMore: true });
+  });
+
+  it.each([
+    { page: 3, limit: 100, first: 201, last: 250 },
+    { page: 5, limit: 50, first: 201, last: 250 },
+    { page: 4, limit: 100, first: 301, last: 250 },
+  ])("ends pagination on page $page with limit $limit", async ({ page, limit, first, last }) => {
+    const client = mockMediaLibrary(250);
+
+    const result = await client.fetchAllHarvestMedia({ page, limit });
+
+    expect(result.media.map((item) => item.id)).toEqual(idsBetween(first, last));
+    expect(result.pagination).toEqual({ page, limit, total: 250, hasMore: false });
+  });
+
+  it("returns an empty collection without suggesting another page", async () => {
+    const client = mockMediaLibrary(0);
+
+    const result = await client.fetchAllHarvestMedia({ page: 1, limit: 100 });
+
+    expect(result.media).toEqual([]);
+    expect(result.pagination).toEqual({ page: 1, limit: 100, total: 0, hasMore: false });
+  });
+
+  it("offers another caller page while the final upstream page still has unused records", async () => {
+    const client = mockMediaLibrary(50);
+
+    const second = await client.fetchAllHarvestMedia({ page: 2, limit: 20 });
+    const third = await client.fetchAllHarvestMedia({ page: 3, limit: 20 });
+
+    expect(second.media.map((item) => item.id)).toEqual(idsBetween(21, 40));
+    expect(second.pagination.hasMore).toBe(true);
+    expect(third.media.map((item) => item.id)).toEqual(idsBetween(41, 50));
+    expect(third.pagination.hasMore).toBe(false);
+  });
+
+  it("stops when an upstream page is empty despite stale pagination metadata", async () => {
+    const fetchMock = vi.fn(async () => Response.json({
+      media: [],
+      pagination: { page: 3, limit: 50, total: 500, hasMore: true },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new EmpathyLedgerClient("https://el.example.test", "test-key");
+
+    const result = await client.fetchAllHarvestMedia({ page: 2, limit: 100 });
+
+    expect(result.media).toEqual([]);
+    expect(result.pagination.hasMore).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not suggest more pages after an empty response ends a partial page", async () => {
+    const client = mockMediaLibrary(50);
+    const fetchMock = vi.mocked(fetch);
+    const originalFetch = fetchMock.getMockImplementation()!;
+    fetchMock.mockImplementation(async (...args) => {
+      const response = await originalFetch(...args);
+      const body = await response.json();
+      return Response.json({ ...body, pagination: { ...body.pagination, total: 500, hasMore: true } });
+    });
+
+    const result = await client.fetchAllHarvestMedia({ page: 1, limit: 100 });
+
+    expect(result.media.map((item) => item.id)).toEqual(idsBetween(1, 50));
+    expect(result.pagination.hasMore).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/server/__tests__/harvestImageStorage.test.ts
+++ b/server/__tests__/harvestImageStorage.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock } = vi.hoisted(() => ({ createClientMock: vi.fn() }));
+vi.mock("@supabase/supabase-js", () => ({ createClient: createClientMock }));
+
+const SOURCE_URL = "https://source.example.test/photo.jpg?token=fixture";
+const PUBLIC_URL = "https://harvest.example.test/storage/v1/object/public/media/harvest-image-mirror/photo_1";
+const OBJECT_PATH = "harvest-image-mirror/photo_1";
+
+describe("Harvest image mirror cache lookup", () => {
+  let mirrorHarvestImage: typeof import("../harvestImageStorage").mirrorHarvestImage;
+  let bucket: {
+    download: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    upload: ReturnType<typeof vi.fn>;
+    getPublicUrl: ReturnType<typeof vi.fn>;
+  };
+  let sourceFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.stubEnv("SUPABASE_URL", "https://harvest.example.test");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "fixture-only");
+    bucket = {
+      download: vi.fn().mockResolvedValue({ data: new Blob(["existing image"]), error: null }),
+      info: vi.fn().mockResolvedValue({ data: { name: OBJECT_PATH }, error: null }),
+      upload: vi.fn().mockResolvedValue({ data: { path: OBJECT_PATH }, error: null }),
+      getPublicUrl: vi.fn().mockReturnValue({ data: { publicUrl: PUBLIC_URL } }),
+    };
+    createClientMock.mockReturnValue({ storage: { from: vi.fn().mockReturnValue(bucket) } });
+    sourceFetch = vi.fn(async () => new Response("source image", {
+      headers: { "Content-Type": "image/jpeg" },
+    }));
+    vi.stubGlobal("fetch", sourceFetch);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    ({ mirrorHarvestImage } = await import("../harvestImageStorage"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  function missingObject(error = { message: "Object not found", status: 404, statusCode: "404" }) {
+    bucket.download.mockResolvedValue({ data: null, error });
+    bucket.info.mockResolvedValue({ data: null, error });
+  }
+
+  it("returns the cached public URL using metadata without downloading image bytes", async () => {
+    const result = await mirrorHarvestImage("photo/1", SOURCE_URL);
+
+    expect(result).toBe(PUBLIC_URL);
+    expect(bucket.info).toHaveBeenCalledWith(OBJECT_PATH);
+    expect(bucket.download).not.toHaveBeenCalled();
+    expect(sourceFetch).not.toHaveBeenCalled();
+    expect(bucket.upload).not.toHaveBeenCalled();
+    expect(bucket.getPublicUrl).toHaveBeenCalledWith(OBJECT_PATH);
+  });
+
+  it.each([404, 400])("uploads a missing object when HTTP %i carries storage status 404", async (status) => {
+    missingObject({ message: "Object not found", status, statusCode: "404" });
+
+    const result = await mirrorHarvestImage("photo/1", SOURCE_URL);
+
+    expect(result).toBe(PUBLIC_URL);
+    expect(sourceFetch).toHaveBeenCalledWith(SOURCE_URL, expect.objectContaining({ signal: expect.any(AbortSignal) }));
+    expect(bucket.upload).toHaveBeenCalledWith(OBJECT_PATH, Buffer.from("source image"), {
+      contentType: "image/jpeg",
+      cacheControl: "31536000",
+      upsert: false,
+    });
+    expect(bucket.download).not.toHaveBeenCalled();
+  });
+
+  it.each([401, 403, 500])("does not treat metadata failure %i as a missing image", async (status) => {
+    const error = { message: "Storage unavailable", status, statusCode: String(status) };
+    bucket.download.mockResolvedValue({ data: null, error });
+    bucket.info.mockResolvedValue({ data: null, error });
+
+    const result = await mirrorHarvestImage("photo/1", SOURCE_URL);
+
+    expect(result).toBe(SOURCE_URL);
+    expect(sourceFetch).not.toHaveBeenCalled();
+    expect(bucket.upload).not.toHaveBeenCalled();
+    expect(bucket.getPublicUrl).not.toHaveBeenCalled();
+  });
+
+  it("preserves the source URL when the metadata request throws", async () => {
+    bucket.info.mockRejectedValue(new Error("Connection failed"));
+
+    expect(await mirrorHarvestImage("photo/1", SOURCE_URL)).toBe(SOURCE_URL);
+    expect(sourceFetch).not.toHaveBeenCalled();
+    expect(bucket.upload).not.toHaveBeenCalled();
+  });
+
+  it("still returns the durable URL when another request uploads first", async () => {
+    missingObject();
+    bucket.upload.mockResolvedValue({ data: null, error: { message: "The resource already exists" } });
+
+    expect(await mirrorHarvestImage("photo/1", SOURCE_URL)).toBe(PUBLIC_URL);
+    expect(bucket.getPublicUrl).toHaveBeenCalledWith(OBJECT_PATH);
+  });
+
+  it("preserves the original source when the upstream response is not an image", async () => {
+    missingObject();
+    sourceFetch.mockResolvedValue(new Response("unavailable", { headers: { "Content-Type": "text/plain" } }));
+
+    expect(await mirrorHarvestImage("photo/1", SOURCE_URL)).toBe(SOURCE_URL);
+    expect(bucket.upload).not.toHaveBeenCalled();
+  });
+});

--- a/server/__tests__/newsletter.test.ts
+++ b/server/__tests__/newsletter.test.ts
@@ -17,6 +17,7 @@ vi.mock("../db", async (importOriginal) => {
   return {
     ...actual,
     createPulseResponse: vi.fn().mockResolvedValue({ id: 123 }),
+    createCommunitySubmission: vi.fn().mockResolvedValue({ id: 123 }),
   };
 });
 
@@ -39,6 +40,7 @@ describe("Go High Level Newsletter Integration", () => {
       GHL_MEMBER_QUESTION_WORKFLOW_ID: "member-question-workflow",
       GHL_GATHERING_RSVP_WORKFLOW_ID: "gathering-rsvp-workflow",
       GHL_CONTACT_FORM_WORKFLOW_ID: "contact-form-workflow",
+      GHL_NEWSLETTER_CONSENT_FIELD_ID: "fixture-newsletter-consent",
     };
   });
 
@@ -137,6 +139,26 @@ describe("Go High Level Newsletter Integration", () => {
   });
 
   describe("upsertGHLContact", () => {
+    it.each([undefined, false, "false", "true", 1, {}, []].map(value => ({ value })))(
+      "does not overwrite newsletter preferences for ordinary upserts with $value consent",
+      async ({ value }) => {
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: async () => ({ contact: { id: "contact-123" } }),
+        });
+
+        const result = await upsertGHLContact({
+          email: "fixture@example.invalid",
+          tags: ["contact-form"],
+          // Exercise malformed runtime values as well as the typed false/omitted cases.
+          newsletterConsent: value as boolean | undefined,
+        });
+
+        expect(result.success).toBe(true);
+        expect(JSON.parse(mockFetch.mock.calls[0][1].body)).not.toHaveProperty("customFields");
+      },
+    );
+
     it("should return error when API credentials are not configured", async () => {
       process.env.GHL_API_KEY = "";
       process.env.GHL_LOCATION_ID = "";
@@ -211,6 +233,61 @@ describe("Go High Level Newsletter Integration", () => {
           },
         }),
       });
+    });
+
+    it.each([
+      { member: false, fieldId: "fixture-newsletter-consent", configured: true, workflow: "newsletter-workflow" },
+      { member: true, fieldId: "aVnqmajnysMtGYhLD0oA", configured: false, workflow: "member-welcome-workflow" },
+    ])("persists signup consent before tags and the $workflow", async ({ member, fieldId, configured, workflow }) => {
+      if (!configured) delete process.env.GHL_NEWSLETTER_CONSENT_FIELD_ID;
+      let finishUpsert!: (response: unknown) => void;
+      mockFetch.mockImplementationOnce(() => new Promise(resolve => { finishUpsert = resolve; }));
+      const caller = appRouter.createCaller(ctx);
+      const subscription = caller.newsletter.subscribe({
+        email: "fixture@example.invalid",
+        firstName: "Fixture",
+        member,
+      });
+
+      await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+      const upsertBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      finishUpsert({
+        ok: true,
+        json: async () => ({ contact: { id: "contact-123" } }),
+      });
+      await expect(subscription).resolves.toMatchObject({ success: true });
+
+      expect(upsertBody.customFields).toEqual([{ id: fieldId, fieldValue: "Yes" }]);
+      const urls = mockFetch.mock.calls.map(([url]) => String(url));
+      expect(urls[0]).toBe("https://services.leadconnectorhq.com/contacts/upsert");
+      const tagIndex = urls.findIndex(url => url.endsWith("/contacts/contact-123/tags"));
+      const workflowIndex = urls.findIndex(url => url.endsWith(`/contacts/contact-123/workflow/${workflow}`));
+      expect(tagIndex).toBeGreaterThan(0);
+      expect(workflowIndex).toBeGreaterThan(tagIndex);
+      expect(JSON.parse(mockFetch.mock.calls[tagIndex][1].body).tags).toContain("comms:harvest-newsletter");
+    });
+
+    it.each(["http", "network"])("blocks tags and workflow enrollment when consent persistence fails through %s", async (failure) => {
+      if (failure === "network") {
+        mockFetch.mockRejectedValueOnce(new Error("Fixture network failure"));
+      } else {
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 422,
+          json: async () => ({ message: "Fixture consent field rejected" }),
+        });
+      }
+      const caller = appRouter.createCaller(ctx);
+
+      await expect(caller.newsletter.subscribe({
+        email: "fixture@example.invalid",
+        firstName: "Fixture",
+      })).rejects.toThrow();
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(mockFetch.mock.calls[0][1].body).customFields).toEqual([
+        { id: "fixture-newsletter-consent", fieldValue: "Yes" },
+      ]);
     });
 
     it("builds Harvest member tags without losing newsletter compatibility", () => {

--- a/server/__tests__/notionEditorialConfiguration.test.ts
+++ b/server/__tests__/notionEditorialConfiguration.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const notion = vi.hoisted(() => ({
+  query: vi.fn(),
+  retrieve: vi.fn(),
+}));
+
+vi.mock("@notionhq/client", () => ({
+  Client: class {
+    dataSources = notion;
+  },
+}));
+
+vi.mock("../gohighlevel.js", () => ({
+  getGHLAccountMap: vi.fn(),
+  createGHLSocialPost: vi.fn(),
+  getGHLSocialAccounts: vi.fn(),
+  getGHLSocialPosts: vi.fn(),
+}));
+
+const paths = [
+  {
+    name: "calendar queries",
+    method: "query" as const,
+    read: async () => (await import("../notion")).queryEditorialCalendar(),
+    expected: [{ id: "post-1", title: "Harvest update" }],
+  },
+  {
+    name: "editorial schema retrieval",
+    method: "retrieve" as const,
+    read: async () => (await import("../notion")).getEditorialCommunicationTypes(),
+    expected: ["Newsletter"],
+  },
+];
+
+describe.each(paths)("Notion configuration for $name", ({ method, read, expected }) => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    vi.stubEnv("NOTION_API_KEY", "test-notion-key");
+    vi.stubEnv("NOTION_TOKEN", undefined);
+    vi.stubEnv("NOTION_EDITORIAL_DS_ID", undefined);
+    vi.stubEnv("NOTION_EDITORIAL_DB_ID", undefined);
+    vi.stubGlobal("fetch", vi.fn(() => {
+      throw new Error("Notion configuration tests must not access the network");
+    }));
+    notion.query.mockResolvedValue({
+      results: [{
+        id: "post-1",
+        properties: {
+          "Content/Communication Name": {
+            type: "title",
+            title: [{ plain_text: "Harvest update" }],
+          },
+        },
+      }],
+      has_more: false,
+      next_cursor: null,
+    });
+    notion.retrieve.mockResolvedValue({
+      properties: {
+        "Communication Type": { select: { options: [{ name: "Newsletter" }] } },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("reads with only an explicit data source ID configured", async () => {
+    vi.stubEnv("NOTION_EDITORIAL_DS_ID", "editorial-data-source");
+
+    await expect(read()).resolves.toMatchObject(expected);
+
+    expect(notion[method]).toHaveBeenCalledTimes(1);
+    expect(notion[method]).toHaveBeenCalledWith(
+      expect.objectContaining({ data_source_id: "editorial-data-source" }),
+    );
+  });
+
+  it("retains database-only configuration support", async () => {
+    vi.stubEnv("NOTION_EDITORIAL_DB_ID", "editorial-database");
+
+    await expect(read()).resolves.toMatchObject(expected);
+
+    expect(notion[method]).toHaveBeenCalledTimes(1);
+    expect(notion[method]).toHaveBeenCalledWith(
+      expect.objectContaining({ data_source_id: "editorial-database" }),
+    );
+  });
+
+  it("retries the configured database ID when the data source is not found", async () => {
+    vi.stubEnv("NOTION_EDITORIAL_DS_ID", "missing-data-source");
+    vi.stubEnv("NOTION_EDITORIAL_DB_ID", "editorial-database");
+    notion[method].mockRejectedValueOnce({ code: "object_not_found", status: 404 });
+
+    await expect(read()).resolves.toMatchObject(expected);
+
+    expect(notion[method].mock.calls.map(([request]) => request.data_source_id))
+      .toEqual(["missing-data-source", "editorial-database"]);
+  });
+
+  it("does not replace a data source error with a missing database configuration error", async () => {
+    vi.stubEnv("NOTION_EDITORIAL_DS_ID", "missing-data-source");
+    const error = { code: "object_not_found", status: 404 };
+    notion[method].mockRejectedValueOnce(error);
+
+    await expect(read()).rejects.toBe(error);
+    expect(notion[method]).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a permission error using the database fallback", async () => {
+    vi.stubEnv("NOTION_EDITORIAL_DS_ID", "editorial-data-source");
+    vi.stubEnv("NOTION_EDITORIAL_DB_ID", "editorial-database");
+    const error = { code: "restricted_resource", status: 403 };
+    notion[method].mockRejectedValueOnce(error);
+
+    await expect(read()).rejects.toBe(error);
+    expect(notion[method]).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails clearly when neither source nor database ID is configured", async () => {
+    await expect(read()).rejects.toThrow("NOTION_EDITORIAL_DB_ID not configured");
+    expect(notion[method]).not.toHaveBeenCalled();
+  });
+});

--- a/server/__tests__/publicStorytellerPagination.test.ts
+++ b/server/__tests__/publicStorytellerPagination.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ELArticle, ELStoryteller } from "../empathyLedgerClient";
+
+vi.mock("dotenv", () => ({ default: { config: vi.fn() } }));
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(() => { throw new Error("Public profiles must not access the database"); }),
+}));
+vi.mock("node:fs/promises", () => ({
+  readdir: vi.fn().mockResolvedValue([]),
+  readFile: vi.fn(),
+  stat: vi.fn(),
+  unlink: vi.fn(),
+}));
+vi.mock("../empathyLedgerClient", () => ({
+  empathyLedgerClient: {
+    fetchStorytellers: vi.fn(),
+    fetchArticles: vi.fn(),
+    fetchStoryteller: vi.fn(),
+    fetchMediaForStoryteller: vi.fn(),
+  },
+}));
+
+import { empathyLedgerClient } from "../empathyLedgerClient";
+import {
+  getPublicHarvestStorytellerBySlug,
+  listPublicHarvestStorytellers,
+} from "../empathyLedgerAdmin";
+
+type AttributedArticle = ELArticle & { storyteller?: { id: string }; internalNotes?: string };
+
+function storyteller(index: number): ELStoryteller {
+  return {
+    id: `teller-${index}`,
+    slug: `canonical-person-${index}`,
+    displayName: `Person ${index}`,
+    bio: "Public biography",
+    avatarUrl: null,
+    location: "Witta",
+    transcriptCount: 3,
+  };
+}
+
+function article(index: number, tellerId?: string): AttributedArticle {
+  return {
+    id: `article-${index}`,
+    title: `Article ${index}`,
+    slug: `article-${index}`,
+    subtitle: null,
+    excerpt: "Public excerpt",
+    authorName: "Public author",
+    articleType: "story",
+    primaryProject: "the-harvest",
+    publishedAt: "2026-09-05T00:00:00Z",
+    tags: [],
+    themes: ["community"],
+    visibility: "public",
+    syndicationDestinations: ["harvest"],
+    featuredImageUrl: null,
+    featuredImageAlt: null,
+    storyteller: tellerId ? { id: tellerId } : undefined,
+    internalNotes: "Must not appear in public results",
+  };
+}
+
+function paginate<T>(items: T[], options: { page?: number; limit?: number }, cap = 200) {
+  const page = options.page ?? 1;
+  const limit = Math.min(options.limit ?? 20, cap);
+  return {
+    items: items.slice((page - 1) * limit, page * limit),
+    pagination: { page, limit, total: items.length, hasMore: page * limit < items.length },
+  };
+}
+
+function mockPages(tellers: ELStoryteller[], articles: AttributedArticle[], cap = 200) {
+  vi.mocked(empathyLedgerClient.fetchStorytellers).mockImplementation(async (options = {}) => {
+    const result = paginate(tellers, options, cap);
+    return { storytellers: result.items, pagination: result.pagination };
+  });
+  vi.mocked(empathyLedgerClient.fetchArticles).mockImplementation(async (options = {}) => {
+    const result = paginate(articles, options, cap);
+    return { articles: result.items, pagination: result.pagination };
+  });
+}
+
+describe("public storyteller pagination", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(empathyLedgerClient.fetchStorytellers).mockReset();
+    vi.mocked(empathyLedgerClient.fetchArticles).mockReset();
+    mockPages([], []);
+    vi.mocked(empathyLedgerClient.fetchStoryteller).mockResolvedValue(null);
+    vi.mocked(empathyLedgerClient.fetchMediaForStoryteller).mockResolvedValue([]);
+  });
+
+  it("includes later-page people and article counts while excluding drafts and private fields", async () => {
+    const tellers = Array.from({ length: 201 }, (_, index) => storyteller(index));
+    const tail = { ...tellers[200], email: "private@example.com", internalNotes: "private" };
+    tellers[200] = tail;
+    tellers.push({ ...storyteller(201), slug: "barry-rodgerig" });
+    const articles = [
+      ...Array.from({ length: 200 }, (_, index) => article(index, tellers[0].id)),
+      article(200, tellers[0].id),
+      article(201, tail.id),
+    ];
+    mockPages(tellers, articles);
+
+    const results = await listPublicHarvestStorytellers();
+
+    expect(results).toHaveLength(201);
+    expect(results[0]).toMatchObject({ articleCount: 201, publishedArticleCount: 201 });
+    expect(results.find((item) => item.id === tail.id)).toEqual({
+      id: tail.id,
+      slug: tail.slug,
+      displayName: tail.displayName,
+      bio: tail.bio,
+      avatarUrl: tail.avatarUrl,
+      location: tail.location,
+      projectRole: null,
+      articleCount: 1,
+      publishedArticleCount: 1,
+      publishedStoryCount: 0,
+      transcriptCount: 3,
+    });
+    expect(results.some((item) => item.slug === "barry-rodgerig")).toBe(false);
+    for (const method of [empathyLedgerClient.fetchStorytellers, empathyLedgerClient.fetchArticles]) {
+      expect(method).toHaveBeenCalledWith({ project: "the-harvest", limit: 200, page: 2, throwOnError: true });
+      expect(method).toHaveBeenCalledTimes(2);
+    }
+  });
+
+  it("finds a profile's articles after page 1 even when the API caps the requested page size", async () => {
+    const teller = storyteller(0);
+    const articles = [
+      ...Array.from({ length: 200 }, (_, index) => article(index, "another-teller")),
+      article(200, teller.id),
+      article(201, teller.id),
+      article(202),
+    ];
+    mockPages([], articles, 100);
+    vi.mocked(empathyLedgerClient.fetchStoryteller).mockResolvedValue(teller);
+
+    const result = await getPublicHarvestStorytellerBySlug("old-person-slug");
+
+    expect(result).toMatchObject({
+      slug: teller.slug,
+      articleCount: 2,
+      publishedArticleCount: 2,
+      articles: [
+        { id: "article-200", themes: ["community"] },
+        { id: "article-201", themes: ["community"] },
+      ],
+      stories: [],
+      transcripts: [],
+    });
+    expect(result!.articles.map((item) => item.id)).toEqual(["article-200", "article-201"]);
+    expect(result!.articles[0]).not.toHaveProperty("internalNotes");
+    expect(result!.articles[0]).not.toHaveProperty("storyteller");
+    expect(empathyLedgerClient.fetchArticles).toHaveBeenCalledTimes(3);
+    expect(empathyLedgerClient.fetchArticles).toHaveBeenLastCalledWith({
+      project: "the-harvest", limit: 200, page: 3, throwOnError: true,
+    });
+  });
+
+  it("preserves a valid empty collection and a profile with no published articles", async () => {
+    expect(await listPublicHarvestStorytellers()).toEqual([]);
+    vi.mocked(empathyLedgerClient.fetchStoryteller).mockResolvedValue(storyteller(0));
+
+    expect(await getPublicHarvestStorytellerBySlug("canonical-person-0")).toMatchObject({
+      articleCount: 0,
+      publishedArticleCount: 0,
+      articles: [],
+    });
+  });
+
+  it.each(["barry-rodgerig", "old-draft-slug"])("keeps draft profiles hidden for %s", async (slug) => {
+    vi.mocked(empathyLedgerClient.fetchStoryteller).mockResolvedValue({
+      ...storyteller(0), slug: "barry-rodgerig",
+    });
+
+    expect(await getPublicHarvestStorytellerBySlug(slug)).toBeNull();
+    expect(empathyLedgerClient.fetchArticles).not.toHaveBeenCalled();
+    expect(empathyLedgerClient.fetchMediaForStoryteller).not.toHaveBeenCalled();
+  });
+
+  it("does not return partial article counts when a later page rejects", async () => {
+    mockPages([storyteller(0)], []);
+    vi.mocked(empathyLedgerClient.fetchArticles)
+      .mockResolvedValueOnce({
+        articles: [article(0, "teller-0")],
+        pagination: { page: 1, limit: 200, total: 2, hasMore: true },
+      })
+      .mockRejectedValueOnce(new Error("Article page unavailable"));
+
+    await expect(listPublicHarvestStorytellers()).rejects.toThrow("Article page unavailable");
+  });
+
+  it.each([
+    ["storytellers", "empty page with more results"],
+    ["articles", "empty page with more results"],
+    ["storytellers", "repeated page"],
+    ["articles", "repeated page"],
+  ])("rejects invalid %s pagination: %s", async (collection, failure) => {
+    const fetchPage = collection === "storytellers"
+      ? vi.mocked(empathyLedgerClient.fetchStorytellers)
+      : vi.mocked(empathyLedgerClient.fetchArticles);
+    const emptyFirstPage = failure === "empty page with more results";
+    fetchPage.mockResolvedValueOnce({
+      storytellers: emptyFirstPage ? [] : [storyteller(0)],
+      articles: emptyFirstPage ? [] : [article(0, "teller-0")],
+      pagination: { page: 1, limit: 200, total: 2, hasMore: true },
+    }).mockResolvedValueOnce({
+      storytellers: [],
+      articles: [],
+      pagination: { page: emptyFirstPage ? 2 : 1, limit: 200, total: 2, hasMore: false },
+    });
+
+    await expect(listPublicHarvestStorytellers()).rejects.toThrow(/pagination/i);
+  });
+});

--- a/server/__tests__/publicStorytellerPaginationClient.test.ts
+++ b/server/__tests__/publicStorytellerPaginationClient.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("dotenv", () => ({ default: { config: vi.fn() } }));
+vi.mock("../harvestImageStorage", () => ({
+  mirrorHarvestImage: vi.fn(async (_id: string, url: string) => url),
+}));
+
+import { EmpathyLedgerClient } from "../empathyLedgerClient";
+import { listPublicHarvestStorytellers } from "../empathyLedgerAdmin";
+
+const teller = { id: "teller-1", slug: "person-one", displayName: "Person One", bio: null, avatarUrl: null };
+const article = { id: "article-1", title: "Article One", storyteller: { id: teller.id }, featuredImageUrl: null };
+
+describe("public pagination with the real EL client", () => {
+  const mockFetch = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal("fetch", mockFetch);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it.each(["storytellers", "articles"])("rejects the public list when a later %s HTTP request fails", async (collection) => {
+    mockFetch.mockImplementation(async (input) => {
+      const url = new URL(String(input));
+      const current = url.pathname.split("/").at(-1);
+      const page = Number(url.searchParams.get("page") ?? 1);
+      if (current === collection && page === 2) {
+        return new Response("Service unavailable", { status: 503 });
+      }
+      if (current !== "storytellers" && current !== "articles") {
+        throw new Error(`Unexpected request: ${url.pathname}`);
+      }
+      return Response.json({
+        [current]: current === "storytellers" ? [teller] : [article],
+        pagination: { page, limit: 200, total: current === collection ? 2 : 1, hasMore: current === collection },
+      });
+    });
+
+    await expect(listPublicHarvestStorytellers()).rejects.toThrow("Empathy Ledger API error: 503");
+  });
+
+  it.each(["articles", "storytellers"] as const)("supports strict %s failures while preserving the default empty fallback", async (collection) => {
+    mockFetch.mockImplementation(async () => new Response("Service unavailable", { status: 503 }));
+    const client = new EmpathyLedgerClient("https://el.example.invalid");
+    const fetchPage = collection === "articles"
+      ? client.fetchArticles.bind(client)
+      : client.fetchStorytellers.bind(client);
+
+    await expect(fetchPage({ page: 2, throwOnError: true })).rejects.toThrow("Empathy Ledger API error: 503");
+    await expect(fetchPage({ page: 2 })).resolves.toEqual({
+      [collection]: [],
+      pagination: { page: 1, limit: 20, total: 0, hasMore: false },
+    });
+  });
+});

--- a/server/__tests__/worksLifecycle.test.ts
+++ b/server/__tests__/worksLifecycle.test.ts
@@ -1,0 +1,92 @@
+import React, { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { load } from "cheerio";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Works from "../../client/src/pages/Works";
+
+const { state, contentQuery } = vi.hoisted(() => ({
+  state: { user: null as { role: string } | null, content: {} as Record<string, string> },
+  contentQuery: vi.fn(),
+}));
+
+vi.mock("@/_core/hooks/useAuth", () => ({ useAuth: () => ({ user: state.user }) }));
+vi.mock("@/lib/trpc", () => ({ trpc: { content: { get: { useQuery: contentQuery } } } }));
+vi.mock("@/lib/seo", () => ({ setPageSeo: vi.fn() }));
+vi.mock("wouter", () => ({
+  Link: ({ children, ...props }: { children: ReactNode; href: string }) => createElement("a", props, children),
+}));
+vi.mock("framer-motion", () => {
+  const element = (tag: string) => ({ children, className }: { children: ReactNode; className?: string }) =>
+    createElement(tag, { className }, children);
+  return { motion: { div: element("div"), article: element("article") } };
+});
+vi.mock("@/components/EditableText", () => ({
+  EditableText: ({ defaultContent }: { defaultContent: string }) => defaultContent,
+}));
+vi.mock("@/components/HarvestImage", () => ({ HarvestImage: () => null }));
+vi.mock("@/components/VisitStrip", () => ({ VisitStrip: () => null }));
+vi.mock("../../client/src/pages/HarvestReviewTest", () => ({
+  harvestButtonClasses: { primary: "" },
+  SiteNav: () => null,
+  SiteFooter: () => null,
+}));
+
+beforeEach(() => {
+  // The isolated Vitest config uses the classic JSX transform for this real TSX page.
+  vi.stubGlobal("React", React);
+  state.user = null;
+  state.content = {};
+  contentQuery.mockReset();
+  contentQuery.mockImplementation(({ page, slot }: { page: string; slot: string }) => ({
+    data: state.content[`${page}/${slot}`] === undefined
+      ? undefined
+      : { content: state.content[`${page}/${slot}`] },
+  }));
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+function renderBadges(slug: string) {
+  const $ = load(renderToStaticMarkup(createElement(Works)));
+  const card = $(`a[href="/works/${slug}"]`).first().closest("article");
+  return card.find(".absolute.top-4.left-4 span").map((_index, element) => $(element).text()).get();
+}
+
+describe("Works index lifecycle badges", () => {
+  it.each([
+    { slug: "the-garden", status: "Growing" },
+    { slug: "the-cedar", status: "Growing" },
+    { slug: "the-shop", status: "Forthcoming" },
+    { slug: "the-milk-man", status: "Built" },
+  ])("shows visitors one status for $slug", ({ slug, status }) => {
+    expect(renderBadges(slug)).toEqual([status]);
+  });
+
+  it("uses the same saved lifecycle slot as the work detail page", () => {
+    state.content["works/the-shop-lifecycleTags"] = JSON.stringify(["built", "making"]);
+
+    expect(renderBadges("the-shop")).toEqual(["Growing"]);
+    expect(contentQuery).toHaveBeenCalledWith({ page: "works", slot: "the-shop-lifecycleTags" });
+  });
+
+  it("keeps the full sorted taxonomy for admins, including saved overrides", () => {
+    state.user = { role: "admin" };
+    state.content["works/the-shop-lifecycleTags"] = JSON.stringify(["making", "built"]);
+
+    expect(renderBadges("the-shop")).toEqual(["Built", "Making"]);
+    expect(renderBadges("the-garden")).toEqual(["Planted", "Growing"]);
+  });
+
+  it.each(["not-json", '{"status":"built"}', '["unknown"]'])(
+    "uses the default status when a saved override is invalid: %s",
+    (content) => {
+      state.content["works/the-garden-lifecycleTags"] = content;
+      expect(renderBadges("the-garden")).toEqual(["Growing"]);
+    },
+  );
+
+  it("respects an intentionally empty saved tag list", () => {
+    state.content["works/the-garden-lifecycleTags"] = "[]";
+    expect(renderBadges("the-garden")).toEqual(["Forthcoming"]);
+  });
+});

--- a/server/empathyLedgerAdmin.ts
+++ b/server/empathyLedgerAdmin.ts
@@ -5,7 +5,7 @@ import { randomUUID } from "node:crypto";
 import { readdir, readFile, stat, unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, extname, join, relative } from "node:path";
-import { empathyLedgerClient } from "./empathyLedgerClient.js";
+import { empathyLedgerClient, type ELArticle, type ELStoryteller } from "./empathyLedgerClient.js";
 
 dotenv.config({
   path: ".env.local",
@@ -1552,26 +1552,54 @@ function slugifyDisplayName(name: string): string {
     .slice(0, 80);
 }
 
+async function fetchAllPublicHarvestStorytellers(): Promise<ELStoryteller[]> {
+  const storytellers: ELStoryteller[] = [];
+  for (let page = 1; ; page += 1) {
+    const response = await empathyLedgerClient.fetchStorytellers({
+      project: "the-harvest",
+      limit: 200,
+      page,
+      throwOnError: true,
+    });
+    if (response.pagination.page !== page || (response.pagination.hasMore && !response.storytellers.length)) {
+      throw new Error(`Invalid public storyteller pagination on page ${page}`);
+    }
+    storytellers.push(...response.storytellers);
+    if (!response.pagination.hasMore) return storytellers;
+  }
+}
+
+async function fetchAllPublicHarvestArticles(): Promise<ELArticle[]> {
+  const articles: ELArticle[] = [];
+  for (let page = 1; ; page += 1) {
+    const response = await empathyLedgerClient.fetchArticles({
+      project: "the-harvest",
+      limit: 200,
+      page,
+      throwOnError: true,
+    });
+    if (response.pagination.page !== page || (response.pagination.hasMore && !response.articles.length)) {
+      throw new Error(`Invalid public article pagination on page ${page}`);
+    }
+    articles.push(...response.articles);
+    if (!response.pagination.hasMore) return articles;
+  }
+}
+
 export async function listPublicHarvestStorytellers(): Promise<PublicHarvestStoryteller[]> {
   // Refactored 2026-05-13: was hitting EL's Supabase via service-role keys, which
   // requires EMPATHY_LEDGER_SUPABASE_URL/SERVICE_ROLE_KEY env vars not set in Vercel
   // prod. Now uses EL's public content-hub API (same pattern as fetchArticles +
   // photo picker). No service-role keys needed anywhere on the public path.
-  const tellersRes = await empathyLedgerClient.fetchStorytellers({
-    project: "the-harvest",
-    limit: 200,
-  });
+  const storytellers = await fetchAllPublicHarvestStorytellers();
 
-  // For article counts: fetch the project's articles once and group by storyteller.
+  // For article counts: fetch every project article page and group by storyteller.
   // EL's storyteller list doesn't include counts. Stories/transcripts not exposed
   // in a way we can attribute here yet (see PR notes), so leave those at 0.
   type ArticleWithStoryteller = { storyteller?: { id?: string } | null };
-  const articlesRes = await empathyLedgerClient.fetchArticles({
-    project: "the-harvest",
-    limit: 200,
-  });
+  const allArticles = await fetchAllPublicHarvestArticles();
   const articleCounts = new Map<string, { total: number; published: number }>();
-  for (const a of (articlesRes.articles ?? []) as ArticleWithStoryteller[]) {
+  for (const a of allArticles as ArticleWithStoryteller[]) {
     const id = a.storyteller?.id;
     if (!id) continue;
     const cur = articleCounts.get(id) ?? { total: 0, published: 0 };
@@ -1595,7 +1623,7 @@ export async function listPublicHarvestStorytellers(): Promise<PublicHarvestStor
       is_active: boolean | null;
     } | null;
   };
-  const rows: LinkRow[] = tellersRes.storytellers.map((t) => ({
+  const rows: LinkRow[] = storytellers.map((t) => ({
     role: null, // public API doesn't expose per-project role yet
     status: "active",
     storytellers: {
@@ -1612,7 +1640,7 @@ export async function listPublicHarvestStorytellers(): Promise<PublicHarvestStor
   // Transcript counts and EL-provided slugs come straight from the storyteller API.
   const transcriptCountByTeller = new Map<string, number>();
   const apiSlugByTeller = new Map<string, string>();
-  for (const t of tellersRes.storytellers) {
+  for (const t of storytellers) {
     if (typeof t.transcriptCount === "number") transcriptCountByTeller.set(t.id, t.transcriptCount);
     if (t.slug) apiSlugByTeller.set(t.id, t.slug);
   }
@@ -1738,11 +1766,8 @@ export async function getPublicHarvestStorytellerBySlug(
     primaryProject?: string | null;
     storyteller?: { id?: string } | null;
   };
-  const articlesRes = await empathyLedgerClient.fetchArticles({
-    project: "the-harvest",
-    limit: 200,
-  });
-  const ownArticles = (articlesRes.articles as unknown as ArticleWithStoryteller[]).filter(
+  const allArticles = await fetchAllPublicHarvestArticles();
+  const ownArticles = (allArticles as unknown as ArticleWithStoryteller[]).filter(
     (a) => a.storyteller?.id === single.id,
   );
 

--- a/server/empathyLedgerClient.ts
+++ b/server/empathyLedgerClient.ts
@@ -126,6 +126,7 @@ interface FetchArticlesOptions {
   destination?: string;
   after?: string;
   before?: string;
+  throwOnError?: boolean;
 }
 
 const DEFAULT_BASE_URL =
@@ -237,6 +238,7 @@ class EmpathyLedgerClient {
       };
     } catch (error) {
       console.error("[EmpathyLedger] Failed to fetch articles:", error);
+      if (options.throwOnError) throw error;
       // Return empty response on error
       return { articles: [], pagination: { page: 1, limit: 20, total: 0, hasMore: false } };
     }
@@ -294,7 +296,7 @@ class EmpathyLedgerClient {
    * Fetch storytellers from the content-hub.
    * Public, no auth needed. Filter by project slug to scope to one site.
    */
-  async fetchStorytellers(options: { project?: string; limit?: number; page?: number } = {}): Promise<ELStorytellersResponse> {
+  async fetchStorytellers(options: { project?: string; limit?: number; page?: number; throwOnError?: boolean } = {}): Promise<ELStorytellersResponse> {
     const params = new URLSearchParams();
     if (options.project) params.append("project", options.project);
     if (options.limit) params.append("limit", options.limit.toString());
@@ -307,6 +309,7 @@ class EmpathyLedgerClient {
       return await this.fetch<ELStorytellersResponse>(endpoint);
     } catch (error) {
       console.error("[EmpathyLedger] Failed to fetch storytellers:", error);
+      if (options.throwOnError) throw error;
       return { storytellers: [], pagination: { page: 1, limit: 20, total: 0, hasMore: false } };
     }
   }
@@ -484,6 +487,9 @@ class EmpathyLedgerClient {
     // larger requested limits (the photo picker asks for 100), loop pages.
     const EL_PAGE_SIZE = 50;
     const startPage = options.page ?? 1;
+    const requestedOffset = (startPage - 1) * requestedLimit;
+    const upstreamStartPage = Math.floor(requestedOffset / EL_PAGE_SIZE) + 1;
+    const skipWithinPage = requestedOffset % EL_PAGE_SIZE;
 
     type RawMedia = {
       id: string;
@@ -499,10 +505,11 @@ class EmpathyLedgerClient {
 
     const collected: RawMedia[] = [];
     let pagination: ELPagination = { page: startPage, limit: EL_PAGE_SIZE, total: 0, hasMore: false };
+    let upstreamHasMore = false;
 
     try {
-      let cursor = startPage;
-      while (collected.length < requestedLimit) {
+      let cursor = upstreamStartPage;
+      while (collected.length < skipWithinPage + requestedLimit) {
         const params = new URLSearchParams();
         params.append("project", "the-harvest");
         params.append("limit", EL_PAGE_SIZE.toString());
@@ -512,10 +519,11 @@ class EmpathyLedgerClient {
           `/api/v1/content-hub/media?${params.toString()}`,
         );
         pagination = raw.pagination;
+        upstreamHasMore = raw.media.length > 0 && raw.pagination.hasMore;
 
         collected.push(...raw.media);
 
-        if (!raw.pagination.hasMore || raw.media.length === 0) break;
+        if (!upstreamHasMore) break;
         cursor += 1;
       }
     } catch (error) {
@@ -525,7 +533,7 @@ class EmpathyLedgerClient {
 
     // Map the broader content-hub schema onto the gallery schema the website
     // consumes. Untagged photos get empty arrays so the UI keeps working.
-    const sliced = collected.slice(0, requestedLimit);
+    const sliced = collected.slice(skipWithinPage, skipWithinPage + requestedLimit);
 
     // Resolve each item's proxy link to its real storage URL, in
     // concurrency-limited batches so we don't fire hundreds of requests at
@@ -566,7 +574,9 @@ class EmpathyLedgerClient {
         page: startPage,
         limit: requestedLimit,
         total: pagination.total,
-        hasMore: pagination.total > collected.length,
+        hasMore: sliced.length > 0 && (
+          upstreamHasMore || collected.length > skipWithinPage + requestedLimit
+        ),
       },
     };
   }

--- a/server/gohighlevel.ts
+++ b/server/gohighlevel.ts
@@ -10,6 +10,7 @@ import path from "path";
 
 const GHL_API_BASE = "https://services.leadconnectorhq.com";
 const GHL_API_VERSION = "2021-07-28";
+const DEFAULT_NEWSLETTER_CONSENT_FIELD_ID = "aVnqmajnysMtGYhLD0oA";
 
 interface GHLContactInput {
   email?: string;
@@ -121,7 +122,7 @@ export async function createGHLContact(input: GHLContactInput): Promise<{ succes
  * Upsert a contact in Go High Level (create or update if exists)
  * Useful when you want to update existing contacts instead of failing on duplicates
  */
-export async function upsertGHLContact(input: GHLContactInput): Promise<{ success: boolean; contactId?: string; error?: string }> {
+export async function upsertGHLContact(input: GHLContactInput & { newsletterConsent?: boolean }): Promise<{ success: boolean; contactId?: string; error?: string }> {
   const apiKey = process.env.GHL_API_KEY;
   const locationId = process.env.GHL_LOCATION_ID;
 
@@ -150,6 +151,12 @@ export async function upsertGHLContact(input: GHLContactInput): Promise<{ succes
         phone: input.phone || undefined,
         locationId: locationId,
         source: input.source || "Harvest | Website",
+        // Persist affirmative signup consent before downstream tags or workflows.
+        // Other contact updates leave existing newsletter preferences untouched.
+        customFields: input.newsletterConsent === true ? [{
+          id: process.env.GHL_NEWSLETTER_CONSENT_FIELD_ID || DEFAULT_NEWSLETTER_CONSENT_FIELD_ID,
+          fieldValue: "Yes",
+        }] : undefined,
       }),
     });
 

--- a/server/harvestImageStorage.ts
+++ b/server/harvestImageStorage.ts
@@ -75,10 +75,19 @@ async function mirrorHarvestImageOnce(assetId: string, sourceUrl: string): Promi
 
   const safeId = assetId.replace(/[^a-zA-Z0-9_-]/g, "_");
   const basePath = `${MIRROR_PREFIX}/${safeId}`;
-  const { data } = await supabase.storage.from(BUCKET).download(basePath);
-  if (data) return supabase.storage.from(BUCKET).getPublicUrl(basePath).data.publicUrl;
 
   try {
+    // Check metadata without transferring the cached image back to the server.
+    const { data, error: lookupError } = await supabase.storage.from(BUCKET).info(basePath);
+    if (data) return supabase.storage.from(BUCKET).getPublicUrl(basePath).data.publicUrl;
+    if (lookupError) {
+      const status = "statusCode" in lookupError
+        ? String(lookupError.statusCode)
+        : "status" in lookupError ? String(lookupError.status) : undefined;
+      // Storage can report a missing object as HTTP 400 with statusCode 404.
+      if (status !== "404") throw lookupError;
+    }
+
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 10_000);
     const response = await fetch(resolvedSourceUrl, { signal: controller.signal });

--- a/server/notion.ts
+++ b/server/notion.ts
@@ -43,7 +43,10 @@ function notionObjectNotFound(error: unknown): boolean {
 }
 
 function editorialDataSourceCandidates(): string[] {
-  return Array.from(new Set([getDataSourceId(), getDbId()].filter(Boolean)));
+  const candidates = [getDataSourceId()];
+  const databaseId = process.env.NOTION_EDITORIAL_DB_ID;
+  if (databaseId) candidates.push(databaseId);
+  return Array.from(new Set(candidates));
 }
 
 async function queryEditorialDataSource(notion: Client, query: Omit<Parameters<Client["dataSources"]["query"]>[0], "data_source_id">) {

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -891,6 +891,8 @@ export const appRouter = router({
           phone: input.phone || undefined,
           source: input.source || "Harvest | Newsletter",
           tags: allTags,
+          // Submitting this dedicated signup action is the newsletter opt-in.
+          newsletterConsent: true,
         });
 
         if (!result.success) {

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -21,8 +21,12 @@ supabase functions deploy admin-businesses
 supabase functions deploy business-claim
 supabase functions deploy business-update
 supabase functions deploy contact-form
-supabase functions deploy newsletter-subscribe
 ```
+
+Newsletter and membership signups use `trpc.newsletter.subscribe` in `server/routers.ts`.
+The legacy `newsletter-subscribe` Edge Function is archived and must not be redeployed
+as part of this setup. Its deployed copy was deleted on 5 September 2026; see
+the [retirement record](../_archive/2026-07-06-newsletter-subscribe-edge-fn/RESTORE.md).
 
 ## 3) Set Edge Function secrets
 

--- a/supabase/functions/community-submit/index.ts
+++ b/supabase/functions/community-submit/index.ts
@@ -201,7 +201,7 @@ Deno.serve(async (req) => {
       "harvest-website",
       "harvest-inbox",
     ];
-    if (fields.helpType) tags.push(`pod:${String(fields.helpType).replace(/[^a-z0-9]+/gi, "-").toLowerCase()}`);
+    // helpType records an offer of help; pod membership is assigned after human review.
     if (fields.sourceCampaign) tags.push(`source:campaign:${String(fields.sourceCampaign).replace(/[^a-z0-9]+/gi, "-").toLowerCase()}`);
     if (fields.sourceContent) tags.push(`source:content:${String(fields.sourceContent).replace(/[^a-z0-9]+/gi, "-").toLowerCase()}`);
 
@@ -257,6 +257,7 @@ Deno.serve(async (req) => {
       if (fields.title) noteLines.push(`**Title:** ${fields.title}`);
       if (fields.description) noteLines.push(`**Description:** ${fields.description}`);
       if (fields.message) noteLines.push(`**Message:** ${fields.message}`);
+      if (fields.helpType) noteLines.push(`**Help preference:** ${fields.helpType}`);
       if (fields.businessName) noteLines.push(`**Business:** ${fields.businessName}`);
       if (fields.portfolioUrl) noteLines.push(`**Portfolio:** ${fields.portfolioUrl}`);
       if (fields.durationWeeks) noteLines.push(`**Duration:** ${fields.durationWeeks} weeks`);
@@ -303,6 +304,7 @@ Deno.serve(async (req) => {
             `<p><strong>${escapeHtml(String(type).toUpperCase())} submission (website)</strong></p>`,
             fields.title ? `<p>Title: ${escapeHtml(fields.title)}</p>` : "",
             fields.businessName ? `<p>Business: ${escapeHtml(fields.businessName)}</p>` : "",
+            fields.helpType ? `<p>Help preference: ${escapeHtml(fields.helpType)}</p>` : "",
             fields.eventType ? `<p>Event type: ${escapeHtml(fields.eventType)}</p>` : "",
             preferredDate ? `<p>Preferred date: ${escapeHtml(preferredDate)}</p>` : "",
             fields.guests ? `<p>Expected guests: ${escapeHtml(fields.guests)}</p>` : "",

--- a/supabase/functions/contact-form/index.ts
+++ b/supabase/functions/contact-form/index.ts
@@ -5,6 +5,8 @@ const DEFAULT_HARVEST_INBOX_NEW_STAGE_ID = "aafc9a01-1ad6-42c8-8c47-69a74cf1141d
 // The existing "Message" custom field (contact.message). Populated so the ACT
 // notification workflow email can render the submitter's message via {{ contact.message }}.
 const DEFAULT_CONTACT_MESSAGE_FIELD_ID = "ceJz9FUf8dE4fmvnPDKd";
+// Existing contact.newsletter_consent single-option field (Yes / No).
+const DEFAULT_NEWSLETTER_CONSENT_FIELD_ID = "aVnqmajnysMtGYhLD0oA";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -145,6 +147,7 @@ Deno.serve(async req => {
 
   const payload = await req.json();
   const { name, email, subject, message, subscribe } = payload;
+  const newsletterConsent = subscribe === true;
 
   if (!name || !email || !message) {
     return jsonResponse({ success: false, error: "Name, email and message are required" }, 400);
@@ -167,7 +170,7 @@ Deno.serve(async req => {
     "harvest-website",
     "harvest-inbox",
     "act-inquiry", // ACT-wide inquiry marker the shared notification workflow triggers on
-    ...(subscribe ? ["comms:harvest-newsletter"] : []),
+    ...(newsletterConsent ? ["comms:harvest-newsletter"] : []),
   ];
 
   // Fold the subject into the message so the single "Message" field carries the
@@ -177,6 +180,13 @@ Deno.serve(async req => {
     : String(message);
   const messageFieldId =
     Deno.env.get("GHL_CONTACT_MESSAGE_FIELD_ID") || DEFAULT_CONTACT_MESSAGE_FIELD_ID;
+  const customFields = [{ id: messageFieldId, fieldValue: messageFieldValue }];
+  if (newsletterConsent) {
+    customFields.push({
+      id: Deno.env.get("GHL_NEWSLETTER_CONSENT_FIELD_ID") || DEFAULT_NEWSLETTER_CONSENT_FIELD_ID,
+      fieldValue: "Yes",
+    });
+  }
 
   // Create/update contact in GHL
   const contactResponse = await fetch(`${GHL_API_BASE}/contacts/upsert`, {
@@ -195,7 +205,7 @@ Deno.serve(async req => {
       source: "Harvest | Contact",
       // Populate contact.message so the ACT notification workflow email can show
       // what the person actually wrote (via {{ contact.message }}), not just their address.
-      customFields: [{ id: messageFieldId, value: messageFieldValue }],
+      customFields,
     }),
   });
 


### PR DESCRIPTION
Newsletter consent was not persisted before marketing tags and welcome workflows, media pages could overlap or omit records, and public lifecycle/status views could disagree. This PR fixes the remaining confirmed findings from the review audit on top of current main.

- Persist explicit newsletter signup and contact-form consent using the verified CRM field; leave other contact preferences unchanged and stop marketing actions when the upsert fails.
- Keep volunteer help preferences for human review without assigning pod membership.
- Complete public storyteller/article pagination, propagate failed page reads, preserve media page boundaries, and use storage metadata for cache checks.
- Support Notion data-source-only configuration and make Works cards use saved lifecycle overrides and the same public status resolver as detail pages.
- Correct the affected runbooks and unsubscribe templates, and remove the obsolete newsletter wrapper and deployment instruction.

Current main's route-marker smoke implementation and form validation are preserved. Unrelated work in the existing development checkout is excluded.

Validation:

- Node 24: all 119 tests across 13 suites pass.
- TypeScript checking, the production build, and Deno checks for both changed Edge Functions pass.
- The actual built-site smoke command passed all eight principal route markers, app-shell and sitemap checks, and browser runtime checks in local-static mode.
- Four unsubscribe templates validated; standards and scope reviews found no actionable issues.
- [Required GitHub CI](https://github.com/Acurioustractor/theharvest/actions/runs/33927750647) and Vercel checks passed for b53f83c9213755081d22bced787136f4e9c26306.
- [Deployed preview](https://the-harvest-68wp32bxs-benjamin-knights-projects.vercel.app) smoke passed for that exact commit: deployment provenance, redirects, sitemap, all eight route markers, and browser runtime. Preview access requires Vercel authentication.

Related historical findings: #3, #12, #20, #22, #23, #25, #26, #28, #29, and #30.

Release note: the changed contact-form and community-submit Edge Functions need a separate deployment. The legacy newsletter-subscribe function was already retired with approval on 5 September; this PR records that completed operation. CRM behavior is covered with isolated HTTP mocks, and no contacts or welcome messages were created by validation.
