### PR TITLE
Rent in Money, weekly; the building room by room; Goods facility counted as a tenant

### DIFF
--- a/.scratch/harvest-financial-model/people-places-entities.ts
+++ b/.scratch/harvest-financial-model/people-places-entities.ts
@@ -170,6 +170,12 @@ const ENTITY_MAP: EntityRule[] = [
     why: "The green week is only green because staff cost is missing from the file",
   },
   {
+    money: "Goods production facility on the Harvest site (space, power, water)",
+    today: "Nowhere. Goods builds beds at Witta and pays Harvest nothing; Harvest carries the whole rent",
+    next: "Monthly recharge journal: ACT Pty (Goods, ACT-GD) pays Harvest a facility fee by floor area plus metered power. Same journal carries Joey's Goods hours the other way",
+    why: "Goods' R&D claim needs its true cost base, and Harvest's viability needs its true income. One journal fixes both",
+  },
+  {
     money: "Trina, Joey time on beds",
     today: "Unbooked",
     next: "A Curious Tractor Pty Ltd trading as Goods on Country, tracking ACT-GD",

--- a/.scratch/harvest-financial-model/rooms.ts
+++ b/.scratch/harvest-financial-model/rooms.ts
@@ -1,0 +1,60 @@
+/**
+ * The Harvest building, room by room.
+ * Run: npx tsx .scratch/harvest-financial-model/rooms.ts
+ *
+ * Sources:
+ *   - Architect's measured survey with the nursery's original labels:
+ *     client/public/images/plans/building-survey-labelled.jpeg (Thais, Jan 2026)
+ *   - January 2026 walkthrough zone plan: docs/vision-prep/audio-transcripts/site-walkthrough-jan2026.md
+ *   - The site's own floor-plan viewer: client/src/components/FloorPlanViewer.tsx (7 named spaces)
+ *   - Ben, 7 Sep 2026: "front room is the room, the bathroom links to it, the back room is the studio,
+ *     then the workshop space"
+ *
+ * `today` is what the room is used for now. `let` is whether it can earn as space by the week.
+ * Where Ben's three names have not been matched to a survey label, `today` says so. Nothing here
+ * is a measurement of what has been built; the survey is the nursery as it was.
+ */
+
+interface Room {
+  survey: string;              // label on the architect's survey
+  janPlan: string;             // what the January zone plan intended
+  today: string;               // Ben, 7 Sep 2026, or "unmapped"
+  let: "week" | "session" | "no";
+  weekly: number | null;       // $/wk if let by the week
+  note?: string;
+}
+
+export const ROOMS: Room[] = [
+  { survey: "Office (front, with its own PWD toilet)", janPlan: "Reception area at entry", today: "Probably 'the front room': Joey's room, bathroom linked. Ben to confirm", let: "week", weekly: 400 },
+  { survey: "Staff Room", janPlan: "Part of the back rooms", today: "unmapped", let: "no", weekly: null, note: "Small. Candidate for the residency if the studio is an office." },
+  { survey: "Green Room", janPlan: "Back rooms", today: "unmapped", let: "no", weekly: null },
+  { survey: "Cold Room", janPlan: "Keep; food storage", today: "Cold room", let: "no", weekly: null, note: "Earns through food, not rent." },
+  { survey: "Green store", janPlan: "Storage", today: "unmapped", let: "no", weekly: null },
+  { survey: "Server nook + PWD", janPlan: "Bathrooms decision (options A to D)", today: "The bathroom that links to the front room", let: "no", weekly: null },
+  { survey: "Office 1", janPlan: "Rammed earth room = artist in residence office/studio", today: "Probably 'the back room', the studio. Ben to confirm", let: "week", weekly: 600, note: "Office tenant at $600, or a resident at $400. One at a time." },
+  { survey: "Office 2", janPlan: "Office spaces (site floor-plan viewer)", today: "unmapped", let: "week", weekly: 600, note: "If this is a second lettable office, the rent ladder changes. Ben has not named it." },
+  { survey: "Mail Order Business: Receive & Pack + Store (the hall, pallet racking)", janPlan: "Demolish internal walls: one modular rectangle, restaurant, gallery, performance, making", today: "The workshop space (the Art Space) and the indoor pizza and gathering room", let: "session", weekly: null, note: "Earns by the session: workshops, work days, ticketed nights, hire. Never by the week." },
+  { survey: "Tool Store", janPlan: "Storage for classroom equipment on wheels", today: "unmapped", let: "no", weekly: null },
+  { survey: "Seed Pack", janPlan: "'The Classroom': bookable education and workshop space", today: "unmapped", let: "session", weekly: null, note: "The January plan's bookable classroom. Pilates, pottery, cooking, birthing classes." },
+  { survey: "Seed Store", janPlan: "Storage", today: "unmapped", let: "no", weekly: null },
+  { survey: "Eco-Garden Centre (the big shed)", janPlan: "Stage 1: clad, light, retail or deli, pop-up shop", today: "The Deli / General Store (Zones DB: Planning)", let: "session", weekly: null, note: "Café licence lives here or in the hall. Council food posture gates it." },
+  { survey: "Outside: Milk Create Pavilion, Pergola, fire pit, sauna", janPlan: "Scaffold pavilion, pizza oven, fire pit under the pecans", today: "Pizza nights, sauna sessions", let: "session", weekly: null },
+];
+
+const weekly = ROOMS.filter((r) => r.let === "week");
+const money = (n: number) => "$" + Math.round(n).toLocaleString("en-AU");
+console.log("=".repeat(96));
+console.log("THE BUILDING, ROOM BY ROOM");
+console.log("=".repeat(96));
+console.log("survey label".padEnd(44) + "today".padEnd(40) + "let      $/wk");
+for (const r of ROOMS) console.log(r.survey.slice(0, 43).padEnd(44) + r.today.slice(0, 39).padEnd(40) + r.let.padEnd(8) + (r.weekly === null ? "" : " " + money(r.weekly)));
+console.log(`
+  Lettable by the week: ${weekly.length} rooms (${weekly.map((r) => r.survey.split(" ")[0] + " " + (r.survey.split(" ")[1] ?? "")).join(", ")}).
+  Full let, every week: ${money(weekly.reduce((a, r) => a + (r.weekly ?? 0), 0))}/wk against base rent of $962/wk.
+  Unmapped rooms (nobody has said what they are today): ${ROOMS.filter((r) => r.today === "unmapped").length}.
+
+  Ben's three names, matched to the survey as best the files allow:
+    front room  -> Office (front, with PWD)   [confirm]
+    back room   -> Office 1, the rammed earth room the January plan gave to the artist in residence   [confirm]
+    workshop    -> the Mail Order hall   [confirm]
+  If Office 2 is a real second room and not part of the hall, it is the missing office in the rent ladder.`);

--- a/.scratch/harvest-financial-model/space-income.ts
+++ b/.scratch/harvest-financial-model/space-income.ts
@@ -1,0 +1,97 @@
+/**
+ * The Harvest: what the building can earn as space, and what that covers.
+ * Run: npx tsx .scratch/harvest-financial-model/space-income.ts
+ *
+ * Added 2026-09-07 after Ben asked to start pricing rooms, residencies, offices, the café,
+ * kitchen events and philanthropy. Rent to Sonas is paused by agreement for now and resumes
+ * soon, so the question is: which spaces, at what price, cover the rent when it restarts?
+ *
+ * Only two prices come from Ben (front room $400/wk for Joey, office $600/wk). Everything
+ * else is null until someone writes it down. The building, per Ben on 7 Sep 2026:
+ *   front room (Joey's room, the bathroom links to it), back room (the studio),
+ *   and the workshop space. That is one room, one studio, one workshop. No offices beyond
+ *   the studio, no spare bedrooms.
+ */
+
+type Confidence = "verified" | "inferred" | "assumption" | "unknown";
+
+interface Space {
+  name: string;
+  kind: "room" | "office" | "residency" | "kitchen" | "cafe" | "gift";
+  weekly: number | null;      // $ per unit per week, incl GST where GST applies
+  count: number | null;       // how many units exist
+  occupancy: number;          // 0..1, share of weeks let
+  confidence: Confidence;
+  source: string;
+  note?: string;
+}
+
+const SPACES: Space[] = [
+  { name: "Front room (Joey, live-in caretaker)", kind: "room", weekly: 400, count: 1, occupancy: 1, confidence: "verified", source: "Ben, 7 Sep 2026",
+    note: "Rent is booked as income to the Harvest tenant entity. If $400 is at or above market for one room in a shared house in Maleny, there is no housing FBT; if below, the gap is pay in kind. Market for the room: unverified." },
+  { name: "Other rooms", kind: "room", weekly: 400, count: 0, occupancy: 0.8, confidence: "verified", source: "Ben, 7 Sep: the front room is the room. No other bedroom.",
+    note: "The '3-bed dwelling' in the June staffing brief is not what the building offers for letting today." },
+  { name: "Back room, the studio (office or residency)", kind: "office", weekly: 600, count: 1, occupancy: 0.7, confidence: "assumption", source: "Ben: back room is the studio; office price $600/wk. One space, one tenant at a time",
+    note: "Either an office tenant at $600, or a resident at $400 (Ben: residencies priced like the room). Not both. The ladder below uses the office price; a residency is $200/wk less." },
+  { name: "Workshop space", kind: "office", weekly: null, count: 1, occupancy: 0, confidence: "verified", source: "Ben, 7 Sep: the workshop space. This is the Art Space",
+    note: "Not for letting by the week. Earns by the session (workshops, work days, makers) and that lives in model.ts as programme income, not here." },
+  { name: "Kitchen for an event or a producer", kind: "kitchen", weekly: null, count: 1, occupancy: 0.3, confidence: "unknown", source: "Not priced. Council food posture gates this",
+    note: "Comparable: commercial kitchen hire in SE Qld runs $30 to $60 an hour. Unverified." },
+  { name: "Café licence (sub-operator)", kind: "cafe", weekly: null, count: 1, occupancy: 1, confidence: "unknown", source: "working-capital-plan: $0 to $5K over 4 months; nothing signed",
+    note: "Per month or % of sales. The operating model says sub-operator by end October." },
+  { name: "Philanthropy and grants", kind: "gift", weekly: null, count: 1, occupancy: 1, confidence: "unknown", source: "No line in any model. DGR only through The Butterfly Movement",
+    note: "Not space income. Listed here because Ben asked; belongs in model.ts as its own stream once a first ask exists." },
+];
+
+/* ---- what rent costs, per week ---- */
+const RENT = {
+  baseYearly: 50000,          // lease.md: $50K/yr base from 1 Jul 2026 (verified)
+  outgoingsMonthly: 1500,     // working-capital-plan: 'verify from Sonas', still unverified since April
+  paidSoFar: 4616.70,         // one payment, 17 Jul 2026, from the Xero mirror (verified 7 Sep)
+  paused: true,               // Ben, 7 Sep: 'we have not had to pay for a bit but will pay again soon'
+};
+const rentWeek = RENT.baseYearly / 52;
+const outgoingsWeek = (RENT.outgoingsMonthly * 12) / 52;
+
+const money = (n: number) => "$" + Math.round(n).toLocaleString("en-AU");
+console.log("=".repeat(74));
+console.log("WHAT RENT COSTS, PER WEEK");
+console.log("=".repeat(74));
+console.log(`  Base rent ${money(rentWeek)}/wk  + outgoings ${money(outgoingsWeek)}/wk (unverified)  = ${money(rentWeek + outgoingsWeek)}/wk`);
+console.log(`  Paid since 1 July: ${money(RENT.paidSoFar)} (one payment). Rent is ${RENT.paused ? "paused by agreement, resuming soon" : "due monthly"}.`);
+
+console.log("\n" + "=".repeat(74));
+console.log("SPACES, priced or not");
+console.log("=".repeat(74));
+let known = 0; const unknown: string[] = [];
+for (const s of SPACES) {
+  const line = s.weekly !== null && s.count !== null ? s.weekly * s.count * s.occupancy : null;
+  if (line !== null) known += line; else unknown.push(s.name);
+  console.log(`  ${s.name.padEnd(42)} ${s.weekly === null ? "   ?" : ("$" + s.weekly).padStart(5)}/wk x ${s.count === null ? "?" : s.count} @ ${Math.round(s.occupancy * 100)}%  = ${line === null ? "unknown" : money(line) + "/wk"}  [${s.confidence}]`);
+  if (s.note) console.log(`      ${s.note}`);
+}
+console.log(`\n  Known space income today: ${money(known)}/wk, which is ${Math.round((known / rentWeek) * 100)}% of base rent.`);
+
+console.log("\n" + "=".repeat(74));
+console.log("THE LADDER: what it takes to cover rent from space alone");
+console.log("=".repeat(74));
+const ladder: { label: string; weekly: number }[] = [
+  { label: "Joey's front room", weekly: 400 },
+  { label: "+ the studio as a residency at $400, half the year", weekly: 400 + 400 * 0.5 },
+  { label: "+ the studio as an office at $600, 70% let (instead)", weekly: 400 + 600 * 0.7 },
+  { label: "+ the studio as an office, every week", weekly: 400 + 600 },
+];
+for (const step of ladder) {
+  const covers = step.weekly >= rentWeek ? "covers base rent" : step.weekly >= rentWeek * 0.5 ? "covers half" : "does not cover";
+  const withOut = step.weekly >= rentWeek + outgoingsWeek ? ", and outgoings" : "";
+  console.log(`  ${step.label.padEnd(40)} ${money(step.weekly).padStart(7)}/wk  ${covers}${withOut}`);
+}
+console.log(`
+  Reading: with one room and one studio, space alone tops out at $1,000/wk with the
+  studio let as an office every week of the year, which is base rent and nothing else.
+  The realistic case (front room + studio office most of the time) is about $820/wk,
+  85% of base rent. Pizza, sauna, the workshop sessions and the café licence have to
+  carry outgoings and everything in model.ts. Space is a floor under rent, not a business.
+
+  Unknowns only a walk of the building or a decision can fill:
+    ${unknown.join("\n    ")}`);

--- a/.scratch/harvest-financial-model/space-income.ts
+++ b/.scratch/harvest-financial-model/space-income.ts
@@ -39,6 +39,8 @@ const SPACES: Space[] = [
     note: "Comparable: commercial kitchen hire in SE Qld runs $30 to $60 an hour. Unverified." },
   { name: "Café licence (sub-operator)", kind: "cafe", weekly: null, count: 1, occupancy: 1, confidence: "unknown", source: "working-capital-plan: $0 to $5K over 4 months; nothing signed",
     note: "Per month or % of sales. The operating model says sub-operator by end October." },
+  { name: "Goods on Country production facility (recharge to A Curious Tractor Pty Ltd)", kind: "office", weekly: null, count: 1, occupancy: 1, confidence: "unknown", source: "Ben, 7 Sep 2026: Goods production is at The Harvest and Joey works across both",
+    note: "Goods on Country (trading name of A Curious Tractor Pty Ltd, tracking ACT-GD) makes Stretch Beds on this site. That is a tenant. Harvest charges it a monthly facility fee for the space, power and water it uses, and recharges Joey's Goods hours. Both sides are ACT, so the fee is a recharge journal, not cash lost; it is what makes Harvest's rent bill honest and Goods' R&D cost base complete. Price: a share of rent and outgoings by floor area, plus metered power if it exists. Floor area used: unknown." },
   { name: "Philanthropy and grants", kind: "gift", weekly: null, count: 1, occupancy: 1, confidence: "unknown", source: "No line in any model. DGR only through The Butterfly Movement",
     note: "Not space income. Listed here because Ben asked; belongs in model.ts as its own stream once a first ask exists." },
 ];

--- a/.scratch/harvest-financial-model/space-income.ts
+++ b/.scratch/harvest-financial-model/space-income.ts
@@ -21,27 +21,28 @@ interface Space {
   weekly: number | null;      // $ per unit per week, incl GST where GST applies
   count: number | null;       // how many units exist
   occupancy: number;          // 0..1, share of weeks let
+  status: "current" | "prospective";  // current = money is actually being paid today
   confidence: Confidence;
   source: string;
   note?: string;
 }
 
 const SPACES: Space[] = [
-  { name: "Front room (Joey, live-in caretaker)", kind: "room", weekly: 400, count: 1, occupancy: 1, confidence: "verified", source: "Ben, 7 Sep 2026",
+  { name: "Front room (Joey, live-in caretaker)", kind: "room", weekly: 400, count: 1, occupancy: 1, status: "prospective", confidence: "verified", source: "Ben, 7 Sep 2026: the price. Joey has not moved in; nothing is paid yet",
     note: "Rent is booked as income to the Harvest tenant entity. If $400 is at or above market for one room in a shared house in Maleny, there is no housing FBT; if below, the gap is pay in kind. Market for the room: unverified." },
-  { name: "Other rooms", kind: "room", weekly: 400, count: 0, occupancy: 0.8, confidence: "verified", source: "Ben, 7 Sep: the front room is the room. No other bedroom.",
+  { name: "Other rooms", kind: "room", weekly: 400, count: 0, occupancy: 0.8, status: "prospective", confidence: "verified", source: "Ben, 7 Sep: the front room is the room. No other bedroom.",
     note: "The '3-bed dwelling' in the June staffing brief is not what the building offers for letting today." },
-  { name: "Back room, the studio (office or residency)", kind: "office", weekly: 600, count: 1, occupancy: 0.7, confidence: "assumption", source: "Ben: back room is the studio; office price $600/wk. One space, one tenant at a time",
+  { name: "Back room, the studio (office or residency)", kind: "office", weekly: 600, count: 1, occupancy: 0.7, status: "prospective", confidence: "assumption", source: "Ben: back room is the studio; office price $600/wk. One space, one tenant at a time",
     note: "Either an office tenant at $600, or a resident at $400 (Ben: residencies priced like the room). Not both. The ladder below uses the office price; a residency is $200/wk less." },
-  { name: "Workshop space", kind: "office", weekly: null, count: 1, occupancy: 0, confidence: "verified", source: "Ben, 7 Sep: the workshop space. This is the Art Space",
+  { name: "Workshop space", kind: "office", weekly: null, count: 1, occupancy: 0, status: "prospective", confidence: "verified", source: "Ben, 7 Sep: the workshop space. This is the Art Space",
     note: "Not for letting by the week. Earns by the session (workshops, work days, makers) and that lives in model.ts as programme income, not here." },
-  { name: "Kitchen for an event or a producer", kind: "kitchen", weekly: null, count: 1, occupancy: 0.3, confidence: "unknown", source: "Not priced. Council food posture gates this",
+  { name: "Kitchen for an event or a producer", kind: "kitchen", weekly: null, count: 1, occupancy: 0.3, status: "prospective", confidence: "unknown", source: "Not priced. Council food posture gates this",
     note: "Comparable: commercial kitchen hire in SE Qld runs $30 to $60 an hour. Unverified." },
-  { name: "Café licence (sub-operator)", kind: "cafe", weekly: null, count: 1, occupancy: 1, confidence: "unknown", source: "working-capital-plan: $0 to $5K over 4 months; nothing signed",
+  { name: "Café licence (sub-operator)", kind: "cafe", weekly: null, count: 1, occupancy: 1, status: "prospective", confidence: "unknown", source: "working-capital-plan: $0 to $5K over 4 months; nothing signed",
     note: "Per month or % of sales. The operating model says sub-operator by end October." },
-  { name: "Goods on Country production facility (recharge to A Curious Tractor Pty Ltd)", kind: "office", weekly: null, count: 1, occupancy: 1, confidence: "unknown", source: "Ben, 7 Sep 2026: Goods production is at The Harvest and Joey works across both",
+  { name: "Goods on Country production facility (recharge to A Curious Tractor Pty Ltd)", kind: "office", weekly: null, count: 1, occupancy: 1, status: "prospective", confidence: "unknown", source: "Ben, 7 Sep 2026: Goods production is at The Harvest and Joey works across both",
     note: "Goods on Country (trading name of A Curious Tractor Pty Ltd, tracking ACT-GD) makes Stretch Beds on this site. That is a tenant. Harvest charges it a monthly facility fee for the space, power and water it uses, and recharges Joey's Goods hours. Both sides are ACT, so the fee is a recharge journal, not cash lost; it is what makes Harvest's rent bill honest and Goods' R&D cost base complete. Price: a share of rent and outgoings by floor area, plus metered power if it exists. Floor area used: unknown." },
-  { name: "Philanthropy and grants", kind: "gift", weekly: null, count: 1, occupancy: 1, confidence: "unknown", source: "No line in any model. DGR only through The Butterfly Movement",
+  { name: "Philanthropy and grants", kind: "gift", weekly: null, count: 1, occupancy: 1, status: "prospective", confidence: "unknown", source: "No line in any model. DGR only through The Butterfly Movement",
     note: "Not space income. Listed here because Ben asked; belongs in model.ts as its own stream once a first ask exists." },
 ];
 
@@ -65,14 +66,14 @@ console.log(`  Paid since 1 July: ${money(RENT.paidSoFar)} (one payment). Rent i
 console.log("\n" + "=".repeat(74));
 console.log("SPACES, priced or not");
 console.log("=".repeat(74));
-let known = 0; const unknown: string[] = [];
+let current = 0, prospective = 0; const unknown: string[] = [];
 for (const s of SPACES) {
   const line = s.weekly !== null && s.count !== null ? s.weekly * s.count * s.occupancy : null;
-  if (line !== null) known += line; else unknown.push(s.name);
-  console.log(`  ${s.name.padEnd(42)} ${s.weekly === null ? "   ?" : ("$" + s.weekly).padStart(5)}/wk x ${s.count === null ? "?" : s.count} @ ${Math.round(s.occupancy * 100)}%  = ${line === null ? "unknown" : money(line) + "/wk"}  [${s.confidence}]`);
+  if (line === null) unknown.push(s.name); else if (s.status === "current") current += line; else prospective += line;
+  console.log(`  ${s.name.padEnd(42)} ${s.weekly === null ? "   ?" : ("$" + s.weekly).padStart(5)}/wk x ${s.count === null ? "?" : s.count} @ ${Math.round(s.occupancy * 100)}%  = ${line === null ? "unknown" : money(line) + "/wk"}  [${s.status}, ${s.confidence}]`);
   if (s.note) console.log(`      ${s.note}`);
 }
-console.log(`\n  Known space income today: ${money(known)}/wk, which is ${Math.round((known / rentWeek) * 100)}% of base rent.`);
+console.log(`\n  Space income being paid today: ${money(current)}/wk. Priced but not yet let: ${money(prospective)}/wk (${Math.round((prospective / rentWeek) * 100)}% of base rent if it all lands).`);
 
 console.log("\n" + "=".repeat(74));
 console.log("THE LADDER: what it takes to cover rent from space alone");

--- a/scripts/harvest-money-week.ts
+++ b/scripts/harvest-money-week.ts
@@ -88,17 +88,19 @@ if (error) throw new Error(error.message);
 const rows = (rowsRaw ?? []) as Row[];
 const isHV = (r: Row, li?: Row["line_items"] extends (infer L)[] | null ? L : never) => (li?.tracking?.find((t) => t.Name === "Project Tracking")?.Option ?? "").startsWith("ACT-HV") || r.project_code === "ACT-HV";
 function mirrorWeek(start: string, end: string) {
-  let bidfood = 0, wages = 0, other = 0;
+  let bidfood = 0, wages = 0, other = 0, rent = 0;
   for (const r of rows) {
     if (r.date < start || r.date > end || r.type !== "SPEND") continue;
     if (/^bidfood/i.test(r.contact_name ?? "")) { bidfood += Number(r.total); continue; }
+    // Rent: anything paid to Sonas (the landlord) or coded 469 Rent, whatever project tag the bookkeeper used.
+    if (/sonas/i.test(r.contact_name ?? "") || (r.line_items ?? []).some((li) => li.account_code === "469")) { rent += Number(r.total); continue; }
     for (const li of r.line_items ?? []) {
       if (!isHV(r, li)) continue;
       const amt = Number(li.line_amount ?? 0);
       if (li.account_code === "477" || li.account_code === "478") wages += amt; else other += amt;
     }
   }
-  return { bidfood, wages, other };
+  return { bidfood, wages, other, rent };
 }
 
 // ---- Xero bank balance (ACT OAuth app) ----
@@ -136,7 +138,7 @@ async function upsert(tok: string, w: Record<string, unknown>, title: string) {
     Week: { title: [{ text: { content: title } }] },
     "Week starting": { date: { start: w.start as string } },
     "Square taken": num(w.taken as number), Sales: num(w.sales as number), Heads: num(w.heads as number), "Card fees": num(w.cardFees as number), Cash: num(w.cash as number),
-    "Bidfood out": num(w.bidfood as number), "Wages out": num(w.wages as number), "Other Harvest spend": num(w.other as number), "Net week": num(w.net as number), "Bank balance": num(w.bank as number | null),
+    "Bidfood out": num(w.bidfood as number), "Wages out": num(w.wages as number), "Other Harvest spend": num(w.other as number), "Rent out": num(w.rent as number), "Net week": num(w.net as number), "Bank balance": num(w.bank as number | null),
     Status: { select: { name: w.status as string } },
     Source: { rich_text: [{ text: { content: w.source as string } }] },
   };
@@ -160,16 +162,16 @@ const now = new Date().toISOString().slice(0, 16).replace("T", " ");
 const tok = APPLY ? await notionToken() : null;
 if (APPLY && !tok) { console.error("No Notion token can read the Money, weekly database. Share the database with the integration in Notion (... > Connections), or put a working NOTION_TOKEN in .env."); process.exit(1); }
 console.log(`Money, weekly ${APPLY ? "*** APPLY ***" : "(dry run)"} | ${weeks[0].start} to ${weeks[weeks.length - 1].end}\n`);
-console.log("week (Mon)  taken   sales heads   fees   cash  bidfood  wages  other     net     bank  status");
+console.log("week (Mon)  taken   sales heads   fees   cash  bidfood  wages  other   rent     net     bank  status");
 for (const wk of weeks) {
   const s = await squareWeek(wk.start, wk.end);
   const m = mirrorWeek(wk.start, wk.end);
   const bank = await bankBalance(wk.end);
-  const net = s.taken - s.cardFees - m.bidfood - m.wages - m.other;
+  const net = s.taken - s.cardFees - m.bidfood - m.wages - m.other - m.rent;
   const partial = wk.end >= iso(new Date(Date.now() + 10 * 3600e3 - 3 * 86400e3));
   const status = partial ? "Partial" : net >= 0 ? "Green" : "Red";
-  const w = { ...s, ...m, net, bank, status, start: wk.start, source: `harvest-money-week ${now} AEST: Square API (The Harvest, closed orders + payments), xero_transactions mirror (Bidfood by contact, 477/478 wages, other ACT-HV spend), Xero BankSummary at ${wk.end}, account NJ Marchesi T/as ACT Everyday only. Founder labour not counted.` };
-  console.log(`${wk.start}  ${fmt(s.taken).padStart(7)} ${String(s.sales).padStart(5)} ${String(s.heads).padStart(5)} ${fmt(s.cardFees).padStart(6)} ${fmt(s.cash).padStart(6)} ${fmt(m.bidfood).padStart(8)} ${fmt(m.wages).padStart(6)} ${fmt(m.other).padStart(6)} ${fmt(net).padStart(7)} ${fmt(bank).padStart(8)}  ${status}`);
+  const w = { ...s, ...m, net, bank, status, start: wk.start, source: `harvest-money-week ${now} AEST: Square API (The Harvest, closed orders + payments), xero_transactions mirror (Bidfood by contact, 477/478 wages, other ACT-HV spend, rent = Sonas or account 469), Xero BankSummary at ${wk.end}, account NJ Marchesi T/as ACT Everyday only. Founder labour not counted.` };
+  console.log(`${wk.start}  ${fmt(s.taken).padStart(7)} ${String(s.sales).padStart(5)} ${String(s.heads).padStart(5)} ${fmt(s.cardFees).padStart(6)} ${fmt(s.cash).padStart(6)} ${fmt(m.bidfood).padStart(8)} ${fmt(m.wages).padStart(6)} ${fmt(m.other).padStart(6)} ${fmt(m.rent).padStart(6)} ${fmt(net).padStart(7)} ${fmt(bank).padStart(8)}  ${status}`);
   if (APPLY && tok) console.log(`             -> Notion ${await upsert(tok, w, weekendLabel(wk.start, wk.end))}`);
 }
 if (!APPLY) console.log("\nDry run. Add --apply to write the rows to Notion.");


### PR DESCRIPTION
Scripts and model only.

- `scripts/harvest-money-week.ts`: `Rent out` column (payee Sonas or account 469, any tag). Net week now subtracts rent. Only one rent payment exists since 1 July ($4,616.70 on 17 Jul); rent is paused by agreement per Ben.
- `.scratch/harvest-financial-model/space-income.ts`: what rent costs per week ($962 base + $346 outgoings unverified) and the ladder of what space lets cover it, using Ben's two prices (room $400, office $600). Goods on Country's bed production is counted as a tenant: facility recharge by floor area plus power, and Joey's Goods hours the other way, in one monthly journal.
- `.scratch/harvest-financial-model/rooms.ts`: the building room by room from the architect's survey (`client/public/images/plans/building-survey-labelled.jpeg`), the January zone plan and Ben's three names. Office 2 is the open question: if it is a real room, three weekly lets cover rent and outgoings.
- Notion has the matching database "Spaces: what each room can earn" (15 rows, Monthly potential formula) under Harvest HQ.